### PR TITLE
Revert back to previous baseline of vcpkg

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,14 +1,14 @@
 {
     "default-registry": {
         "kind": "git",
-        "baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
+        "baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6",
         "repository": "https://github.com/microsoft/vcpkg"
     },
-  "registries": [
-    {
-      "kind": "artifact",
-      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
-      "name": "microsoft"
-    }
-  ]
+    "registries": [
+        {
+            "kind": "artifact",
+            "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+            "name": "microsoft"
+        }
+    ]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
     "default-registry": {
         "kind": "git",
-        "baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6",
+        "baseline": "fba75d09065fcc76a25dcf386b1d00d33f5175af",
         "repository": "https://github.com/microsoft/vcpkg"
     },
     "registries": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,11 +8,5 @@
         "type-lite",
         "fast-float",
         "spdlog"
-    ],
-    "overrides": [
-        {
-            "name": "fmt",
-            "version": "10.1.1"
-        }
     ]
 }


### PR DESCRIPTION
grpc 1.28 create huge binary files that was too large for the caching on github action. Revert to previous config to make sure all vcpkg artifacts can be cached.