### PR TITLE
Fix rel perm axis

### DIFF
--- a/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp
+++ b/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp
@@ -402,9 +402,7 @@ void RiuRelativePermeabilityPlotPanel::plotCurvesInQwt( RiaDefines::EclipseUnitS
 
         if ( plotOnWhichYAxis == RIGHT_YAXIS )
         {
-            QwtAxisId relatedYAxis( QwtAxis::YRight, 0 );
-
-            qwtCurve->setYAxis( relatedYAxis );
+            qwtCurve->setYAxis( { QwtAxis::YRight, 0 } );
             shouldEnableRightYAxis = true;
         }
 

--- a/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp
+++ b/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp
@@ -403,7 +403,9 @@ void RiuRelativePermeabilityPlotPanel::plotCurvesInQwt( RiaDefines::EclipseUnitS
 
         if ( plotOnWhichYAxis == RIGHT_YAXIS )
         {
-            qwtCurve->setYAxis( RiuPlotAxis::defaultRight() );
+            QwtAxisId relatedYAxis( QwtAxis::YRight, 0 );
+
+            qwtCurve->QwtPlotCurve::setYAxis( relatedYAxis );
             shouldEnableRightYAxis = true;
         }
 
@@ -432,9 +434,15 @@ void RiuRelativePermeabilityPlotPanel::plotCurvesInQwt( RiaDefines::EclipseUnitS
     }
 
     if ( shouldEnableRightYAxis )
+    {
         plot->setAxesCount( QwtAxis::YRight, 1 );
+        plot->setAxisVisible( QwtAxis::YRight, true );
+    }
     else
+    {
         plot->setAxesCount( QwtAxis::YRight, 0 );
+        plot->setAxisVisible( QwtAxis::YRight, false );
+    }
 
     addTransparentCurve( plot, points, axes, logScaleLeftAxis );
 

--- a/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp
+++ b/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp
@@ -27,14 +27,12 @@
 #include "RiuDockedQwtPlot.h"
 #include "RiuGuiTheme.h"
 #include "RiuPlotCurveSymbol.h"
-#include "RiuQwtPlotCurve.h"
 #include "RiuQwtPlotTools.h"
 #include "RiuQwtSymbol.h"
 #include "RiuRelativePermeabilityPlotUpdater.h"
 #include "RiuTextDialog.h"
 
 #include "cvfAssert.h"
-#include "cvfTrace.h"
 
 #include "qwt_legend.h"
 #include "qwt_plot.h"
@@ -89,6 +87,14 @@ RiuRelativePermeabilityPlotPanel::RiuRelativePermeabilityPlotPanel( QWidget* par
     , m_swat( HUGE_VAL )
     , m_sgas( HUGE_VAL )
     , m_plotUpdater( new RiuRelativePermeabilityPlotUpdater( this ) )
+    , m_qwtPlot( nullptr )
+    , m_selectedCurvesButtonGroup( nullptr )
+    , m_groupBox( nullptr )
+    , m_logarithmicScaleKrAxisCheckBox( nullptr )
+    , m_showUnscaledCheckBox( nullptr )
+    , m_fixedXAxisCheckBox( nullptr )
+    , m_fixedLeftYAxisCheckBox( nullptr )
+
 {
     m_qwtPlot = new RelPermQwtPlot( this );
     m_qwtPlot->setProperty( "qss-class", "RelPermPlot" );
@@ -153,13 +159,6 @@ RiuRelativePermeabilityPlotPanel::RiuRelativePermeabilityPlotPanel( QWidget* par
     slotShowCurveSelectionWidgets( showCurveSelection->checkState() );
 
     plotUiSelectedCurves();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-RiuRelativePermeabilityPlotPanel::~RiuRelativePermeabilityPlotPanel()
-{
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -352,11 +351,11 @@ void RiuRelativePermeabilityPlotPanel::plotCurvesInQwt( RiaDefines::EclipseUnitS
             plotOnWhichYAxis = RIGHT_YAXIS;
         }
 
-        RiuQwtPlotCurve* qwtCurve = new RiuQwtPlotCurve( nullptr, curve.name.c_str() );
+        QwtPlotCurve* qwtCurve = new QwtPlotCurve( curve.name.c_str() );
 
         CVF_ASSERT( curve.saturationVals.size() == curve.yVals.size() );
         const bool includePositiveValuesOnly = ( logScaleLeftAxis && plotOnWhichYAxis == LEFT_YAXIS );
-        qwtCurve->setSamplesFromXValuesAndYValues( curve.saturationVals, curve.yVals, includePositiveValuesOnly );
+        qwtCurve->setSamples( curve.saturationVals.data(), curve.yVals.data(), static_cast<int>( curve.saturationVals.size() ) );
 
         qwtCurve->setTitle( curve.name.c_str() );
 
@@ -390,7 +389,7 @@ void RiuRelativePermeabilityPlotPanel::plotCurvesInQwt( RiaDefines::EclipseUnitS
         const QPen curvePen( QBrush(), 1, penStyle );
         qwtCurve->setPen( curvePen );
 
-        RiuQwtSymbol* curveSymbol = new RiuQwtSymbol( RiuPlotCurveSymbol::SYMBOL_ELLIPSE );
+        auto* curveSymbol = new RiuQwtSymbol( RiuPlotCurveSymbol::SYMBOL_ELLIPSE );
         curveSymbol->setSize( 6, 6 );
         curveSymbol->setBrush( Qt::NoBrush );
         qwtCurve->setSymbol( curveSymbol );
@@ -405,7 +404,7 @@ void RiuRelativePermeabilityPlotPanel::plotCurvesInQwt( RiaDefines::EclipseUnitS
         {
             QwtAxisId relatedYAxis( QwtAxis::YRight, 0 );
 
-            qwtCurve->QwtPlotCurve::setYAxis( relatedYAxis );
+            qwtCurve->setYAxis( relatedYAxis );
             shouldEnableRightYAxis = true;
         }
 

--- a/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.h
+++ b/ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.h
@@ -46,7 +46,6 @@ class RiuRelativePermeabilityPlotPanel : public QWidget
 
 public:
     RiuRelativePermeabilityPlotPanel( QWidget* parent );
-    ~RiuRelativePermeabilityPlotPanel() override;
 
     void                                setPlotData( RiaDefines::EclipseUnitSystem                                unitSystem,
                                                      const std::vector<RigFlowDiagSolverInterface::RelPermCurve>& relPermCurves,


### PR DESCRIPTION
### **PR Type**
enhancement, bug_fix


___

### **Description**
- Refactored the `RiuRelativePermeabilityPlotPanel` class by removing unused includes and the destructor.
- Initialized several member variables in the constructor to ensure proper setup.
- Replaced `RiuQwtPlotCurve` with `QwtPlotCurve` and updated related method calls for setting samples and axis.
- Fixed the visibility of the right Y-axis by setting it based on the presence of curves that require it.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RiuRelativePermeabilityPlotPanel.cpp</strong><dd><code>Refactor and fix right Y-axis visibility in plot panel</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.cpp

<li>Removed unused includes and destructor.<br> <li> Added initialization for several member variables.<br> <li> Replaced <code>RiuQwtPlotCurve</code> with <code>QwtPlotCurve</code> and updated method calls.<br> <li> Ensured right Y-axis visibility is correctly set.<br>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/154/files#diff-5722a838c06552e885e9c1b3d95168786aa2c4383a829750e8018d50e8e1c8d3">+20/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RiuRelativePermeabilityPlotPanel.h</strong><dd><code>Remove destructor declaration from header file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/UserInterface/RiuRelativePermeabilityPlotPanel.h

- Removed the destructor declaration from the header file.



</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/154/files#diff-46b5d8b82a7e5422bb8d9fde28d1367b35946d2ec7ee51dd5f9d01b107cacc3f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

