### PR TITLE
Avoid pinning for grpc-related packages

### DIFF
--- a/GrpcInterface/Python/build-requirements.txt
+++ b/GrpcInterface/Python/build-requirements.txt
@@ -1,6 +1,6 @@
 grpcio
-grpcio-tools<1.64 # to make sure we use libprotoc 26.1, to display version info use 'python -m grpc_tools.protoc --version'
-protobuf>=5.26.1,<5.27 # use same requirements as ortools https://github.com/google/or-tools/blob/stable/ortools/python/setup.py.in
+grpcio-tools
+protobuf
 wheel
 typing-extensions
 pytest


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove version constraints from grpc-related packages

- Unpin `grpcio-tools` and `protobuf` dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pinned Dependencies"] --> B["Unpinned Dependencies"]
  B --> C["grpcio-tools"]
  B --> D["protobuf"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-requirements.txt</strong><dd><code>Unpin grpc package versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

GrpcInterface/Python/build-requirements.txt

<ul><li>Remove version constraint <code><1.64</code> from <code>grpcio-tools</code><br> <li> Remove version constraint <code>>=5.26.1,<5.27</code> from <code>protobuf</code><br> <li> Keep explanatory comments removed</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/349/files#diff-aa3d8f2e4a25d855618a62f63b8dba0122631b344596630df566a9f95fb11940">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

