### PR TITLE
Clamp values to min/max range when loading from XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ CMakeUserPresets.json
 # Tool files
 .vscode
 .claude
+nul
 
 # Temp files
 *.temp
@@ -81,3 +82,4 @@ CMakeUserPresets.json
 
 #Python
 *.pyc
+/build/

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h
@@ -175,7 +175,6 @@ public:
     // Override validate from PdmFieldHandle
     QString validate() const override;
 
-protected:
     // Clamp value to range if defined
     DataType clampValue( const DataType& value ) const
     {
@@ -198,6 +197,7 @@ protected:
         }
     }
 
+protected:
     DataType m_fieldValue;
 
     // Default value stuff.

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h
@@ -176,6 +176,28 @@ public:
     QString validate() const override;
 
 protected:
+    // Clamp value to range if defined
+    DataType clampValue( const DataType& value ) const
+    {
+        if constexpr ( std::is_arithmetic<DataType>::value )
+        {
+            DataType clampedValue = value;
+            if ( m_minValue.has_value() && clampedValue < m_minValue.value() )
+            {
+                clampedValue = m_minValue.value();
+            }
+            if ( m_maxValue.has_value() && clampedValue > m_maxValue.value() )
+            {
+                clampedValue = m_maxValue.value();
+            }
+            return clampedValue;
+        }
+        else
+        {
+            return value;
+        }
+    }
+
     DataType m_fieldValue;
 
     // Default value stuff.

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmXmlFieldCapability.inl
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmXmlFieldCapability.inl
@@ -1,6 +1,7 @@
 
 #include "cafAssert.h"
 #include "cafInternalPdmFieldIoHelper.h"
+#include "cafPdmDataValueField.h"
 #include "cafPdmObjectFactory.h"
 #include "cafPdmObjectHandle.h"
 #include "cafPdmReferenceHelper.h"
@@ -37,6 +38,13 @@ std::vector<QString> caf::PdmFieldXmlCap<FieldType>::readFieldData( QXmlStreamRe
     this->assertValid();
     typename FieldType::FieldDataType value;
     PdmFieldReader<typename FieldType::FieldDataType>::readFieldData( value, xmlStream, m_field );
+
+    // Clamp value if the field is a PdmDataValueField
+    if constexpr ( std::is_base_of_v<PdmDataValueField<typename FieldType::FieldDataType>, FieldType> )
+    {
+        value = m_field->clampValue( value );
+    }
+
     m_field->setValue( value );
     return {};
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Implements automatic value clamping during XML deserialization

- Clamps out-of-range values to defined min/max bounds

- Adds compile-time type checking for clamping logic

- Includes comprehensive unit tests for edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  XML["XML Data"] -->|readFieldData| Reader["PdmFieldXmlCap"]
  Reader -->|constexpr check| TypeCheck{"Is PdmDataValueField?"}
  TypeCheck -->|Yes| Clamp["clampValue"]
  TypeCheck -->|No| SetValue["setValue"]
  Clamp -->|clamped value| SetValue
  XML -->|direct load| Unclamped["Unclamped Fields"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cafInternalPdmXmlFieldCapability.inl</strong><dd><code>Add value clamping to XML field deserialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafInternalPdmXmlFieldCapability.inl

<ul><li>Added include for <code>cafPdmDataValueField.h</code> header<br> <li> Implemented compile-time type checking using <code>std::is_base_of_v</code> in <br><code>readFieldData()</code><br> <li> Calls <code>clampValue()</code> on field values before <code>setValue()</code> for <br><code>PdmDataValueField</code> instances<br> <li> Ensures values are clamped to min/max ranges during XML <br>deserialization</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/531/files#diff-791ac9628020119c961334c88b7c759d164996dc39dd160bd5c2f92498eb55b9">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cafPdmDataValueField.h</strong><dd><code>Add public clampValue method for range enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h

<ul><li>Added public <code>clampValue()</code> method to <code>PdmDataValueField</code> class<br> <li> Implements clamping logic using <code>if constexpr</code> for arithmetic types only<br> <li> Clamps values to <code>m_minValue</code> if below minimum and <code>m_maxValue</code> if above <br>maximum<br> <li> Returns original value unchanged for non-arithmetic types</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/531/files#diff-c0c5a4a8b4a6854a11335fc565d2fc7f838fdf61440f6c95644e9cc8c6525bed">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cafPdmXmlBasicTest.cpp</strong><dd><code>Add comprehensive XML import clamping unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmXml_UnitTests/cafPdmXmlBasicTest.cpp

<ul><li>Created <code>ClampedFieldObject</code> test class with multiple clamped and <br>unclamped fields<br> <li> Added <code>XmlImportClamping</code> test with three test cases covering max <br>clamping, min clamping, and in-range values<br> <li> Tests verify values exceeding max are clamped to maximum bounds<br> <li> Tests verify values below min are clamped to minimum bounds<br> <li> Tests verify in-range values remain unchanged and unclamped fields are <br>unaffected</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/531/files#diff-e6ec3c39d0c67332bfa4a1beb40c4b15ad9633b909b2503c5347d90c7b94438a">+121/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

