### PR TITLE
Crash fixes

### DIFF
--- a/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
+++ b/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
@@ -62,7 +62,7 @@ void RicApplyUserDefinedCameraFeature::onActionTriggered( bool isChecked )
         if ( eye.isUndefined() || vrp.isUndefined() || up.isUndefined() ) return;
 
         RicStoreUserDefinedCameraFeature::activeCamera()->setFromLookAt( eye, vrp, up );
-        
+
         if ( auto activeReservoirView = RiaApplication::instance()->activeReservoirView() )
         {
             activeReservoirView->updateDisplayModelForCurrentTimeStepAndRedraw();

--- a/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
+++ b/ApplicationLibCode/Commands/3dView/RicApplyUserDefinedCameraFeature.cpp
@@ -62,7 +62,11 @@ void RicApplyUserDefinedCameraFeature::onActionTriggered( bool isChecked )
         if ( eye.isUndefined() || vrp.isUndefined() || up.isUndefined() ) return;
 
         RicStoreUserDefinedCameraFeature::activeCamera()->setFromLookAt( eye, vrp, up );
-        RiaApplication::instance()->activeReservoirView()->updateDisplayModelForCurrentTimeStepAndRedraw();
+        
+        if ( auto activeReservoirView = RiaApplication::instance()->activeReservoirView() )
+        {
+            activeReservoirView->updateDisplayModelForCurrentTimeStepAndRedraw();
+        }
     }
 }
 

--- a/ApplicationLibCode/Commands/AnnotationCommands/RicCreateTextAnnotationIn3dViewFeature.cpp
+++ b/ApplicationLibCode/Commands/AnnotationCommands/RicCreateTextAnnotationIn3dViewFeature.cpp
@@ -55,7 +55,7 @@ void RicCreateTextAnnotationIn3dViewFeature::onActionTriggered( bool isChecked )
 
         auto viewer = activeView->viewer();
         if ( !viewer ) return;
-        
+
         auto viewerCommands = viewer->viewerCommands();
         if ( !viewerCommands ) return;
 

--- a/ApplicationLibCode/Commands/AnnotationCommands/RicCreateTextAnnotationIn3dViewFeature.cpp
+++ b/ApplicationLibCode/Commands/AnnotationCommands/RicCreateTextAnnotationIn3dViewFeature.cpp
@@ -51,9 +51,19 @@ void RicCreateTextAnnotationIn3dViewFeature::onActionTriggered( bool isChecked )
     if ( activeView )
     {
         RimGridView* viewOrComparisonView = RiaApplication::instance()->activeMainOrComparisonGridView();
+        if ( !viewOrComparisonView ) return;
 
-        cvf::Vec3d       domainCoord = activeView->viewer()->viewerCommands()->lastPickPositionInDomainCoords();
-        cvf::BoundingBox bbox        = viewOrComparisonView->ownerCase()->activeCellsBoundingBox();
+        auto viewer = activeView->viewer();
+        if ( !viewer ) return;
+        
+        auto viewerCommands = viewer->viewerCommands();
+        if ( !viewerCommands ) return;
+
+        auto ownerCase = viewOrComparisonView->ownerCase();
+        if ( !ownerCase ) return;
+
+        cvf::Vec3d       domainCoord = viewerCommands->lastPickPositionInDomainCoords();
+        cvf::BoundingBox bbox        = ownerCase->activeCellsBoundingBox();
 
         if ( contMapView ) domainCoord[2] = bbox.max().z() - bbox.extent().z() * 0.2;
 
@@ -65,7 +75,8 @@ void RicCreateTextAnnotationIn3dViewFeature::onActionTriggered( bool isChecked )
             newAnnotation->setAnchorPoint( domainCoord );
             cvf::Vec3d labelPos = domainCoord;
 
-            cvf::Camera* viewCamera = activeView->viewer()->mainCamera();
+            cvf::Camera* viewCamera = viewer->mainCamera();
+            if ( !viewCamera ) return;
 
             if ( viewCamera->direction().z() <= 0 )
             {

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewCellIndexFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewCellIndexFilterFeature.cpp
@@ -61,7 +61,7 @@ void RicNewCellIndexFilterFeature::onActionTriggered( bool isChecked )
     // and the case to use
     auto view3d = filtColl->firstAncestorOrThisOfType<Rim3dView>();
     if ( !view3d ) return;
-    
+
     RimCase* sourceCase = view3d->ownerCase();
 
     if ( sourceCase )

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewCellIndexFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewCellIndexFilterFeature.cpp
@@ -59,7 +59,10 @@ void RicNewCellIndexFilterFeature::onActionTriggered( bool isChecked )
     RimCellFilterCollection* filtColl = colls[0];
 
     // and the case to use
-    RimCase* sourceCase = filtColl->firstAncestorOrThisOfTypeAsserted<Rim3dView>()->ownerCase();
+    auto view3d = filtColl->firstAncestorOrThisOfType<Rim3dView>();
+    if ( !view3d ) return;
+    
+    RimCase* sourceCase = view3d->ownerCase();
 
     if ( sourceCase )
     {

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
@@ -70,7 +70,7 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
 
     auto view3d = cellFilterCollection->firstAncestorOrThisOfType<Rim3dView>();
     if ( !view3d ) return;
-    
+
     auto sourceCase = view3d->ownerCase();
     if ( !sourceCase ) return;
 

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
@@ -68,7 +68,10 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
     }
     if ( !cellFilterCollection ) return;
 
-    auto sourceCase = cellFilterCollection->firstAncestorOrThisOfTypeAsserted<Rim3dView>()->ownerCase();
+    auto view3d = cellFilterCollection->firstAncestorOrThisOfType<Rim3dView>();
+    if ( !view3d ) return;
+    
+    auto sourceCase = view3d->ownerCase();
     if ( !sourceCase ) return;
 
     std::vector<RimPolygon*> polygons;

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSliceFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSliceFeature.cpp
@@ -51,7 +51,8 @@ void RicNewRangeFilterSliceFeature::onActionTriggered( bool isChecked )
     if ( !colls.empty() )
     {
         filterCollection = colls.front();
-        sourceCase       = filterCollection->firstAncestorOrThisOfTypeAsserted<Rim3dView>()->ownerCase();
+        auto view3d = filterCollection->firstAncestorOrThisOfType<Rim3dView>();
+        if ( view3d ) sourceCase = view3d->ownerCase();
     }
 
     if ( !filterCollection )

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSliceFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSliceFeature.cpp
@@ -51,7 +51,7 @@ void RicNewRangeFilterSliceFeature::onActionTriggered( bool isChecked )
     if ( !colls.empty() )
     {
         filterCollection = colls.front();
-        auto view3d = filterCollection->firstAncestorOrThisOfType<Rim3dView>();
+        auto view3d      = filterCollection->firstAncestorOrThisOfType<Rim3dView>();
         if ( view3d ) sourceCase = view3d->ownerCase();
     }
 

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedFilterFeature.cpp
@@ -43,7 +43,10 @@ void RicNewUserDefinedFilterFeature::onActionTriggered( bool isChecked )
     RimCellFilterCollection* filtColl = colls[0];
 
     // and the case to use
-    RimCase* sourceCase = filtColl->firstAncestorOrThisOfTypeAsserted<Rim3dView>()->ownerCase();
+    auto view3d = filtColl->firstAncestorOrThisOfType<Rim3dView>();
+    if ( !view3d ) return;
+    
+    RimCase* sourceCase = view3d->ownerCase();
 
     if ( sourceCase )
     {

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedFilterFeature.cpp
@@ -45,7 +45,7 @@ void RicNewUserDefinedFilterFeature::onActionTriggered( bool isChecked )
     // and the case to use
     auto view3d = filtColl->firstAncestorOrThisOfType<Rim3dView>();
     if ( !view3d ) return;
-    
+
     RimCase* sourceCase = view3d->ownerCase();
 
     if ( sourceCase )

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedIndexFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedIndexFilterFeature.cpp
@@ -45,7 +45,7 @@ void RicNewUserDefinedIndexFilterFeature::onActionTriggered( bool isChecked )
     // and the case to use
     auto view3d = filtColl->firstAncestorOrThisOfType<Rim3dView>();
     if ( !view3d ) return;
-    
+
     RimCase* sourceCase = view3d->ownerCase();
 
     if ( sourceCase )

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedIndexFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedIndexFilterFeature.cpp
@@ -43,7 +43,10 @@ void RicNewUserDefinedIndexFilterFeature::onActionTriggered( bool isChecked )
     RimCellFilterCollection* filtColl = colls[0];
 
     // and the case to use
-    RimCase* sourceCase = filtColl->firstAncestorOrThisOfTypeAsserted<Rim3dView>()->ownerCase();
+    auto view3d = filtColl->firstAncestorOrThisOfType<Rim3dView>();
+    if ( !view3d ) return;
+    
+    RimCase* sourceCase = view3d->ownerCase();
 
     if ( sourceCase )
     {

--- a/ApplicationLibCode/Commands/CrossSectionCommands/RicNewAzimuthDipIntersectionFeature.cpp
+++ b/ApplicationLibCode/Commands/CrossSectionCommands/RicNewAzimuthDipIntersectionFeature.cpp
@@ -103,7 +103,10 @@ void RicNewAzimuthDipIntersectionFeatureCmd::redo()
     intersection->setName( "Azimuth and Dip" );
     intersection->configureForAzimuthLine();
 
-    RimCase* rimCase = m_intersectionCollection->firstAncestorOrThisOfTypeAsserted<Rim3dView>()->ownerCase();
+    auto view3d = m_intersectionCollection->firstAncestorOrThisOfType<Rim3dView>();
+    if ( !view3d ) return;
+    
+    RimCase* rimCase = view3d->ownerCase();
     if ( !rimCase ) return;
 
     cvf::BoundingBox bBox = rimCase->allCellsBoundingBox();

--- a/ApplicationLibCode/Commands/CrossSectionCommands/RicNewAzimuthDipIntersectionFeature.cpp
+++ b/ApplicationLibCode/Commands/CrossSectionCommands/RicNewAzimuthDipIntersectionFeature.cpp
@@ -105,7 +105,7 @@ void RicNewAzimuthDipIntersectionFeatureCmd::redo()
 
     auto view3d = m_intersectionCollection->firstAncestorOrThisOfType<Rim3dView>();
     if ( !view3d ) return;
-    
+
     RimCase* rimCase = view3d->ownerCase();
     if ( !rimCase ) return;
 

--- a/ApplicationLibCode/Commands/FlowCommands/RicAddStoredFlowCharacteristicsPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/FlowCommands/RicAddStoredFlowCharacteristicsPlotFeature.cpp
@@ -62,6 +62,7 @@ void RicAddStoredFlowCharacteristicsPlotFeature::onActionTriggered( bool isCheck
     {
         RimFlowCharacteristicsPlot* sourceObject =
             dynamic_cast<RimFlowCharacteristicsPlot*>( caf::SelectionManager::instance()->selectedItem() );
+        if ( !sourceObject ) return;
 
         auto flowCharacteristicsPlot = sourceObject->copyObject<RimFlowCharacteristicsPlot>();
         CVF_ASSERT( flowCharacteristicsPlot );

--- a/ApplicationLibCode/Commands/FlowCommands/RicAddStoredWellAllocationPlotFeature.cpp
+++ b/ApplicationLibCode/Commands/FlowCommands/RicAddStoredWellAllocationPlotFeature.cpp
@@ -61,6 +61,7 @@ void RicAddStoredWellAllocationPlotFeature::onActionTriggered( bool isChecked )
     if ( flowPlotColl )
     {
         RimWellAllocationPlot* sourceObject = dynamic_cast<RimWellAllocationPlot*>( caf::SelectionManager::instance()->selectedItem() );
+        if ( !sourceObject ) return;
 
         auto wellAllocationPlot = sourceObject->copyObject<RimWellAllocationPlot>();
         CVF_ASSERT( wellAllocationPlot );

--- a/ApplicationLibCode/Commands/FractureCommands/RicPlaceThermalFractureUsingTemplateDataFeature.cpp
+++ b/ApplicationLibCode/Commands/FractureCommands/RicPlaceThermalFractureUsingTemplateDataFeature.cpp
@@ -83,7 +83,7 @@ bool RicPlaceThermalFractureUsingTemplateDataFeature::isCommandEnabled() const
 RimWellPathFracture* RicPlaceThermalFractureUsingTemplateDataFeature::selectedThermalFracture()
 {
     auto fracture = caf::SelectionManager::instance()->selectedItemOfType<RimWellPathFracture>();
-    if ( !fracture->fractureTemplate() ) return nullptr;
+    if ( !fracture || !fracture->fractureTemplate() ) return nullptr;
 
     RimThermalFractureTemplate* thermalTemplate = dynamic_cast<RimThermalFractureTemplate*>( fracture->fractureTemplate() );
     if ( !thermalTemplate ) return nullptr;

--- a/ApplicationLibCode/Commands/GeoMechCommands/RicNewFaultReactModelingFeature.cpp
+++ b/ApplicationLibCode/Commands/GeoMechCommands/RicNewFaultReactModelingFeature.cpp
@@ -90,7 +90,8 @@ void RicNewFaultReactModelingFeature::onActionTriggered( bool isChecked )
                 auto normal = cell.faceNormalWithAreaLength( face );
                 normal.z()  = normal.z() / eclView->scaleZ() / eclView->scaleZ();
                 normal.normalize();
-                normal *= eclView->ownerCase()->characteristicCellSize();
+                auto ownerCase = eclView->ownerCase();
+                if ( ownerCase ) normal *= ownerCase->characteristicCellSize();
                 normal *= 3;
 
                 if ( !eclView->mainGrid()->isFaceNormalsOutwards() ) normal = normal * -1.0;

--- a/ApplicationLibCode/Commands/GridCrossPlotCommands/RicCreateGridCrossPlotDataSetFeature.cpp
+++ b/ApplicationLibCode/Commands/GridCrossPlotCommands/RicCreateGridCrossPlotDataSetFeature.cpp
@@ -45,6 +45,7 @@ bool RicCreateGridCrossPlotDataSetFeature::isCommandEnabled() const
 void RicCreateGridCrossPlotDataSetFeature::onActionTriggered( bool isChecked )
 {
     RimGridCrossPlot* crossPlot = caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlot>();
+    if ( !crossPlot ) return;
 
     RimGridCrossPlotDataSet* dataSet = crossPlot->createDataSet();
     dataSet->loadDataAndUpdate( true );

--- a/ApplicationLibCode/Commands/GridCrossPlotCommands/RicSwapGridCrossPlotDataSetAxesFeature.cpp
+++ b/ApplicationLibCode/Commands/GridCrossPlotCommands/RicSwapGridCrossPlotDataSetAxesFeature.cpp
@@ -18,9 +18,8 @@ bool RicSwapGridCrossPlotDataSetAxesFeature::isCommandEnabled() const
     {
         return true;
     }
-    else if ( caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlot>() )
+    else if ( auto plot = caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlot>() )
     {
-        auto plot = caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlot>();
         if ( !plot->dataSets().empty() ) return true;
     }
     return false;
@@ -31,14 +30,12 @@ bool RicSwapGridCrossPlotDataSetAxesFeature::isCommandEnabled() const
 //--------------------------------------------------------------------------------------------------
 void RicSwapGridCrossPlotDataSetAxesFeature::onActionTriggered( bool isChecked )
 {
-    if ( caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlotDataSet>() )
+    if ( auto dataSet = caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlotDataSet>() )
     {
-        auto dataSet = caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlotDataSet>();
         dataSet->swapAxisProperties( true );
     }
-    else if ( caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlot>() )
+    else if ( auto plot = caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlot>() )
     {
-        auto plot = caf::SelectionManager::instance()->selectedItemOfType<RimGridCrossPlot>();
         plot->swapAxes();
     }
 }

--- a/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionBoxAtPosFeature.cpp
+++ b/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionBoxAtPosFeature.cpp
@@ -55,7 +55,13 @@ void RicIntersectionBoxAtPosFeature::onActionTriggered( bool isChecked )
 
         coll->appendIntersectionBoxAndUpdate( intersectionBox );
 
-        cvf::Vec3d domainCoord = activeView->viewer()->viewerCommands()->lastPickPositionInDomainCoords();
+        auto viewer = activeView->viewer();
+        if ( !viewer ) return;
+        
+        auto viewerCommands = viewer->viewerCommands();
+        if ( !viewerCommands ) return;
+        
+        cvf::Vec3d domainCoord = viewerCommands->lastPickPositionInDomainCoords();
 
         intersectionBox->setToDefaultSizeSlice( RimBoxIntersection::PLANE_STATE_NONE, domainCoord );
 

--- a/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionBoxAtPosFeature.cpp
+++ b/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionBoxAtPosFeature.cpp
@@ -57,10 +57,10 @@ void RicIntersectionBoxAtPosFeature::onActionTriggered( bool isChecked )
 
         auto viewer = activeView->viewer();
         if ( !viewer ) return;
-        
+
         auto viewerCommands = viewer->viewerCommands();
         if ( !viewerCommands ) return;
-        
+
         cvf::Vec3d domainCoord = viewerCommands->lastPickPositionInDomainCoords();
 
         intersectionBox->setToDefaultSizeSlice( RimBoxIntersection::PLANE_STATE_NONE, domainCoord );

--- a/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionFeatureImpl.cpp
@@ -42,10 +42,10 @@ void RicIntersectionFeatureImpl::createIntersectionBoxSlize( const QString& name
 
         auto viewer = activeView->viewer();
         if ( !viewer ) return;
-        
+
         auto viewerCommands = viewer->viewerCommands();
         if ( !viewerCommands ) return;
-        
+
         cvf::Vec3d domainCoord = viewerCommands->lastPickPositionInDomainCoords();
 
         RimBoxIntersection* intersectionBox = new RimBoxIntersection();

--- a/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionFeatureImpl.cpp
+++ b/ApplicationLibCode/Commands/IntersectionBoxCommands/RicIntersectionFeatureImpl.cpp
@@ -40,7 +40,13 @@ void RicIntersectionFeatureImpl::createIntersectionBoxSlize( const QString& name
         RimIntersectionCollection* coll = activeMainOrComparisonView->intersectionCollection();
         CVF_ASSERT( coll );
 
-        cvf::Vec3d domainCoord = activeView->viewer()->viewerCommands()->lastPickPositionInDomainCoords();
+        auto viewer = activeView->viewer();
+        if ( !viewer ) return;
+        
+        auto viewerCommands = viewer->viewerCommands();
+        if ( !viewerCommands ) return;
+        
+        cvf::Vec3d domainCoord = viewerCommands->lastPickPositionInDomainCoords();
 
         RimBoxIntersection* intersectionBox = new RimBoxIntersection();
         intersectionBox->setName( name );

--- a/ApplicationLibCode/Commands/RicCopyGridStatisticsToClipboardFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCopyGridStatisticsToClipboardFeature.cpp
@@ -53,7 +53,7 @@ void RicCopyGridStatisticsToClipboardFeature::onActionTriggered( bool isChecked 
     {
         auto viewer = activeView->viewer();
         if ( !viewer ) return;
-        
+
         auto text = viewer->infoText();
         if ( !text.isEmpty() )
         {

--- a/ApplicationLibCode/Commands/RicCopyGridStatisticsToClipboardFeature.cpp
+++ b/ApplicationLibCode/Commands/RicCopyGridStatisticsToClipboardFeature.cpp
@@ -51,7 +51,10 @@ void RicCopyGridStatisticsToClipboardFeature::onActionTriggered( bool isChecked 
 
     if ( activeView )
     {
-        auto text = activeView->viewer()->infoText();
+        auto viewer = activeView->viewer();
+        if ( !viewer ) return;
+        
+        auto text = viewer->infoText();
         if ( !text.isEmpty() )
         {
             // Replace some tokens with newline

--- a/ApplicationLibCode/Commands/RicTogglePerspectiveViewFeature.cpp
+++ b/ApplicationLibCode/Commands/RicTogglePerspectiveViewFeature.cpp
@@ -37,7 +37,11 @@ bool RicTogglePerspectiveViewFeature::isCommandEnabled() const
 {
     RimGridView*              activeGridView = RiaApplication::instance()->activeGridView();
     RimEclipseContourMapView* view2d         = dynamic_cast<RimEclipseContourMapView*>( activeGridView );
-    return !view2d && activeGridView && RiaApplication::instance()->activeReservoirView()->viewer();
+    if ( auto activeReservoirView = RiaApplication::instance()->activeReservoirView() )
+    {
+        return !view2d && activeGridView && activeReservoirView->viewer();
+    }
+    return false;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -45,16 +49,19 @@ bool RicTogglePerspectiveViewFeature::isCommandEnabled() const
 //--------------------------------------------------------------------------------------------------
 void RicTogglePerspectiveViewFeature::onActionTriggered( bool isChecked )
 {
-    if ( RiaApplication::instance()->activeGridView() && RiaApplication::instance()->activeReservoirView()->viewer() )
+    if ( auto activeReservoirView = RiaApplication::instance()->activeReservoirView() )
     {
-        bool isPerspective = RiaApplication::instance()->activeReservoirView()->isPerspectiveView();
-        RiaApplication::instance()->activeReservoirView()->isPerspectiveView = !isPerspective;
-        RiaApplication::instance()->activeReservoirView()->isPerspectiveView.uiCapability()->updateConnectedEditors();
+        if ( RiaApplication::instance()->activeGridView() && activeReservoirView->viewer() )
+        {
+            bool isPerspective = activeReservoirView->isPerspectiveView();
+            activeReservoirView->isPerspectiveView = !isPerspective;
+            activeReservoirView->isPerspectiveView.uiCapability()->updateConnectedEditors();
 
-        RiaApplication::instance()->activeReservoirView()->viewer()->enableParallelProjection( isPerspective );
-        RiaApplication::instance()->activeReservoirView()->viewer()->navigationPolicyUpdate();
+            activeReservoirView->viewer()->enableParallelProjection( isPerspective );
+            activeReservoirView->viewer()->navigationPolicyUpdate();
 
-        action(); // Retrieve the action to update the looks
+            action(); // Retrieve the action to update the looks
+        }
     }
 }
 
@@ -63,9 +70,9 @@ void RicTogglePerspectiveViewFeature::onActionTriggered( bool isChecked )
 //--------------------------------------------------------------------------------------------------
 void RicTogglePerspectiveViewFeature::setupActionLook( QAction* actionToSetup )
 {
-    if ( RiaApplication::instance()->activeReservoirView() && RiaApplication::instance()->activeReservoirView()->viewer() )
+    if ( auto activeReservoirView = RiaApplication::instance()->activeReservoirView() )
     {
-        if ( RiaApplication::instance()->activeReservoirView()->isPerspectiveView() )
+        if ( activeReservoirView->viewer() && activeReservoirView->isPerspectiveView() )
         {
             actionToSetup->setText( "Parallel View" );
             actionToSetup->setIcon( QIcon( ":/Parallel.svg" ) );

--- a/ApplicationLibCode/Commands/RicTogglePerspectiveViewFeature.cpp
+++ b/ApplicationLibCode/Commands/RicTogglePerspectiveViewFeature.cpp
@@ -53,7 +53,7 @@ void RicTogglePerspectiveViewFeature::onActionTriggered( bool isChecked )
     {
         if ( RiaApplication::instance()->activeGridView() && activeReservoirView->viewer() )
         {
-            bool isPerspective = activeReservoirView->isPerspectiveView();
+            bool isPerspective                     = activeReservoirView->isPerspectiveView();
             activeReservoirView->isPerspectiveView = !isPerspective;
             activeReservoirView->isPerspectiveView.uiCapability()->updateConnectedEditors();
 

--- a/ApplicationLibCode/Commands/WellPathCommands/RicCreateWellTargetsPickEventHandler.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicCreateWellTargetsPickEventHandler.cpp
@@ -124,7 +124,7 @@ bool RicCreateWellTargetsPickEventHandler::handle3dPickEvent( const Ric3dPickEve
             cvf::Vec3d domainRayOrigin = rimView->displayCoordTransform()->transformToDomainCoord( firstPickItem.globalRayOrigin() );
 
             auto         rayVector        = ( targetPointInDomain - domainRayOrigin );
-            auto ownerCase = rimView->ownerCase();
+            auto         ownerCase        = rimView->ownerCase();
             const double minimumRayLength = ownerCase ? ownerCase->characteristicCellSize() * 2 : 1.0;
             if ( rayVector.length() < minimumRayLength )
             {

--- a/ApplicationLibCode/Commands/WellPathCommands/RicCreateWellTargetsPickEventHandler.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicCreateWellTargetsPickEventHandler.cpp
@@ -124,7 +124,8 @@ bool RicCreateWellTargetsPickEventHandler::handle3dPickEvent( const Ric3dPickEve
             cvf::Vec3d domainRayOrigin = rimView->displayCoordTransform()->transformToDomainCoord( firstPickItem.globalRayOrigin() );
 
             auto         rayVector        = ( targetPointInDomain - domainRayOrigin );
-            const double minimumRayLength = rimView->ownerCase()->characteristicCellSize() * 2;
+            auto ownerCase = rimView->ownerCase();
+            const double minimumRayLength = ownerCase ? ownerCase->characteristicCellSize() * 2 : 1.0;
             if ( rayVector.length() < minimumRayLength )
             {
                 rayVector = rayVector.getNormalized() * minimumRayLength;

--- a/ApplicationLibCode/Commands/WellPathCommands/RicWellPathPickEventHandler.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicWellPathPickEventHandler.cpp
@@ -129,9 +129,8 @@ bool RicWellPathPickEventHandler::handle3dPickEvent( const Ric3dPickEvent& event
                     RiuMainWindow::instance()->setResultInfo( attrText );
                     RiuMainWindow::instance()->selectAsCurrentItem( collection );
                 }
-                else if ( dynamic_cast<RimWellMeasurement*>( sourceInfo->object() ) )
+                else if ( auto measurement = dynamic_cast<RimWellMeasurement*>( sourceInfo->object() ) )
                 {
-                    RimWellMeasurement* measurement = dynamic_cast<RimWellMeasurement*>( sourceInfo->object() );
 
                     QString measurementText = QString( "Well path name: %1\n" ).arg( measurement->wellName() );
                     measurementText += QString( "Measured Depth: %1\n" ).arg( measurement->MD() );

--- a/ApplicationLibCode/Commands/WellPathCommands/RicWellPathPickEventHandler.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicWellPathPickEventHandler.cpp
@@ -131,7 +131,6 @@ bool RicWellPathPickEventHandler::handle3dPickEvent( const Ric3dPickEvent& event
                 }
                 else if ( auto measurement = dynamic_cast<RimWellMeasurement*>( sourceInfo->object() ) )
                 {
-
                     QString measurementText = QString( "Well path name: %1\n" ).arg( measurement->wellName() );
                     measurementText += QString( "Measured Depth: %1\n" ).arg( measurement->MD() );
                     measurementText += QString( "Value: %1\n" ).arg( measurement->value() );

--- a/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReloadCaseTools.cpp
@@ -97,9 +97,11 @@ void RimReloadCaseTools::reloadEclipseData( RimEclipseCase* eclipseCase, bool re
 
     if ( reloadSummaryData )
     {
-        auto summaryCase = RimReloadCaseTools::findSummaryCaseFromEclipseResultCase( dynamic_cast<RimEclipseResultCase*>( eclipseCase ) );
-        RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots( summaryCase );
-        summaryCase->updateConnectedEditors();
+        if ( auto summaryCase = RimReloadCaseTools::findSummaryCaseFromEclipseResultCase( dynamic_cast<RimEclipseResultCase*>( eclipseCase ) ) )
+        {
+            RiaSummaryTools::reloadSummaryCaseAndUpdateConnectedPlots( summaryCase );
+            summaryCase->updateConnectedEditors();
+        }
     }
 
     updateAllPlots();


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Guard null pointer dereferences across multiple command features

- Replace unsafe `firstAncestorOrThisOfTypeAsserted()` calls with null checks

- Add null checks for viewer, viewerCommands, and ownerCase pointers

- Consolidate repeated pointer lookups into single variables


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Unsafe pointer dereferences"] -->|Add null checks| B["Safe pointer access"]
  C["Repeated pointer lookups"] -->|Consolidate to variables| D["Single lookup with guard"]
  E["Asserted type casts"] -->|Replace with safe casts| F["Guarded type access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>21 files</summary><table>
<tr>
  <td><strong>RicApplyUserDefinedCameraFeature.cpp</strong><dd><code>Guard activeReservoirView null pointer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-4ea22fc02e6ca261e8572d0d6b782eb2d104311a2e4fa222493fdcf12dcc4a37">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicCreateTextAnnotationIn3dViewFeature.cpp</strong><dd><code>Guard viewer and ownerCase pointer access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-3901ea6e68d5658ff334f2774ef97b5108c7e105f8adab4365c286459190c13c">+14/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicNewCellIndexFilterFeature.cpp</strong><dd><code>Replace asserted cast with null check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-570311f0365c05ec7572a795a540cdf9be4d72c31e3cf26286af7d2a86fd9c80">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicNewPolygonFilterFeature.cpp</strong><dd><code>Replace asserted cast with null check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-0627a5fb113d896bcb41e958d4e6ee599340f175341fc014f59823c53b897fed">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicNewRangeFilterSliceFeature.cpp</strong><dd><code>Guard view3d pointer before access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-33b46f8e93e9023700dd566ee070fe3e3fc8daea89b4451489d28ddab7af80bf">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicNewUserDefinedFilterFeature.cpp</strong><dd><code>Replace asserted cast with null check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-71ce7362e78d1d6c45cf3ccc7b11ef23e6625c6ff8adfb2b971c35f48b5da57e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicNewUserDefinedIndexFilterFeature.cpp</strong><dd><code>Replace asserted cast with null check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-3bea1efe57bbf47b1564daeb9de7b77f12eaee4f4873316855e28abcbb65265e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicNewAzimuthDipIntersectionFeature.cpp</strong><dd><code>Replace asserted cast with null check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-378c717eb8ccc4d3d7435a2ac2d312f4b5be4e4d46be728c7558279536728b6a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicAddStoredFlowCharacteristicsPlotFeature.cpp</strong><dd><code>Guard sourceObject null pointer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-5b02c627b8c9dabec2e40c66159a7b96b04ee1698b274213accd5a7297c5f966">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicAddStoredWellAllocationPlotFeature.cpp</strong><dd><code>Guard sourceObject null pointer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-e1270461a5429e7e150e9b69c941a0844dd62cbffd6819579136fd7454c9a4e4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicPlaceThermalFractureUsingTemplateDataFeature.cpp</strong><dd><code>Guard fracture pointer before access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-81fd995734c75dd566653d86a3735e747e59e03b2157ab1c8fb355235ac04d60">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicNewFaultReactModelingFeature.cpp</strong><dd><code>Guard ownerCase pointer access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-93c24d4abd658255ad9d3dd427e635c82e3324251bd3948088f6ff031b9f8171">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicCreateGridCrossPlotDataSetFeature.cpp</strong><dd><code>Guard crossPlot null pointer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-1734c7698bc8fbfd8643ed0240c0980e45b0b991e7a4e77c386cdb89c43efb7b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicSwapGridCrossPlotDataSetAxesFeature.cpp</strong><dd><code>Consolidate pointer lookups with null checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-cea33b84ee2c11b1ed62bdee9fb3d3225b11a574ea9f463dd3b8793d7fda198b">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicIntersectionBoxAtPosFeature.cpp</strong><dd><code>Guard viewer and viewerCommands pointers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-144c465b6fd6183e84f3f358a5e594defb4bf6a1ad67c99f7f94fda43889a6da">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicIntersectionFeatureImpl.cpp</strong><dd><code>Guard viewer and viewerCommands pointers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-717a45ad1c36a142e925a95977a1bf609285b9cc93afec8f55a77b2c0593e63b">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicCopyGridStatisticsToClipboardFeature.cpp</strong><dd><code>Guard viewer pointer before access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-f3b448e09b57b9f495e57ea73feb3843e340c5511deb3d80ca9c4e870f922fc4">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicTogglePerspectiveViewFeature.cpp</strong><dd><code>Guard activeReservoirView pointer access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-10e35141b3d8f7a030501a98e5058df2e8ac2a413d3dca2c980683533c3c8b58">+17/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RicCreateWellTargetsPickEventHandler.cpp</strong><dd><code>Guard ownerCase pointer with fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-3ca8af4089ff5703df58bab96f2eebf3fa516cdd75d3f8817716d26e9b5003c5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RicWellPathPickEventHandler.cpp</strong><dd><code>Consolidate measurement pointer lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-72755a31735047f3db100e67f1588f3e4f973533e12386dd648de3effdcfce7e">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimReloadCaseTools.cpp</strong><dd><code>Guard summaryCase pointer before use</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/491/files#diff-3207ecd377ef72a0a131ab5ea2b5609f46c2915dc19ae0ffab3ca4f395c52dc4">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

