### PR TITLE
Improve scripting optional fields

### DIFF
--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
@@ -131,6 +131,9 @@ TEST( PdmFieldSerialization, ValueList )
 //--------------------------------------------------------------------------------------------------
 TEST( PdmFieldSerialization, OptionalValues )
 {
+    // See currently supported types in PdmPythonGenerator::dataTypeString
+
+    // Optional string
     {
         std::optional<QString> optionalString = std::nullopt;
         QString                text;
@@ -144,7 +147,7 @@ TEST( PdmFieldSerialization, OptionalValues )
                                                                                           &messages,
                                                                                           stringsAreQuoted );
 
-        const QString expected = "\"\"";
+        const QString expected = "";
         EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
 
         std::optional<QString> result;
@@ -181,5 +184,101 @@ TEST( PdmFieldSerialization, OptionalValues )
                                                                                          stringsAreQuoted );
 
         EXPECT_STREQ( sourceText.toStdString().c_str(), result.value().toStdString().c_str() );
+    }
+
+    // Optional float
+    {
+        float                sourceValue    = 23.45;
+        std::optional<float> optionalString = sourceValue;
+
+        QString     text;
+        QTextStream stream( &text );
+
+        caf::PdmScriptIOMessages messages;
+
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<float>>::readFromField( optionalString, stream, &messages );
+
+        const QString expected = "23.45";
+        EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
+
+        std::optional<float> result;
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<float>>::writeToField( result, stream, &messages );
+
+        EXPECT_TRUE( result.has_value() );
+        EXPECT_DOUBLE_EQ( sourceValue, result.value() );
+    }
+
+    // Optional double
+    {
+        double                sourceValue    = 23.45;
+        std::optional<double> optionalString = sourceValue;
+
+        QString     text;
+        QTextStream stream( &text );
+
+        caf::PdmScriptIOMessages messages;
+
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<double>>::readFromField( optionalString, stream, &messages );
+
+        const QString expected = "2.345000000000000e+01";
+        EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
+
+        std::optional<double> result;
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<double>>::writeToField( result, stream, &messages );
+
+        EXPECT_TRUE( result.has_value() );
+        EXPECT_DOUBLE_EQ( sourceValue, result.value() );
+    }
+
+    // Optional bool
+    {
+        bool                     sourceValue    = true;
+        std::optional<bool>      optionalString = sourceValue;
+        QString                  text;
+        QTextStream              stream( &text );
+        caf::PdmScriptIOMessages messages;
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<bool>>::readFromField( optionalString, stream, &messages );
+
+        const QString expected = "true";
+        EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
+
+        std::optional<bool> result;
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<bool>>::writeToField( result, stream, &messages );
+        EXPECT_TRUE( result.has_value() );
+        EXPECT_EQ( sourceValue, result.value() );
+    }
+
+    // Optional int
+    {
+        int                      sourceValue    = 2345;
+        std::optional<int>       optionalString = sourceValue;
+        QString                  text;
+        QTextStream              stream( &text );
+        caf::PdmScriptIOMessages messages;
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<int>>::readFromField( optionalString, stream, &messages );
+
+        const QString expected = "2345";
+        EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
+
+        std::optional<int> result;
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<int>>::writeToField( result, stream, &messages );
+        EXPECT_TRUE( result.has_value() );
+        EXPECT_EQ( sourceValue, result.value() );
+    }
+
+    // Optional int with no value
+    {
+        std::optional<int>       optionalInt;
+        QString                  text;
+        QTextStream              stream( &text );
+        caf::PdmScriptIOMessages messages;
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<int>>::readFromField( optionalInt, stream, &messages );
+
+        const QString expected = "";
+        EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
+
+        std::optional<int> result;
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<int>>::writeToField( result, stream, &messages );
+        EXPECT_FALSE( result.has_value() );
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Improved optional field serialization in scripting framework

- Enhanced error handling with specific status messages

- Added comprehensive unit tests for optional types

- Fixed direct value writing to output streams


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Optional Field"] --> B["Direct Value Writing"]
  B --> C["Enhanced Error Handling"]
  C --> D["Comprehensive Testing"]
  D --> E["Improved Serialization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cafPdmFieldScriptingCapability.h</strong><dd><code>Enhanced optional field serialization and error handling</code>&nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmFieldScriptingCapability.h

<ul><li>Enhanced error handling with specific QTextStream status messages<br> <li> Simplified optional field serialization by writing values directly<br> <li> Removed unnecessary QString conversion and intermediate processing<br> <li> Added error count tracking to prevent field updates on read errors</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/356/files#diff-131086f14546d3848a5304269e485f9b0dfe960d874a289d34aab63ff357182d">+27/-29</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cafPdmFieldSerializationTest.cpp</strong><dd><code>Added comprehensive optional field unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp

<ul><li>Added comprehensive tests for optional float, double, bool, and int <br>types<br> <li> Added test for optional int with no value (nullopt case)<br> <li> Fixed expected output for optional string test from <code>""</code> to empty string<br> <li> Verified serialization and deserialization roundtrip for all types</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/356/files#diff-b5bfc0feddee8555f9c964e676c52e41a59bdea8fd3019752cf70323f48406ce">+100/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

