### PR TITLE
Improve naming of LGR export data

### DIFF
--- a/ApplicationLibCode/Commands/ExportCommands/RicExportLgrFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportLgrFeature.cpp
@@ -370,9 +370,9 @@ void RicExportLgrFeature::writeLgrs( QTextStream& stream, const std::vector<LgrI
             formatter.addOneBasedCellIndex( lgrInfo.mainGridEndCell.j() );
             formatter.addOneBasedCellIndex( lgrInfo.mainGridStartCell.k() );
             formatter.addOneBasedCellIndex( lgrInfo.mainGridEndCell.k() );
-            formatter.add( lgrInfo.sizes.i() );
-            formatter.add( lgrInfo.sizes.j() );
-            formatter.add( lgrInfo.sizes.k() );
+            formatter.add( lgrInfo.lgrCellCounts().i() );
+            formatter.add( lgrInfo.lgrCellCounts().j() );
+            formatter.add( lgrInfo.lgrCellCounts().k() );
             formatter.rowCompleted();
             formatter.tableCompleted( "", false );
         }
@@ -392,14 +392,14 @@ void RicExportLgrFeature::exportLgrsForWellPaths( const QString&                
                                                   std::vector<RimWellPath*>                          wellPaths,
                                                   RimEclipseCase*                                    eclipseCase,
                                                   size_t                                             timeStep,
-                                                  caf::VecIjk                                        lgrCellCounts,
+                                                  caf::VecIjk                                        refinement,
                                                   Lgr::SplitType                                     splitType,
                                                   const std::set<RigCompletionData::CompletionType>& completionTypes,
                                                   QStringList*                                       wellsIntersectingOtherLgrs )
 {
     std::vector<LgrInfo> lgrs;
 
-    lgrs = buildLgrsForWellPaths( wellPaths, eclipseCase, timeStep, lgrCellCounts, splitType, completionTypes, wellsIntersectingOtherLgrs );
+    lgrs = buildLgrsForWellPaths( wellPaths, eclipseCase, timeStep, refinement, splitType, completionTypes, wellsIntersectingOtherLgrs );
 
     for ( const auto& wellPath : wellPaths )
     {
@@ -441,7 +441,7 @@ void RicExportLgrFeature::exportLgrs( const QString& exportFolder, const QString
 std::vector<LgrInfo> RicExportLgrFeature::buildLgrsForWellPaths( std::vector<RimWellPath*>                          wellPaths,
                                                                  RimEclipseCase*                                    eclipseCase,
                                                                  size_t                                             timeStep,
-                                                                 caf::VecIjk                                        lgrCellCounts,
+                                                                 caf::VecIjk                                        refinement,
                                                                  Lgr::SplitType                                     splitType,
                                                                  const std::set<RigCompletionData::CompletionType>& completionTypes,
                                                                  QStringList* wellsIntersectingOtherLgrs )
@@ -468,7 +468,7 @@ std::vector<LgrInfo> RicExportLgrFeature::buildLgrsForWellPaths( std::vector<Rim
             }
 
             auto newLgrs =
-                buildLgrsPerMainCell( firstLgrId + (int)lgrs.size(), eclipseCase, wellPath, intersectingCells, lgrCellCounts, lgrNameFactory );
+                buildLgrsPerMainCell( firstLgrId + (int)lgrs.size(), eclipseCase, wellPath, intersectingCells, refinement, lgrNameFactory );
 
             lgrs.insert( lgrs.end(), newLgrs.begin(), newLgrs.end() );
             if ( isIntersectingOtherLgrs ) wellsIntersectingOtherLgrs->push_back( wellPath->name() );
@@ -480,8 +480,7 @@ std::vector<LgrInfo> RicExportLgrFeature::buildLgrsForWellPaths( std::vector<Rim
             cellsIntersectingCompletions_PerCompletion( eclipseCase, wellPaths, timeStep, completionTypes, wellsIntersectingOtherLgrs );
         if ( !intersectingCells.empty() )
         {
-            auto newLgrs =
-                buildLgrsPerCompletion( firstLgrId + (int)lgrs.size(), eclipseCase, intersectingCells, lgrCellCounts, lgrNameFactory );
+            auto newLgrs = buildLgrsPerCompletion( firstLgrId + (int)lgrs.size(), eclipseCase, intersectingCells, refinement, lgrNameFactory );
             lgrs.insert( lgrs.end(), newLgrs.begin(), newLgrs.end() );
         }
     }
@@ -502,7 +501,7 @@ std::vector<LgrInfo> RicExportLgrFeature::buildLgrsForWellPaths( std::vector<Rim
 
             if ( !intersectingCells.empty() )
             {
-                lgrs.push_back( buildLgr( lgrId, lgrName, eclipseCase, wellPath->name(), intersectingCells, lgrCellCounts ) );
+                lgrs.push_back( buildLgr( lgrId, lgrName, wellPath->name(), intersectingCells, refinement ) );
             }
 
             if ( isIntersectingOtherLgrs ) wellsIntersectingOtherLgrs->push_back( wellPath->name() );
@@ -519,7 +518,7 @@ std::vector<LgrInfo> RicExportLgrFeature::buildLgrsPerMainCell( int             
                                                                 RimEclipseCase*                               eclipseCase,
                                                                 RimWellPath*                                  wellPath,
                                                                 const std::vector<RigCompletionDataGridCell>& intersectingCells,
-                                                                const caf::VecIjk&                            lgrSizes,
+                                                                const caf::VecIjk&                            refinement,
                                                                 LgrNameFactory&                               lgrNameFactory )
 {
     std::vector<LgrInfo> lgrs;
@@ -527,7 +526,7 @@ std::vector<LgrInfo> RicExportLgrFeature::buildLgrsPerMainCell( int             
     for ( const auto& intersectionCell : intersectingCells )
     {
         auto lgrName = lgrNameFactory.newName( "", lgrId );
-        lgrs.push_back( buildLgr( lgrId++, lgrName, eclipseCase, wellPath->name(), { intersectionCell }, lgrSizes ) );
+        lgrs.push_back( buildLgr( lgrId++, lgrName, wellPath->name(), { intersectionCell }, refinement ) );
     }
     return lgrs;
 }
@@ -539,8 +538,8 @@ std::vector<LgrInfo>
     RicExportLgrFeature::buildLgrsPerCompletion( int                                                                     firstLgrId,
                                                  RimEclipseCase*                                                         eclipseCase,
                                                  const std::map<CompletionInfo, std::vector<RigCompletionDataGridCell>>& completionInfo,
-                                                 const caf::VecIjk& lgrSizesPerMainGridCell,
-                                                 LgrNameFactory&    lgrNameFactory )
+                                                 const caf::VecIjk&                                                      refinement,
+                                                 LgrNameFactory&                                                         lgrNameFactory )
 {
     std::vector<LgrInfo> lgrs;
 
@@ -593,7 +592,7 @@ std::vector<LgrInfo>
     for ( auto complInfo : occupiedBbs )
     {
         auto lgrName = lgrNameFactory.newName( complInfo.first.type );
-        lgrs.push_back( buildLgr( lgrId++, lgrName, eclipseCase, complInfo.first.wellPathName, complInfo.second, lgrSizesPerMainGridCell ) );
+        lgrs.push_back( buildLgr( lgrId++, lgrName, complInfo.first.wellPathName, complInfo.second, refinement ) );
     }
     return lgrs;
 }
@@ -603,31 +602,17 @@ std::vector<LgrInfo>
 //--------------------------------------------------------------------------------------------------
 LgrInfo RicExportLgrFeature::buildLgr( int                                           lgrId,
                                        const QString&                                lgrName,
-                                       RimEclipseCase*                               eclipseCase,
                                        const QString&                                wellPathName,
                                        const std::vector<RigCompletionDataGridCell>& intersectingCells,
-                                       const caf::VecIjk&                            lgrSizesPerMainGridCell )
+                                       const caf::VecIjk&                            refinement )
 {
-    // Find min and max IJK
-    auto iRange = initRange();
-    auto jRange = initRange();
-    auto kRange = initRange();
-
+    IjkBoundingBox boundingBox;
     for ( const auto& cell : intersectingCells )
     {
-        iRange.first  = std::min( cell.localCellIndexI(), iRange.first );
-        iRange.second = std::max( cell.localCellIndexI(), iRange.second );
-        jRange.first  = std::min( cell.localCellIndexJ(), jRange.first );
-        jRange.second = std::max( cell.localCellIndexJ(), jRange.second );
-        kRange.first  = std::min( cell.localCellIndexK(), kRange.first );
-        kRange.second = std::max( cell.localCellIndexK(), kRange.second );
+        boundingBox.addCell( cell.localCellIndexI(), cell.localCellIndexJ(), cell.localCellIndexK() );
     }
 
-    caf::VecIjk mainGridStartCell( iRange.first, jRange.first, kRange.first );
-    caf::VecIjk mainGridEndCell( iRange.second, jRange.second, kRange.second );
-
-    IjkBoundingBox boundingBox( mainGridStartCell, mainGridEndCell );
-    return buildLgr( lgrId, lgrName, eclipseCase, wellPathName, boundingBox, lgrSizesPerMainGridCell );
+    return buildLgr( lgrId, lgrName, wellPathName, boundingBox, refinement );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -635,16 +620,11 @@ LgrInfo RicExportLgrFeature::buildLgr( int                                      
 //--------------------------------------------------------------------------------------------------
 LgrInfo RicExportLgrFeature::buildLgr( int                   lgrId,
                                        const QString&        lgrName,
-                                       RimEclipseCase*       eclipseCase,
                                        const QString&        wellPathName,
                                        const IjkBoundingBox& boundingBox,
-                                       const caf::VecIjk&    lgrSizesPerMainGridCell )
+                                       const caf::VecIjk&    refinement )
 {
-    caf::VecIjk lgrSizes( ( boundingBox.max().i() - boundingBox.min().i() + 1 ) * lgrSizesPerMainGridCell.i(),
-                          ( boundingBox.max().j() - boundingBox.min().j() + 1 ) * lgrSizesPerMainGridCell.j(),
-                          ( boundingBox.max().k() - boundingBox.min().k() + 1 ) * lgrSizesPerMainGridCell.k() );
-
-    return LgrInfo( lgrId, lgrName, wellPathName, lgrSizes, boundingBox.min(), boundingBox.max() );
+    return LgrInfo( lgrId, lgrName, wellPathName, refinement, boundingBox.min(), boundingBox.max() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -790,7 +770,7 @@ void RicExportLgrFeature::onActionTriggered( bool isChecked )
     if ( dialogData )
     {
         auto   eclipseCase   = dialogData->caseToApply();
-        auto   lgrCellCounts = dialogData->lgrCellCount();
+        auto   lgrCellCounts = dialogData->refinement();
         size_t timeStep      = dialogData->timeStep();
 
         QStringList wellsIntersectingOtherLgrs;
@@ -876,7 +856,7 @@ std::pair<caf::VecIjk, caf::VecIjk> mainGridCellBoundingBoxFromLgr( const RigGri
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::map<QString /*wellName*/, std::vector<LgrInfo>> RicExportLgrFeature::createLgrInfoListForTemporaryLgrs( const RigMainGrid* mainGrid )
+std::map<QString, std::vector<LgrInfo>> RicExportLgrFeature::createLgrInfoListForTemporaryLgrs( const RigMainGrid* mainGrid )
 {
     std::map<QString, std::vector<LgrInfo>> lgrInfosPerWell;
 
@@ -885,8 +865,17 @@ std::map<QString /*wellName*/, std::vector<LgrInfo>> RicExportLgrFeature::create
         const auto grid = mainGrid->gridByIndex( i );
         if ( !grid->isTempGrid() ) continue;
 
-        caf::VecIjk                         lgrSizes( grid->cellCountI(), grid->cellCountJ(), grid->cellCountK() );
         std::pair<caf::VecIjk, caf::VecIjk> mainGridBoundingBox = mainGridCellBoundingBoxFromLgr( grid );
+
+        size_t mainGridCellCountI = mainGridBoundingBox.second.i() - mainGridBoundingBox.first.i() + 1;
+        size_t mainGridCellCountJ = mainGridBoundingBox.second.j() - mainGridBoundingBox.first.j() + 1;
+        size_t mainGridCellCountK = mainGridBoundingBox.second.k() - mainGridBoundingBox.first.k() + 1;
+
+        auto refinementI = mainGridCellCountI > 0 ? std::max( size_t( 1 ), grid->cellCountI() / mainGridCellCountI ) : 1;
+        auto refinementJ = mainGridCellCountJ > 0 ? std::max( size_t( 1 ), grid->cellCountJ() / mainGridCellCountJ ) : 1;
+        auto refinementK = mainGridCellCountK > 0 ? std::max( size_t( 1 ), grid->cellCountK() / mainGridCellCountK ) : 1;
+
+        caf::VecIjk refinement( refinementI, refinementJ, refinementK );
 
         QString wellName = QString::fromStdString( grid->associatedWellPathName() );
         auto&   item     = lgrInfosPerWell[wellName];
@@ -894,7 +883,7 @@ std::map<QString /*wellName*/, std::vector<LgrInfo>> RicExportLgrFeature::create
         item.emplace_back( LgrInfo( grid->gridId(),
                                     QString::fromStdString( grid->gridName() ),
                                     QString::fromStdString( grid->associatedWellPathName() ),
-                                    lgrSizes,
+                                    refinement,
                                     mainGridBoundingBox.first,
                                     mainGridBoundingBox.second ) );
     }

--- a/ApplicationLibCode/Commands/ExportCommands/RicExportLgrFeature.h
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportLgrFeature.h
@@ -52,31 +52,42 @@ public:
     LgrInfo( int                id,
              const QString&     name,
              const QString&     associatedWellPathName,
-             const caf::VecIjk& sizes,
+             const caf::VecIjk& refinement,
              const caf::VecIjk& mainGridStartCell,
              const caf::VecIjk& mainGridEndCell )
         : id( id )
         , name( name )
         , associatedWellPathName( associatedWellPathName )
-        , sizes( sizes )
+        , refinement( refinement )
         , mainGridStartCell( mainGridStartCell )
         , mainGridEndCell( mainGridEndCell )
     {
     }
 
-    caf::VecIjk sizesPerMainGridCell() const
+    caf::VecIjk lgrCellCounts() const
     {
-        return caf::VecIjk( sizes.i() / ( mainGridEndCell.i() - mainGridStartCell.i() + 1 ),
-                            sizes.j() / ( mainGridEndCell.j() - mainGridStartCell.j() + 1 ),
-                            sizes.k() / ( mainGridEndCell.k() - mainGridStartCell.k() + 1 ) );
+        auto lgrI = ( mainGridEndCell.i() - mainGridStartCell.i() + 1 ) * refinement.i();
+        auto lgrJ = ( mainGridEndCell.j() - mainGridStartCell.j() + 1 ) * refinement.j();
+        auto lgrK = ( mainGridEndCell.k() - mainGridStartCell.k() + 1 ) * refinement.k();
+
+        lgrI = lgrI > 0 ? lgrI : 1;
+        lgrJ = lgrJ > 0 ? lgrJ : 1;
+        lgrK = lgrK > 0 ? lgrK : 1;
+
+        return { lgrI, lgrJ, lgrK };
     }
 
-    size_t cellCount() const { return sizes.i() * sizes.j() * sizes.k(); }
+    size_t lgrCellCount() const
+    {
+        auto size = lgrCellCounts();
+        return size.i() * size.j() * size.k();
+    }
 
-    int         id;
-    QString     name;
-    QString     associatedWellPathName;
-    caf::VecIjk sizes;
+    int     id;
+    QString name;
+    QString associatedWellPathName;
+
+    caf::VecIjk refinement;
 
     caf::VecIjk mainGridStartCell;
     caf::VecIjk mainGridEndCell;
@@ -158,7 +169,7 @@ class RicExportLgrFeature : public caf::CmdFeature
                                                    std::vector<RimWellPath*>                          wellPaths,
                                                    RimEclipseCase*                                    eclipseCase,
                                                    size_t                                             timeStep,
-                                                   caf::VecIjk                                        lgrCellCounts,
+                                                   caf::VecIjk                                        refinement,
                                                    Lgr::SplitType                                     splitType,
                                                    const std::set<RigCompletionData::CompletionType>& completionTypes,
                                                    QStringList*                                       wellsIntersectingOtherLgrs );
@@ -168,14 +179,14 @@ class RicExportLgrFeature : public caf::CmdFeature
     static std::vector<LgrInfo> buildLgrsForWellPaths( std::vector<RimWellPath*>                          wellPaths,
                                                        RimEclipseCase*                                    eclipseCase,
                                                        size_t                                             timeStep,
-                                                       caf::VecIjk                                        lgrCellCounts,
+                                                       caf::VecIjk                                        refinement,
                                                        Lgr::SplitType                                     splitType,
                                                        const std::set<RigCompletionData::CompletionType>& completionTypes,
                                                        QStringList*                                       wellsIntersectingOtherLgrs );
 
     static std::vector<RimWellPath*> selectedWellPaths();
 
-    static std::map<QString /*wellName*/, std::vector<LgrInfo>> createLgrInfoListForTemporaryLgrs( const RigMainGrid* mainGrid );
+    static std::map<QString, std::vector<LgrInfo>> createLgrInfoListForTemporaryLgrs( const RigMainGrid* mainGrid );
 
 protected:
     bool isCommandEnabled() const override;
@@ -189,26 +200,24 @@ private:
                                                       RimEclipseCase*                               eclipseCase,
                                                       RimWellPath*                                  wellPath,
                                                       const std::vector<RigCompletionDataGridCell>& intersectingCells,
-                                                      const caf::VecIjk&                            lgrSizes,
+                                                      const caf::VecIjk&                            refinement,
                                                       LgrNameFactory&                               lgrNameFactory );
     static std::vector<LgrInfo> buildLgrsPerCompletion( int             firstLgrId,
                                                         RimEclipseCase* eclipseCase,
                                                         const std::map<CompletionInfo, std::vector<RigCompletionDataGridCell>>& completionInfo,
-                                                        const caf::VecIjk& lgrSizesPerMainGridCell,
+                                                        const caf::VecIjk& refinement,
                                                         LgrNameFactory&    lgrNameFactory );
     static LgrInfo              buildLgr( int                                           lgrId,
                                           const QString&                                lgrName,
-                                          RimEclipseCase*                               eclipseCase,
                                           const QString&                                wellPathName,
                                           const std::vector<RigCompletionDataGridCell>& intersectingCells,
-                                          const caf::VecIjk&                            lgrSizesPerMainGridCell );
+                                          const caf::VecIjk&                            refinement );
 
     static LgrInfo buildLgr( int                   lgrId,
                              const QString&        lgrName,
-                             RimEclipseCase*       eclipseCase,
                              const QString&        wellPathName,
                              const IjkBoundingBox& boundingBox,
-                             const caf::VecIjk&    lgrSizesPerMainGridCell );
+                             const caf::VecIjk&    refinement );
 
     static std::vector<RigCompletionDataGridCell> cellsIntersectingCompletions( RimEclipseCase*    eclipseCase,
                                                                                 const RimWellPath* wellPath,

--- a/ApplicationLibCode/Commands/ExportCommands/RicExportLgrUi.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportLgrUi.cpp
@@ -62,13 +62,13 @@ RicExportLgrUi::RicExportLgrUi()
     CAF_PDM_InitField( &m_includeFractures, "IncludeFractures", true, "Fractures" );
     CAF_PDM_InitField( &m_includeFishbones, "IncludeFishbones", true, "Fishbones" );
 
-    QString ijkLabel = "Cell Count I, J, K";
-    CAF_PDM_InitField( &m_cellCountI, "CellCountI", 2, ijkLabel );
-    CAF_PDM_InitField( &m_cellCountJ, "CellCountJ", 2, "" );
-    CAF_PDM_InitField( &m_cellCountK, "CellCountK", 2, "" );
+    QString ijkLabel = "Refinement I, J, K";
+    CAF_PDM_InitField( &m_refinementI, "CellCountI", 2, ijkLabel );
+    CAF_PDM_InitField( &m_refinementJ, "CellCountJ", 2, "" );
+    CAF_PDM_InitField( &m_refinementK, "CellCountK", 2, "" );
 
-    m_cellCountJ.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
-    m_cellCountK.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
+    m_refinementJ.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
+    m_refinementK.uiCapability()->setUiLabelPosition( caf::PdmUiItemInfo::HIDDEN );
 
     CAF_PDM_InitField( &m_splitType, "SplitType", Lgr::SplitTypeEnum(), "Split Type" );
 }
@@ -104,9 +104,9 @@ void RicExportLgrUi::setTimeStep( int timeStep )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-caf::VecIjk RicExportLgrUi::lgrCellCount() const
+caf::VecIjk RicExportLgrUi::refinement() const
 {
-    return caf::VecIjk( m_cellCountI, m_cellCountJ, m_cellCountK );
+    return caf::VecIjk( m_refinementI, m_refinementJ, m_refinementK );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -180,9 +180,9 @@ void RicExportLgrUi::setDefaultValuesFromCase()
         m_exportFolder     = caseFolder;
     }
 
-    m_cellCountI = 2;
-    m_cellCountJ = 2;
-    m_cellCountK = 2;
+    m_refinementI = 2;
+    m_refinementJ = 2;
+    m_refinementK = 2;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -230,9 +230,9 @@ void RicExportLgrUi::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering&
     uiOrdering.add( &m_splitType, { .newRow = true, .totalColumnSpan = 6, .leftLabelColumnSpan = 1 } );
 
     caf::PdmUiGroup* gridRefinement = uiOrdering.addNewGroup( "Grid Refinement" );
-    gridRefinement->add( &m_cellCountI, { .newRow = true, .totalColumnSpan = 2, .leftLabelColumnSpan = 1 } );
-    gridRefinement->appendToRow( &m_cellCountJ );
-    gridRefinement->appendToRow( &m_cellCountK );
+    gridRefinement->add( &m_refinementI, { .newRow = true, .totalColumnSpan = 2, .leftLabelColumnSpan = 1 } );
+    gridRefinement->appendToRow( &m_refinementJ );
+    gridRefinement->appendToRow( &m_refinementK );
 
     //    uiOrdering.add(&m_wellPathsInfo);
     uiOrdering.skipRemainingFields( true );

--- a/ApplicationLibCode/Commands/ExportCommands/RicExportLgrUi.h
+++ b/ApplicationLibCode/Commands/ExportCommands/RicExportLgrUi.h
@@ -53,7 +53,7 @@ public:
     void setCase( RimEclipseCase* rimCase );
     void setTimeStep( int timeStep );
 
-    caf::VecIjk                                 lgrCellCount() const;
+    caf::VecIjk                                 refinement() const;
     QString                                     exportFolder() const;
     RimEclipseCase*                             caseToApply() const;
     int                                         timeStep() const;
@@ -79,9 +79,9 @@ private:
     caf::PdmField<bool>               m_includeFractures;
     caf::PdmField<bool>               m_includeFishbones;
 
-    caf::PdmField<int> m_cellCountI;
-    caf::PdmField<int> m_cellCountJ;
-    caf::PdmField<int> m_cellCountK;
+    caf::PdmField<int> m_refinementI;
+    caf::PdmField<int> m_refinementJ;
+    caf::PdmField<int> m_refinementK;
 
     caf::PdmField<Lgr::SplitTypeEnum> m_splitType;
 };

--- a/ApplicationLibCode/Commands/RicCreateTemporaryLgrFeature.h
+++ b/ApplicationLibCode/Commands/RicCreateTemporaryLgrFeature.h
@@ -49,12 +49,14 @@ public:
     void createLgrsForWellPaths( std::vector<RimWellPath*>                          wellPaths,
                                  RimEclipseCase*                                    eclipseCase,
                                  size_t                                             timeStep,
-                                 caf::VecIjk                                        lgrCellCounts,
+                                 caf::VecIjk                                        refinement,
                                  Lgr::SplitType                                     splitType,
                                  const std::set<RigCompletionData::CompletionType>& completionTypes,
                                  QStringList*                                       wellsIntersectingOtherLgrs );
 
     void updateViews( RimEclipseCase* eclipseCase );
+
+    static void createLgr( const LgrInfo& lgrInfo, RigMainGrid* mainGrid );
 
 protected:
     bool isCommandEnabled() const override;
@@ -62,7 +64,6 @@ protected:
     void setupActionLook( QAction* actionToSetup ) override;
 
 private:
-    void createLgr( const LgrInfo& lgrInfo, RigMainGrid* mainGrid );
     void computeCachedData( RimEclipseCase* eclipseCase );
     void deleteAllCachedData( RimEclipseCase* eclipseCase );
 };


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Rename `lgrCellCounts` parameter to `refinement` throughout codebase

- Update LgrInfo class to use refinement-based calculations

- Change UI labels from "Cell Count" to "Refinement"

- Refactor LGR size computation logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parameter Renaming"] --> B["lgrCellCounts → refinement"]
  A --> C["UI Label Updates"]
  B --> D["LgrInfo Class Changes"]
  D --> E["Size Calculation Refactor"]
  C --> F["Cell Count → Refinement"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RicExportLgrFeature.cpp</strong><dd><code>Refactor LGR export to use refinement terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/ExportCommands/RicExportLgrFeature.cpp

<ul><li>Rename <code>lgrCellCounts</code> parameter to <code>refinement</code> in multiple functions<br> <li> Update LgrInfo usage to call <code>lgrCellCounts()</code> method instead of direct <br><code>sizes</code> access<br> <li> Refactor LGR building logic to use refinement terminology<br> <li> Remove unused <code>eclipseCase</code> parameter from buildLgr functions</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/350/files#diff-f0d8f6c7e70ee974d6a123e82a0876bd71540d57ed41ea5b7dd1a07da03a6f8c">+33/-44</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RicExportLgrUi.cpp</strong><dd><code>Update UI to use refinement terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/ExportCommands/RicExportLgrUi.cpp

<ul><li>Rename member variables from <code>m_cellCount*</code> to <code>m_refinement*</code><br> <li> Update UI labels from "Cell Count I, J, K" to "Refinement I, J, K"<br> <li> Rename <code>lgrCellCount()</code> method to <code>refinement()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/350/files#diff-49fd2b62b8f909c67c194e568f68763d7702adf4c102939a792ef207db1d36f1">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RicCreateTemporaryLgrFeature.cpp</strong><dd><code>Update temporary LGR creation for refinement terminology</code>&nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/RicCreateTemporaryLgrFeature.cpp

<ul><li>Rename <code>lgrCellCounts</code> parameter to <code>refinement</code><br> <li> Update method calls to use <code>lgrCellCount()</code> instead of <code>cellCount()</code><br> <li> Refactor LGR creation to use refinement-based calculations<br> <li> Make <code>createLgr</code> method static</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/350/files#diff-ee9c1f6d6958af27c7b755a43a6194ec6eb28a0f7fdd25795489848abf71d781">+21/-26</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RicExportLgrFeature.h</strong><dd><code>Update LgrInfo class and method signatures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/ExportCommands/RicExportLgrFeature.h

<ul><li>Rename <code>sizes</code> member to <code>refinement</code> in LgrInfo class<br> <li> Add <code>lgrCellCounts()</code> and <code>lgrCellCount()</code> methods<br> <li> Update function signatures to use <code>refinement</code> parameter<br> <li> Remove <code>eclipseCase</code> parameter from buildLgr methods</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/350/files#diff-029d0d28f41b9e706c10053d4ae53bab441d51de4846c17b46030f9f20f7aa90">+29/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RicExportLgrUi.h</strong><dd><code>Update UI header for refinement terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/ExportCommands/RicExportLgrUi.h

<ul><li>Rename member variables from <code>m_cellCount*</code> to <code>m_refinement*</code><br> <li> Update <code>lgrCellCount()</code> method name to <code>refinement()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/350/files#diff-d56fbd2c6d5ae43effbd824353548a7adc0a7f0cc231d632d4f7f438e94696e9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RicCreateTemporaryLgrFeature.h</strong><dd><code>Update header for refinement terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/RicCreateTemporaryLgrFeature.h

<ul><li>Rename <code>lgrCellCounts</code> parameter to <code>refinement</code><br> <li> Make <code>createLgr</code> method static</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/350/files#diff-e4716c4ed9f70e1460b70a87f58fa42f59f74867a0913e9679850c41bbec4e5c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

