### PR TITLE
Update to clang-format-18

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   clang-format-job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set apt mirror
         # GitHub Actions apt proxy is super unstable
@@ -15,26 +15,26 @@ jobs:
           curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
           sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
 
-      - name: Install clang-format 15.0
+      - name: Install clang-format 18
         run: |
           sudo apt-get update
-          sudo apt-get install --option="APT::Acquire::Retries=3" clang-format-15
-          clang-format-15 --version
+          sudo apt-get install --option="APT::Acquire::Retries=3" clang-format-18
+          clang-format-18 --version
       - uses: actions/checkout@v4
       - name: Check format - ApplicationLibCode
         run: |
           cd ApplicationLibCode
-          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-15 -i
+          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-18 -i
           git diff
       - name: Check format - ApplicationExeCode
         run: |
           cd ApplicationExeCode
-          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-15 -i
+          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | xargs clang-format-18 -i
           git diff
       - name: Check format - AppFwk
         run: |
           cd Fwk/AppFwk
-          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | grep -v gtest | xargs clang-format-15 -i
+          find -name '*.h' -o -name '*.cpp' -o -name '*.inl' | grep -v gtest | xargs clang-format-18 -i
           git diff
       - uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Updated workflow to use Ubuntu 24.04 for CI.

- Upgraded `clang-format` version from 15 to 18.

- Adjusted formatting commands to align with `clang-format-18`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clang-format.yml</strong><dd><code>Upgrade CI configuration to Ubuntu 24.04 and clang-format 18</code></dd></summary>
<hr>

.github/workflows/clang-format.yml

<li>Changed CI runner from Ubuntu 22.04 to 24.04.<br> <li> Updated <code>clang-format</code> version from 15 to 18.<br> <li> Modified formatting commands to use <code>clang-format-18</code>.


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/184/files#diff-a831caa275b24aef91cae39788523170fade9491c692313781fec16340f44188">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>