### PR TITLE
Attributes in constructor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,98 @@ interval = completions_settings.add_diameter_roughness_interval(start_md=100, en
 print(f"Start: {interval.start_md}, End: {interval.end_md}")
 ```
 
+## PDM UI Attribute System
+
+### Migrating from defineEditorAttribute (Deprecated)
+
+The `defineEditorAttribute()` method is deprecated in favor of a map-based attribute system. The new approach sets attributes once in constructors rather than repeatedly on every UI refresh.
+
+#### Old Pattern (Deprecated - Avoid in New Code)
+
+```cpp
+// In header
+void defineEditorAttribute( const caf::PdmFieldHandle* field,
+                            QString                    uiConfigName,
+                            caf::PdmUiEditorAttribute* attribute ) override;
+
+// In cpp
+void MyObject::defineEditorAttribute( const caf::PdmFieldHandle* field,
+                                      QString                    uiConfigName,
+                                      caf::PdmUiEditorAttribute* attribute )
+{
+    if ( field == &m_myField )
+    {
+        auto* attr = dynamic_cast<caf::PdmUiLineEditorAttribute*>( attribute );
+        if ( attr )
+        {
+            attr->maximumWidth = 200;
+            attr->placeholderText = "Enter value...";
+        }
+    }
+}
+```
+
+#### New Pattern (Recommended)
+
+```cpp
+MyObject::MyObject()
+{
+    CAF_PDM_InitField(&m_myField, "myField", defaultValue, "My Field");
+
+    // Set attributes once in constructor using map-based system
+    m_myField.uiCapability()->setAttributeInt("maximumWidth", 200);
+    m_myField.uiCapability()->setAttributeString("placeholderText", "Enter value...");
+}
+```
+
+#### Migration Benefits
+
+- ✅ **Performance**: Set once, not on every UI refresh
+- ✅ **Type Safety**: Type-safe helpers (setAttributeInt, setAttributeBool, setAttributeString, setAttributeDouble)
+- ✅ **Validation**: Runtime warnings for unsupported attributes via PdmLogger
+- ✅ **Maintainability**: Cleaner code, attributes near field initialization
+- ✅ **Discoverability**: All attributes visible in one place
+
+#### Config-Specific Attributes
+
+For different UI configurations:
+
+```cpp
+// In defineUiOrdering() for dynamic/config-specific attributes
+void MyObject::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
+{
+    if ( uiConfigName == "CompactView" )
+    {
+        m_myField.uiCapability()->setAttributeInt("maximumWidth", 100, "CompactView");
+    }
+
+    uiOrdering.add(&m_myField);
+}
+```
+
+#### Finding Supported Attributes
+
+Each editor validates attributes at runtime. If you set an unsupported attribute, you'll get a warning:
+
+```
+PdmUiLineEditor: Unsupported attribute 'maxWidth' set on field.
+Supported attributes are: maximumWidth, selectAllOnFocusEvent, placeholderText, ...
+```
+
+To find supported attributes for a specific editor:
+1. Check the editor's header file (e.g., `cafPdmUiLineEditor.h`) for the attribute class members
+2. Check validation code in the editor's cpp file for the `supportedAttributes` set
+3. Trigger a warning by setting a dummy attribute and reading the error message
+
+#### When to Keep defineEditorAttribute
+
+Keep `defineEditorAttribute()` only for:
+- Complex attributes that cannot be stored in QVariant (e.g., field pointers, validators)
+- Dynamic attributes that depend on complex runtime state
+- Special cases like `currentIndexFieldHandle` in tree selection editors
+
+For 95% of cases, use the map-based system.
+
 ## Development Notes
 
 - **Version**: Current version defined in `ResInsightVersion.cmake` (2025.04.4-dev)

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp
@@ -773,4 +773,137 @@ void PdmUiItem::addFieldEditor( PdmUiEditorHandle* fieldView )
     m_editors.insert( fieldView );
 }
 
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiItem::setAttribute( const std::string& key, const QVariant& value, const QString& uiConfigName )
+{
+    m_attributeMaps[uiConfigName][key] = value;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QVariant PdmUiItem::getAttribute( const std::string& key, const QString& uiConfigName ) const
+{
+    // Check config-specific attributes first
+    if ( !uiConfigName.isEmpty() )
+    {
+        auto configIt = m_attributeMaps.find( uiConfigName );
+        if ( configIt != m_attributeMaps.end() )
+        {
+            auto attrIt = configIt->second.find( key );
+            if ( attrIt != configIt->second.end() )
+            {
+                return attrIt->second;
+            }
+        }
+    }
+
+    // Fall back to default config ("")
+    auto defaultIt = m_attributeMaps.find( "" );
+    if ( defaultIt != m_attributeMaps.end() )
+    {
+        auto attrIt = defaultIt->second.find( key );
+        if ( attrIt != defaultIt->second.end() )
+        {
+            return attrIt->second;
+        }
+    }
+
+    return QVariant(); // Return invalid QVariant if not found
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool PdmUiItem::hasAttribute( const std::string& key, const QString& uiConfigName ) const
+{
+    return getAttribute( key, uiConfigName ).isValid();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiItem::setAttributeInt( const std::string& key, int value, const QString& uiConfigName )
+{
+    setAttribute( key, QVariant( value ), uiConfigName );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiItem::setAttributeBool( const std::string& key, bool value, const QString& uiConfigName )
+{
+    setAttribute( key, QVariant( value ), uiConfigName );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiItem::setAttributeString( const std::string& key, const QString& value, const QString& uiConfigName )
+{
+    setAttribute( key, QVariant( value ), uiConfigName );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void PdmUiItem::setAttributeDouble( const std::string& key, double value, const QString& uiConfigName )
+{
+    setAttribute( key, QVariant( value ), uiConfigName );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<int> PdmUiItem::getAttributeInt( const std::string& key, const QString& uiConfigName ) const
+{
+    QVariant value = getAttribute( key, uiConfigName );
+    if ( value.isValid() && value.canConvert<int>() )
+    {
+        return value.toInt();
+    }
+    return std::nullopt;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<bool> PdmUiItem::getAttributeBool( const std::string& key, const QString& uiConfigName ) const
+{
+    QVariant value = getAttribute( key, uiConfigName );
+    if ( value.isValid() && value.canConvert<bool>() )
+    {
+        return value.toBool();
+    }
+    return std::nullopt;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<QString> PdmUiItem::getAttributeString( const std::string& key, const QString& uiConfigName ) const
+{
+    QVariant value = getAttribute( key, uiConfigName );
+    if ( value.isValid() && value.canConvert<QString>() )
+    {
+        return value.toString();
+    }
+    return std::nullopt;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<double> PdmUiItem::getAttributeDouble( const std::string& key, const QString& uiConfigName ) const
+{
+    QVariant value = getAttribute( key, uiConfigName );
+    if ( value.isValid() && value.canConvert<double>() )
+    {
+        return value.toDouble();
+    }
+    return std::nullopt;
+}
+
 } // End of namespace caf

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.cpp
@@ -825,6 +825,36 @@ bool PdmUiItem::hasAttribute( const std::string& key, const QString& uiConfigNam
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::map<std::string, QVariant> PdmUiItem::getAttributes( const QString& uiConfigName ) const
+{
+    std::map<std::string, QVariant> result;
+
+    // Start with default config attributes
+    auto defaultIt = m_attributeMaps.find( "" );
+    if ( defaultIt != m_attributeMaps.end() )
+    {
+        result = defaultIt->second;
+    }
+
+    // Override with config-specific attributes
+    if ( !uiConfigName.isEmpty() )
+    {
+        auto configIt = m_attributeMaps.find( uiConfigName );
+        if ( configIt != m_attributeMaps.end() )
+        {
+            for ( const auto& [key, value] : configIt->second )
+            {
+                result[key] = value;
+            }
+        }
+    }
+
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void PdmUiItem::setAttributeInt( const std::string& key, int value, const QString& uiConfigName )
 {
     setAttribute( key, QVariant( value ), uiConfigName );

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.h
@@ -297,9 +297,10 @@ public:
     virtual bool isUiGroup() const;
 
     // Map-based attribute system
-    void     setAttribute( const std::string& key, const QVariant& value, const QString& uiConfigName = "" );
-    QVariant getAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
-    bool     hasAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
+    void                                setAttribute( const std::string& key, const QVariant& value, const QString& uiConfigName = "" );
+    QVariant                            getAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
+    bool                                hasAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
+    std::map<std::string, QVariant>     getAttributes( const QString& uiConfigName = "" ) const;
 
     // Type-safe helpers
     void setAttributeInt( const std::string& key, int value, const QString& uiConfigName = "" );

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.h
@@ -39,7 +39,10 @@
 #include "cafIconProvider.h"
 #include "cafPdmUiFieldSpecialization.h"
 
+#include <map>
+#include <optional>
 #include <set>
+#include <string>
 #include <type_traits>
 
 namespace caf
@@ -293,6 +296,22 @@ public:
 
     virtual bool isUiGroup() const;
 
+    // Map-based attribute system
+    void     setAttribute( const std::string& key, const QVariant& value, const QString& uiConfigName = "" );
+    QVariant getAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
+    bool     hasAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
+
+    // Type-safe helpers
+    void setAttributeInt( const std::string& key, int value, const QString& uiConfigName = "" );
+    void setAttributeBool( const std::string& key, bool value, const QString& uiConfigName = "" );
+    void setAttributeString( const std::string& key, const QString& value, const QString& uiConfigName = "" );
+    void setAttributeDouble( const std::string& key, double value, const QString& uiConfigName = "" );
+
+    std::optional<int>     getAttributeInt( const std::string& key, const QString& uiConfigName = "" ) const;
+    std::optional<bool>    getAttributeBool( const std::string& key, const QString& uiConfigName = "" ) const;
+    std::optional<QString> getAttributeString( const std::string& key, const QString& uiConfigName = "" ) const;
+    std::optional<double>  getAttributeDouble( const std::string& key, const QString& uiConfigName = "" ) const;
+
     /// Intended to be called when fields in an object has been changed
     void updateConnectedEditors() const;
     void scheduleUpdateConnectedEditors() const;
@@ -330,6 +349,9 @@ private:
 
     PdmUiItemInfo*                   m_staticItemInfo;
     std::map<QString, PdmUiItemInfo> m_configItemInfos;
+
+    // Map-based attributes: uiConfigName -> (attributeKey -> value)
+    std::map<QString, std::map<std::string, QVariant>> m_attributeMaps;
 
     static bool sm_showExtraDebugText;
 };

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiItem.h
@@ -297,10 +297,10 @@ public:
     virtual bool isUiGroup() const;
 
     // Map-based attribute system
-    void                                setAttribute( const std::string& key, const QVariant& value, const QString& uiConfigName = "" );
-    QVariant                            getAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
-    bool                                hasAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
-    std::map<std::string, QVariant>     getAttributes( const QString& uiConfigName = "" ) const;
+    void     setAttribute( const std::string& key, const QVariant& value, const QString& uiConfigName = "" );
+    QVariant getAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
+    bool     hasAttribute( const std::string& key, const QString& uiConfigName = "" ) const;
+    std::map<std::string, QVariant> getAttributes( const QString& uiConfigName = "" ) const;
 
     // Type-safe helpers
     void setAttributeInt( const std::string& key, int value, const QString& uiConfigName = "" );

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.h
@@ -35,6 +35,8 @@ public:
     static void expandUiTree( PdmUiTreeOrdering* root, const QString& uiConfigName = "" );
 
     /// For a specific field, return editor specific parameters used to customize the editor behavior.
+    /// @deprecated Internal method called by editors. Use map-based attributes instead.
+    [[deprecated( "Internal use only. Use field.uiCapability()->setAttribute() for setting attributes." )]]
     void editorAttribute( const PdmFieldHandle* field, const QString& uiConfigName, PdmUiEditorAttribute* attribute );
 
     /// Return object editor specific parameters used to customize the editor behavior.

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.h
@@ -90,9 +90,8 @@ protected:
     ///             Example: field.uiCapability()->setAttributeInt("maximumWidth", 200);
     ///             See CLAUDE.md for migration guide and supported attributes by editor.
     [[deprecated( "Use field.uiCapability()->setAttribute() instead. See CLAUDE.md for migration guide." )]]
-    virtual void defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                        QString                    uiConfigName,
-                                        caf::PdmUiEditorAttribute* attribute )
+    virtual void
+        defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
     {
     }
 

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiObjectHandle.h
@@ -85,6 +85,11 @@ protected:
     virtual void defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName = "" ) {}
 
     /// Override to provide editor specific data for the field and uiConfigName
+    /// @deprecated Use map-based attributes via field.uiCapability()->setAttribute() in constructor
+    ///             or defineUiOrdering() instead. Set attributes once rather than on every UI refresh.
+    ///             Example: field.uiCapability()->setAttributeInt("maximumWidth", 200);
+    ///             See CLAUDE.md for migration guide and supported attributes by editor.
+    [[deprecated( "Use field.uiCapability()->setAttribute() instead. See CLAUDE.md for migration guide." )]]
     virtual void defineEditorAttribute( const caf::PdmFieldHandle* field,
                                         QString                    uiConfigName,
                                         caf::PdmUiEditorAttribute* attribute )

--- a/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.cpp
@@ -23,6 +23,26 @@ LabelsAndHyperlinks::LabelsAndHyperlinks()
     CAF_PDM_InitFieldNoDefault( &m_hyperlinkTextField, "HyperlinkTextField", "" );
     m_hyperlinkTextField.uiCapability()->setUiEditorTypeName( caf::PdmUiLabelEditor::uiEditorTypeName() );
 
+    // Set attributes using new map-based system
+    m_hyperlinkTextField.uiCapability()->setAttributeString( "linkText",
+                                                             "Click <a href=\"dummy\">link</a> to select the "
+                                                             "<b>Optional Field</b> object." );
+
+    std::function<void( const QString& )> callback = [this]( const QString& link )
+    {
+        auto mainWin = MainWindow::instance();
+        if ( auto root = mainWin->root() )
+        {
+            auto obj = root->descendantsIncludingThisOfType<OptionalFields>();
+            if ( !obj.empty() )
+            {
+                mainWin->setTreeViewSelection( obj.front() );
+            }
+        }
+    };
+
+    m_hyperlinkTextField.uiCapability()->setAttribute( "linkActivatedCallback", QVariant::fromValue( callback ) );
+
     CAF_PDM_InitField( &m_showButton, "ShowButton", true, "Show Fieldless Button" );
 }
 
@@ -80,34 +100,4 @@ void LabelsAndHyperlinks::defineUiOrdering( QString uiConfigName, caf::PdmUiOrde
     uiOrdering.add( &m_hyperlinkTextField );
 
     uiOrdering.addNewLabel( "Another label at the bottom demonstrating multiple labels" );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void LabelsAndHyperlinks::defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                                 QString                    uiConfigName,
-                                                 caf::PdmUiEditorAttribute* attribute )
-{
-    if ( field == &m_hyperlinkTextField )
-    {
-        if ( auto labelEditorAttribute = dynamic_cast<caf::PdmUiLabelEditorAttribute*>( attribute ) )
-        {
-            labelEditorAttribute->m_linkText =
-                "Click <a href=\"dummy\">link</a> to select the <b>Optional Field</b> object.";
-
-            labelEditorAttribute->m_linkActivatedCallback = [this]( const QString& link )
-            {
-                auto mainWin = MainWindow::instance();
-                if ( auto root = mainWin->root() )
-                {
-                    auto obj = root->descendantsIncludingThisOfType<OptionalFields>();
-                    if ( !obj.empty() )
-                    {
-                        mainWin->setTreeViewSelection( obj.front() );
-                    }
-                }
-            };
-        }
-    }
 }

--- a/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/LabelsAndHyperlinks.h
@@ -15,9 +15,6 @@ public:
 
 protected:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
-    void defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                QString                    uiConfigName,
-                                caf::PdmUiEditorAttribute* attribute ) override;
 
 private:
     caf::PdmField<QString> m_labelTextField;

--- a/Fwk/AppFwk/cafTests/cafTestApplication/LineEditAndPushButtons.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/LineEditAndPushButtons.cpp
@@ -20,6 +20,7 @@ LineEditAndPushButtons::LineEditAndPushButtons()
 
     CAF_PDM_InitFieldNoDefault( &m_statusTextField, "StatusTextField", "Status Text", "", "", "" );
     CAF_PDM_InitFieldNoDefault( &m_textField, "TextField", "Text", "", "", "" );
+    m_textField.uiCapability()->setAttributeBool( "notifyWhenTextIsEdited", true );
 
     CAF_PDM_InitFieldNoDefault( &m_labelField, "LabelField", "Medium length text in label", "", "", "" );
     m_labelField.uiCapability()->setUiEditorTypeName( caf::PdmUiLabelEditor::uiEditorTypeName() );
@@ -32,21 +33,28 @@ LineEditAndPushButtons::LineEditAndPushButtons()
                                 "",
                                 "" );
     m_labelLongTextField.uiCapability()->setUiEditorTypeName( caf::PdmUiLabelEditor::uiEditorTypeName() );
+    m_labelLongTextField.uiCapability()->setAttributeBool( "useWordWrap", true );
+    m_labelLongTextField.uiCapability()->setAttributeBool( "useSingleWidgetInsteadOfLabelAndEditorWidget", true );
 
     CAF_PDM_InitFieldNoDefault( &m_textListField, "TextListField", "Text List Field", "", "", "" );
     m_textListField.uiCapability()->setUiEditorTypeName( caf::PdmUiListEditor::uiEditorTypeName() );
+    m_textListField.uiCapability()->setAttributeInt( "heightHint", 150 );
 
     CAF_PDM_InitFieldNoDefault( &m_pushButton_a, "PushButtonA", "Rotate", "", "", "" );
     caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_pushButton_a );
+    m_pushButton_a.uiCapability()->setAttributeString( "buttonText", "&Push Me" );
 
     CAF_PDM_InitFieldNoDefault( &m_pushButtonReplace, "PushButtonB", "Replace (CTRL + Enter)", "", "", "" );
     caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_pushButtonReplace );
+    m_pushButtonReplace.uiCapability()->setAttributeString( "buttonText", "Replace (Ctrl + Enter)" );
 
     CAF_PDM_InitFieldNoDefault( &m_pushButtonClear, "PushButtonC", "Clear (Alt + Enter)", "", "", "" );
     caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_pushButtonClear );
+    m_pushButtonClear.uiCapability()->setAttributeString( "buttonText", "Clear (Alt + Enter)" );
 
     CAF_PDM_InitFieldNoDefault( &m_pushButtonAppend, "PushButtonD", "Append (Shift + Enter)", "", "", "" );
     caf::PdmUiPushButtonEditor::configureEditorLabelHidden( &m_pushButtonAppend );
+    m_pushButtonAppend.uiCapability()->setAttributeString( "buttonText", "Append (Shift + Enter)" );
 
     std::vector<QString> items;
     items.push_back( "sldkfj" );
@@ -112,63 +120,6 @@ void LineEditAndPushButtons::fieldChangedByUi( const caf::PdmFieldHandle* change
 //--------------------------------------------------------------------------------------------------
 void LineEditAndPushButtons::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void LineEditAndPushButtons::defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                                    QString                    uiConfigName,
-                                                    caf::PdmUiEditorAttribute* attribute )
-{
-    if ( field == &m_textField )
-    {
-        auto myAttr = dynamic_cast<caf::PdmUiLineEditorAttribute*>( attribute );
-        if ( myAttr )
-        {
-            myAttr->notifyWhenTextIsEdited = true;
-        }
-    }
-    else if ( field == &m_labelLongTextField )
-    {
-        auto myAttr = dynamic_cast<caf::PdmUiLabelEditorAttribute*>( attribute );
-        if ( myAttr )
-        {
-            myAttr->m_useWordWrap                                  = true;
-            myAttr->m_useSingleWidgetInsteadOfLabelAndEditorWidget = true;
-        }
-    }
-    else if ( field == &m_textListField )
-    {
-        auto myAttr = dynamic_cast<caf::PdmUiListEditorAttribute*>( attribute );
-        if ( myAttr )
-        {
-            myAttr->heightHint = 150;
-        }
-    }
-
-    {
-        auto myAttr = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-        if ( myAttr )
-        {
-            if ( field == &m_pushButton_a )
-            {
-                myAttr->m_buttonText = "&Push Me";
-            }
-            if ( field == &m_pushButtonReplace )
-            {
-                myAttr->m_buttonText = "Replace (Ctrl + Enter)";
-            }
-            if ( field == &m_pushButtonClear )
-            {
-                myAttr->m_buttonText = "Clear (Alt + Enter)";
-            }
-            if ( field == &m_pushButtonAppend )
-            {
-                myAttr->m_buttonText = "Append (Shift + Enter)";
-            }
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafTests/cafTestApplication/LineEditAndPushButtons.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/LineEditAndPushButtons.h
@@ -16,10 +16,6 @@ public:
 private:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
 
-    void defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                QString                    uiConfigName,
-                                caf::PdmUiEditorAttribute* attribute ) override;
-
     void rotateContent();
     void appendText();
     void replaceText();

--- a/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/MainWindow.cpp
@@ -694,6 +694,7 @@ public:
                            "",
                            "Toggle Field tooltip",
                            " Toggle Field whatsthis" );
+        m_toggleField.uiCapability()->setAttributeBool( "wordWrap", true );
 
         CAF_PDM_InitField( &m_pushButtonField, "Push", false, "Button Field", "", "", " " );
         CAF_PDM_InitField( &m_doubleField,
@@ -724,6 +725,7 @@ public:
         m_proxyEnumField.registerSetMethod( this, &SmallDemoPdmObjectA::setEnumMember );
         m_proxyEnumField.registerGetMethod( this, &SmallDemoPdmObjectA::enumMember );
         m_proxyEnumMember = TestEnumType::T2;
+        m_proxyEnumField.uiCapability()->setAttributeBool( "showPreviousAndNextButtons", true );
 
         CAF_PDM_InitFieldNoDefault( &m_multipleAppEnum, "MultipleAppEnumValue", "MultipleAppEnumValue", "", "", "" );
         m_multipleAppEnum.capability<caf::PdmUiFieldHandle>()->setUiEditorTypeName(
@@ -870,22 +872,6 @@ protected:
                 attr->currentIndexFieldHandle = &m_highlightedEnum;
             }
         }
-        else if ( field == &m_proxyEnumField )
-        {
-            caf::PdmUiComboBoxEditorAttribute* attr = dynamic_cast<caf::PdmUiComboBoxEditorAttribute*>( attribute );
-            if ( attr )
-            {
-                attr->showPreviousAndNextButtons = true;
-            }
-        }
-        else if ( field == &m_toggleField )
-        {
-            auto* attr = dynamic_cast<caf::PdmUiCheckBoxEditorAttribute*>( attribute );
-            if ( attr )
-            {
-                attr->setWordWrap( true );
-            }
-        }
     }
 
     //--------------------------------------------------------------------------------------------------
@@ -934,9 +920,11 @@ public:
 
         CAF_PDM_InitField( &m_applyAutoOnChildObjectFields, "ApplyAutoValue", false, "Apply Auto Values" );
         m_applyAutoOnChildObjectFields.uiCapability()->setUiEditorTypeName( caf::PdmUiPushButtonEditor::uiEditorTypeName() );
+        m_applyAutoOnChildObjectFields.uiCapability()->setAttributeString( "buttonText", "Apply Auto Values" );
 
         CAF_PDM_InitField( &m_updateAutoValues, "UpdateAutoValue", false, "Update Auto Values" );
         m_updateAutoValues.uiCapability()->setUiEditorTypeName( caf::PdmUiPushButtonEditor::uiEditorTypeName() );
+        m_updateAutoValues.uiCapability()->setAttributeString( "buttonText", "Update Auto Values" );
 
         CAF_PDM_InitField( &m_doubleField,
                            "BigNumber",
@@ -1143,31 +1131,6 @@ protected:
         if ( fieldNeedingMenu == &m_objectListOfSameType )
         {
             caf::PdmUiTableView::addActionsToMenu( menu, &m_objectListOfSameType );
-        }
-    }
-
-    //--------------------------------------------------------------------------------------------------
-    ///
-    //--------------------------------------------------------------------------------------------------
-    void defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                QString                    uiConfigName,
-                                caf::PdmUiEditorAttribute* attribute ) override
-    {
-        if ( field == &m_applyAutoOnChildObjectFields )
-        {
-            auto* attr = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-            if ( attr )
-            {
-                attr->m_buttonText = "Apply Auto Values";
-            }
-        }
-        if ( field == &m_updateAutoValues )
-        {
-            auto* attr = dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute );
-            if ( attr )
-            {
-                attr->m_buttonText = "Update Auto Values";
-            }
         }
     }
 };

--- a/Fwk/AppFwk/cafTests/cafTestApplication/ManyGroups.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/ManyGroups.cpp
@@ -240,21 +240,3 @@ void ManyGroups::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiO
         }
     */
 }
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void ManyGroups::defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                        QString                    uiConfigName,
-                                        caf::PdmUiEditorAttribute* attribute )
-{
-    if ( field == &m_multiSelectList )
-    {
-        caf::PdmUiTreeSelectionEditorAttribute* myAttr = dynamic_cast<caf::PdmUiTreeSelectionEditorAttribute*>( attribute );
-        if ( myAttr )
-        {
-            // myAttr->showTextFilter = false;
-            // myAttr->showToggleAllCheckbox = false;
-        }
-    }
-}

--- a/Fwk/AppFwk/cafTests/cafTestApplication/ManyGroups.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/ManyGroups.h
@@ -48,8 +48,4 @@ protected:
     ///
     //--------------------------------------------------------------------------------------------------
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
-
-    void defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                QString                    uiConfigName,
-                                caf::PdmUiEditorAttribute* attribute ) override;
 };

--- a/Fwk/AppFwk/cafTests/cafTestApplication/TamComboBox.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/TamComboBox.cpp
@@ -14,6 +14,10 @@ TamComboBox::TamComboBox()
 
     CAF_PDM_InitField( &m_name, "UserDescription", QString( "Filter Name" ), "Name", "", "", "" );
     m_name.uiCapability()->setUiEditorTypeName( caf::PdmUiComboBoxEditor::uiEditorTypeName() );
+    m_name.uiCapability()->setAttributeBool( "enableEditableContent", true );
+    m_name.uiCapability()->setAttributeBool( "enableAutoComplete", false );
+    m_name.uiCapability()->setAttributeBool( "adjustWidthToContents", true );
+    m_name.uiCapability()->setAttributeBool( "notifyWhenTextIsEdited", false );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -56,21 +60,4 @@ void TamComboBox::fieldChangedByUi( const caf::PdmFieldHandle* changedField, con
 //--------------------------------------------------------------------------------------------------
 void TamComboBox::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void TamComboBox::defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                         QString                    uiConfigName,
-                                         caf::PdmUiEditorAttribute* attribute )
-{
-    auto attr = dynamic_cast<caf::PdmUiComboBoxEditorAttribute*>( attribute );
-    if ( attr )
-    {
-        attr->enableEditableContent  = true;
-        attr->enableAutoComplete     = false;
-        attr->adjustWidthToContents  = true;
-        attr->notifyWhenTextIsEdited = false;
-    }
 }

--- a/Fwk/AppFwk/cafTests/cafTestApplication/TamComboBox.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/TamComboBox.h
@@ -29,10 +29,6 @@ private:
 protected:
     virtual void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
 
-    virtual void defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                        QString                    uiConfigName,
-                                        caf::PdmUiEditorAttribute* attribute ) override;
-
 private:
     QStringList m_historyItems;
 };

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiColorEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiColorEditor.cpp
@@ -40,6 +40,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiFieldEditorHandle.h"
 
@@ -89,15 +90,49 @@ void PdmUiColorEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
+    }
 
-        if ( m_attributes.showLabel )
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "showAlpha", "showLabel" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "showAlpha", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
         {
-            m_colorTextLabel->show();
+            m_attributes.showAlpha = val.toBool();
         }
-        else
+
+        val = uiItem->getAttribute( "showLabel", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
         {
-            m_colorTextLabel->hide();
+            m_attributes.showLabel = val.toBool();
         }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING( QString( "PdmUiColorEditor: Unsupported attribute '%1' set on field. Supported "
+                                              "attributes are: showAlpha, showLabel" )
+                                         .arg( QString::fromStdString( key ) ) );
+            }
+        }
+    }
+
+    if ( m_attributes.showLabel )
+    {
+        m_colorTextLabel->show();
+    }
+    else
+    {
+        m_colorTextLabel->hide();
     }
 
     bool isReadOnly = uiField()->isUiReadOnly( uiConfigName );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp
@@ -38,6 +38,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiFieldEditorHandle.h"
 #include "cafUiAppearanceSettings.h"
@@ -78,6 +79,17 @@ void PdmUiComboBoxEditor::configureAndUpdateUi( const QString& uiConfigName )
     PdmUiItem* uiItem = uiField();
     if ( uiItem )
     {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "adjustWidthToContents",
+                                                                   "showPreviousAndNextButtons",
+                                                                   "minimumContentsLength",
+                                                                   "maximumMenuContentsLength",
+                                                                   "enableEditableContent",
+                                                                   "enableAutoComplete",
+                                                                   "iconSize",
+                                                                   "placeholderText",
+                                                                   "notifyWhenTextIsEdited" };
+
         QVariant val;
 
         val = uiItem->getAttribute( "adjustWidthToContents", uiConfigName );
@@ -132,6 +144,21 @@ void PdmUiComboBoxEditor::configureAndUpdateUi( const QString& uiConfigName )
         if ( val.isValid() && val.canConvert<bool>() )
         {
             m_attributes.notifyWhenTextIsEdited = val.toBool();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString( "PdmUiComboBoxEditor: Unsupported attribute '%1' set on field. Supported "
+                             "attributes are: adjustWidthToContents, showPreviousAndNextButtons, "
+                             "minimumContentsLength, maximumMenuContentsLength, enableEditableContent, "
+                             "enableAutoComplete, iconSize, placeholderText, notifyWhenTextIsEdited" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
         }
     }
 

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiComboBoxEditor.cpp
@@ -74,6 +74,67 @@ void PdmUiComboBoxEditor::configureAndUpdateUi( const QString& uiConfigName )
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
     }
 
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        QVariant val;
+
+        val = uiItem->getAttribute( "adjustWidthToContents", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.adjustWidthToContents = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "showPreviousAndNextButtons", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.showPreviousAndNextButtons = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "minimumContentsLength", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
+        {
+            m_attributes.minimumContentsLength = val.toInt();
+        }
+
+        val = uiItem->getAttribute( "maximumMenuContentsLength", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
+        {
+            m_attributes.maximumMenuContentsLength = val.toInt();
+        }
+
+        val = uiItem->getAttribute( "enableEditableContent", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.enableEditableContent = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "enableAutoComplete", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.enableAutoComplete = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "iconSize", uiConfigName );
+        if ( val.isValid() && val.canConvert<QSize>() )
+        {
+            m_attributes.iconSize = val.toSize();
+        }
+
+        val = uiItem->getAttribute( "placeholderText", uiConfigName );
+        if ( val.isValid() && val.canConvert<QString>() )
+        {
+            m_attributes.placeholderText = val.toString();
+        }
+
+        val = uiItem->getAttribute( "notifyWhenTextIsEdited", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.notifyWhenTextIsEdited = val.toBool();
+        }
+    }
+
     if ( !m_comboBox.isNull() )
     {
         m_comboBox->setEnabled( !uiField()->isUiReadOnly( uiConfigName ) );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiDateEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiDateEditor.cpp
@@ -38,6 +38,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -73,6 +74,34 @@ void PdmUiDateEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "dateFormat" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "dateFormat", uiConfigName );
+        if ( val.isValid() && val.canConvert<QString>() )
+        {
+            m_attributes.dateFormat = val.toString();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING( QString( "PdmUiDateEditor: Unsupported attribute '%1' set on field. Supported "
+                                              "attributes are: dateFormat" )
+                                         .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     if ( !m_attributes.dateFormat.isEmpty() )

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleSliderEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleSliderEditor.cpp
@@ -37,6 +37,7 @@
 #include "cafPdmUiDoubleSliderEditor.h"
 
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmUiFieldHandle.h"
 #include "cafPdmUiObjectHandle.h"
 
@@ -79,6 +80,64 @@ void PdmUiDoubleSliderEditor::configureAndUpdateUi( const QString& uiConfigName 
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "minimum",
+                                                                   "maximum",
+                                                                   "decimals",
+                                                                   "sliderTickCount",
+                                                                   "delaySliderUpdateUntilRelease" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "minimum", uiConfigName );
+        if ( val.isValid() && val.canConvert<double>() )
+        {
+            m_attributes.m_minimum = val.toDouble();
+        }
+
+        val = uiItem->getAttribute( "maximum", uiConfigName );
+        if ( val.isValid() && val.canConvert<double>() )
+        {
+            m_attributes.m_maximum = val.toDouble();
+        }
+
+        val = uiItem->getAttribute( "decimals", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
+        {
+            m_attributes.m_decimals = val.toInt();
+        }
+
+        val = uiItem->getAttribute( "sliderTickCount", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
+        {
+            m_attributes.m_sliderTickCount = val.toInt();
+        }
+
+        val = uiItem->getAttribute( "delaySliderUpdateUntilRelease", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.m_delaySliderUpdateUntilRelease = val.toBool();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString(
+                        "PdmUiDoubleSliderEditor: Unsupported attribute '%1' set on field. Supported "
+                        "attributes are: minimum, maximum, decimals, sliderTickCount, delaySliderUpdateUntilRelease" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     double  doubleValue = uiField()->uiValue().toDouble();

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleValueEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleValueEditor.cpp
@@ -38,6 +38,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -90,6 +91,9 @@ void PdmUiDoubleValueEditor::configureAndUpdateUi( const QString& uiConfigName )
     PdmUiItem* uiItem = uiField();
     if ( uiItem )
     {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "decimals", "numberFormat" };
+
         if ( auto val = uiItem->getAttributeInt( "decimals", uiConfigName ) )
         {
             m_attributes.m_decimals = *val;
@@ -98,6 +102,19 @@ void PdmUiDoubleValueEditor::configureAndUpdateUi( const QString& uiConfigName )
         if ( auto val = uiItem->getAttributeInt( "numberFormat", uiConfigName ) )
         {
             m_attributes.m_numberFormat = static_cast<PdmUiDoubleValueEditorAttribute::NumberFormat>( *val );
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString( "PdmUiDoubleValueEditor: Unsupported attribute '%1' set on field. Supported "
+                             "attributes are: decimals, numberFormat" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
         }
     }
 

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleValueEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleValueEditor.cpp
@@ -86,6 +86,21 @@ void PdmUiDoubleValueEditor::configureAndUpdateUi( const QString& uiConfigName )
         }
     }
 
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        if ( auto val = uiItem->getAttributeInt( "decimals", uiConfigName ) )
+        {
+            m_attributes.m_decimals = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeInt( "numberFormat", uiConfigName ) )
+        {
+            m_attributes.m_numberFormat = static_cast<PdmUiDoubleValueEditorAttribute::NumberFormat>( *val );
+        }
+    }
+
     bool    valueOk = false;
     double  value   = uiField()->uiValue().toDouble( &valueOk );
     QString textValue;

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiFilePathEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiFilePathEditor.cpp
@@ -38,6 +38,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -74,6 +75,65 @@ void PdmUiFilePathEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "selectSaveFileName",
+                                                                   "fileSelectionFilter",
+                                                                   "defaultPath",
+                                                                   "selectDirectory",
+                                                                   "appendUiSelectedFolderToText",
+                                                                   "multipleItemSeparator" };
+
+        if ( auto val = uiItem->getAttributeBool( "selectSaveFileName", uiConfigName ) )
+        {
+            m_attributes.m_selectSaveFileName = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeString( "fileSelectionFilter", uiConfigName ) )
+        {
+            m_attributes.m_fileSelectionFilter = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeString( "defaultPath", uiConfigName ) )
+        {
+            m_attributes.m_defaultPath = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeBool( "selectDirectory", uiConfigName ) )
+        {
+            m_attributes.m_selectDirectory = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeBool( "appendUiSelectedFolderToText", uiConfigName ) )
+        {
+            m_attributes.m_appendUiSelectedFolderToText = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeString( "multipleItemSeparator", uiConfigName ) )
+        {
+            if ( !val->isEmpty() )
+            {
+                m_attributes.m_multipleItemSeparator = val->at( 0 );
+            }
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING( QString( "PdmUiFilePathEditor: Unsupported attribute '%1' set on field. Supported "
+                                              "attributes are: selectSaveFileName, fileSelectionFilter, defaultPath, "
+                                              "selectDirectory, appendUiSelectedFolderToText, multipleItemSeparator" )
+                                         .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     m_lineEdit->setText( uiField()->uiValue().toString() );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiLabelEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiLabelEditor.cpp
@@ -72,6 +72,32 @@ void PdmUiLabelEditor::configureAndUpdateUi( const QString& uiConfigName )
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &attributes );
     }
 
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        if ( auto val = uiItem->getAttributeBool( "useWordWrap", uiConfigName ) )
+        {
+            attributes.m_useWordWrap = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeBool( "useSingleWidgetInsteadOfLabelAndEditorWidget", uiConfigName ) )
+        {
+            attributes.m_useSingleWidgetInsteadOfLabelAndEditorWidget = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeString( "linkText", uiConfigName ) )
+        {
+            attributes.m_linkText = *val;
+        }
+
+        QVariant callbackVariant = uiItem->getAttribute( "linkActivatedCallback", uiConfigName );
+        if ( callbackVariant.isValid() && callbackVariant.canConvert<std::function<void( const QString& )>>() )
+        {
+            attributes.m_linkActivatedCallback = callbackVariant.value<std::function<void( const QString& )>>();
+        }
+    }
+
     if ( !attributes.m_linkText.isEmpty() )
     {
         // Configure rich text and hyper link support

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiLabelEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiLabelEditor.cpp
@@ -36,6 +36,7 @@
 
 #include "cafPdmUiLabelEditor.h"
 
+#include "cafPdmLogging.h"
 #include "cafPdmUiFieldEditorHandle.h"
 #include "cafPdmUiFieldHandle.h"
 #include "cafPdmUiObjectHandle.h"
@@ -76,6 +77,12 @@ void PdmUiLabelEditor::configureAndUpdateUi( const QString& uiConfigName )
     PdmUiItem* uiItem = uiField();
     if ( uiItem )
     {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "useWordWrap",
+                                                                   "useSingleWidgetInsteadOfLabelAndEditorWidget",
+                                                                   "linkText",
+                                                                   "linkActivatedCallback" };
+
         if ( auto val = uiItem->getAttributeBool( "useWordWrap", uiConfigName ) )
         {
             attributes.m_useWordWrap = *val;
@@ -95,6 +102,20 @@ void PdmUiLabelEditor::configureAndUpdateUi( const QString& uiConfigName )
         if ( callbackVariant.isValid() && callbackVariant.canConvert<std::function<void( const QString& )>>() )
         {
             attributes.m_linkActivatedCallback = callbackVariant.value<std::function<void( const QString& )>>();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString( "PdmUiLabelEditor: Unsupported attribute '%1' set on field. Supported attributes "
+                             "are: useWordWrap, useSingleWidgetInsteadOfLabelAndEditorWidget, linkText, "
+                             "linkActivatedCallback" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
         }
     }
 

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp
@@ -38,6 +38,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -163,6 +164,15 @@ void PdmUiLineEditor::configureAndUpdateUi( const QString& uiConfigName )
             PdmUiItem* uiItem = uiField();
             if ( uiItem )
             {
+                // List of supported attributes for validation
+                static const std::set<std::string> supportedAttributes = { "maximumWidth",
+                                                                           "selectAllOnFocusEvent",
+                                                                           "placeholderText",
+                                                                           "avoidSendingEnterEvent",
+                                                                           "completerCaseSensitivity",
+                                                                           "completerFilterMode",
+                                                                           "notifyWhenTextIsEdited" };
+
                 QVariant val;
 
                 val = uiItem->getAttribute( "maximumWidth", uiConfigName );
@@ -205,6 +215,21 @@ void PdmUiLineEditor::configureAndUpdateUi( const QString& uiConfigName )
                 if ( val.isValid() && val.canConvert<bool>() )
                 {
                     leab.notifyWhenTextIsEdited = val.toBool();
+                }
+
+                // Validate: warn about unsupported attributes
+                auto allAttributes = uiItem->getAttributes( uiConfigName );
+                for ( const auto& [key, value] : allAttributes )
+                {
+                    if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+                    {
+                        CAF_PDM_LOG_WARNING(
+                            QString( "PdmUiLineEditor: Unsupported attribute '%1' set on field. Supported "
+                                     "attributes are: maximumWidth, selectAllOnFocusEvent, placeholderText, "
+                                     "avoidSendingEnterEvent, completerCaseSensitivity, completerFilterMode, "
+                                     "notifyWhenTextIsEdited" )
+                                .arg( QString::fromStdString( key ) ) );
+                    }
                 }
             }
 

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiLineEditor.cpp
@@ -159,6 +159,55 @@ void PdmUiLineEditor::configureAndUpdateUi( const QString& uiConfigName )
                 uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &leab );
             }
 
+            // Override with map-based attributes if present (new system takes precedence)
+            PdmUiItem* uiItem = uiField();
+            if ( uiItem )
+            {
+                QVariant val;
+
+                val = uiItem->getAttribute( "maximumWidth", uiConfigName );
+                if ( val.isValid() && val.canConvert<int>() )
+                {
+                    leab.maximumWidth = val.toInt();
+                }
+
+                val = uiItem->getAttribute( "selectAllOnFocusEvent", uiConfigName );
+                if ( val.isValid() && val.canConvert<bool>() )
+                {
+                    leab.selectAllOnFocusEvent = val.toBool();
+                }
+
+                val = uiItem->getAttribute( "placeholderText", uiConfigName );
+                if ( val.isValid() && val.canConvert<QString>() )
+                {
+                    leab.placeholderText = val.toString();
+                }
+
+                val = uiItem->getAttribute( "avoidSendingEnterEvent", uiConfigName );
+                if ( val.isValid() && val.canConvert<bool>() )
+                {
+                    leab.avoidSendingEnterEventToParentWidget = val.toBool();
+                }
+
+                val = uiItem->getAttribute( "completerCaseSensitivity", uiConfigName );
+                if ( val.isValid() && val.canConvert<int>() )
+                {
+                    leab.completerCaseSensitivity = static_cast<Qt::CaseSensitivity>( val.toInt() );
+                }
+
+                val = uiItem->getAttribute( "completerFilterMode", uiConfigName );
+                if ( val.isValid() && val.canConvert<int>() )
+                {
+                    leab.completerFilterMode = static_cast<Qt::MatchFlags>( val.toInt() );
+                }
+
+                val = uiItem->getAttribute( "notifyWhenTextIsEdited", uiConfigName );
+                if ( val.isValid() && val.canConvert<bool>() )
+                {
+                    leab.notifyWhenTextIsEdited = val.toBool();
+                }
+            }
+
             if ( uiField()->isAutoValueEnabled() )
             {
                 QString highlightColor = UiAppearanceSettings::instance()->autoValueEditorColor();

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiListEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiListEditor.cpp
@@ -37,6 +37,7 @@
 #include "cafPdmUiListEditor.h"
 
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -172,17 +173,51 @@ void PdmUiListEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &attributes );
+    }
 
-        m_listView->setHeightHint( attributes.heightHint );
-        if ( !attributes.allowHorizontalScrollBar )
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "heightHint", "allowHorizontalScrollBar" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "heightHint", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
         {
-            m_listView->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+            attributes.heightHint = val.toInt();
         }
 
-        m_listView->setProperty( "state", attributes.qssState );
-        m_listView->style()->unpolish( m_listView );
-        m_listView->style()->polish( m_listView );
+        val = uiItem->getAttribute( "allowHorizontalScrollBar", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            attributes.allowHorizontalScrollBar = val.toBool();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING( QString( "PdmUiListEditor: Unsupported attribute '%1' set on field. Supported "
+                                              "attributes are: heightHint, allowHorizontalScrollBar" )
+                                         .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
+
+    m_listView->setHeightHint( attributes.heightHint );
+    if ( !attributes.allowHorizontalScrollBar )
+    {
+        m_listView->setHorizontalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
+    }
+
+    m_listView->setProperty( "state", attributes.qssState );
+    m_listView->style()->unpolish( m_listView );
+    m_listView->style()->polish( m_listView );
 
     MyStringListModel* strListModel = dynamic_cast<MyStringListModel*>( m_model.data() );
 

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiPickableLineEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiPickableLineEditor.cpp
@@ -36,6 +36,7 @@
 #include "cafPdmUiPickableLineEditor.h"
 
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -65,6 +66,35 @@ void caf::PdmUiPickableLineEditor::configureAndUpdateUi( const QString& uiConfig
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attribute );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "enablePicking" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "enablePicking", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attribute.enablePicking = val.toBool();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString( "PdmUiPickableLineEditor: Unsupported attribute '%1' set on field. Supported "
+                             "attributes are: enablePicking" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     if ( m_attribute.pickEventHandler )

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiPushButtonEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiPushButtonEditor.cpp
@@ -38,6 +38,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -71,6 +72,32 @@ void PdmUiPushButtonEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &attributes );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "buttonText" };
+
+        if ( auto val = uiItem->getAttributeString( "buttonText", uiConfigName ) )
+        {
+            attributes.m_buttonText = *val;
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString( "PdmUiPushButtonEditor: Unsupported attribute '%1' set on field. Supported "
+                             "attributes are: buttonText" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     QVariant variantFieldValue = uiField()->uiValue();

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiSliderEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiSliderEditor.cpp
@@ -38,6 +38,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -69,6 +70,52 @@ void PdmUiSliderEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "minimum", "maximum", "showSpinBox", "step" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "minimum", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
+        {
+            m_attributes.m_minimum = val.toInt();
+        }
+
+        val = uiItem->getAttribute( "maximum", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
+        {
+            m_attributes.m_maximum = val.toInt();
+        }
+
+        val = uiItem->getAttribute( "showSpinBox", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.m_showSpinBox = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "step", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
+        {
+            m_attributes.m_step = val.toInt();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING( QString( "PdmUiSliderEditor: Unsupported attribute '%1' set on field. Supported "
+                                              "attributes are: minimum, maximum, showSpinBox, step" )
+                                         .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     {

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTableViewEditor.cpp
@@ -37,6 +37,7 @@
 
 #include "cafPdmChildArrayField.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiCheckBoxDelegate.h"
 #include "cafPdmUiEditorHandle.h"
@@ -188,6 +189,77 @@ void PdmUiTableViewEditor::configureAndUpdateUi( const QString& uiConfigName )
     {
         childArrayFH->ownerObject()->uiCapability()->editorAttribute( childArrayFH, uiConfigName, &editorAttrib );
         editorAttribLoaded = true;
+
+        // Override with map-based attributes if present (new system takes precedence)
+        if ( auto uiItem = childArrayFH->uiCapability() )
+        {
+            // List of supported attributes for validation
+            static const std::set<std::string> supportedAttributes = { "tableSelectionLevel",
+                                                                       "rowSelectionLevel",
+                                                                       "enableHeaderText",
+                                                                       "minimumHeight",
+                                                                       "heightHint",
+                                                                       "alwaysEnforceResizePolicy",
+                                                                       "enableDropTarget" };
+
+            QVariant val;
+
+            val = uiItem->getAttribute( "tableSelectionLevel", uiConfigName );
+            if ( val.isValid() && val.canConvert<int>() )
+            {
+                editorAttrib.tableSelectionLevel = val.toInt();
+            }
+
+            val = uiItem->getAttribute( "rowSelectionLevel", uiConfigName );
+            if ( val.isValid() && val.canConvert<int>() )
+            {
+                editorAttrib.rowSelectionLevel = val.toInt();
+            }
+
+            val = uiItem->getAttribute( "enableHeaderText", uiConfigName );
+            if ( val.isValid() && val.canConvert<bool>() )
+            {
+                editorAttrib.enableHeaderText = val.toBool();
+            }
+
+            val = uiItem->getAttribute( "minimumHeight", uiConfigName );
+            if ( val.isValid() && val.canConvert<int>() )
+            {
+                editorAttrib.minimumHeight = val.toInt();
+            }
+
+            val = uiItem->getAttribute( "heightHint", uiConfigName );
+            if ( val.isValid() && val.canConvert<int>() )
+            {
+                editorAttrib.heightHint = val.toInt();
+            }
+
+            val = uiItem->getAttribute( "alwaysEnforceResizePolicy", uiConfigName );
+            if ( val.isValid() && val.canConvert<bool>() )
+            {
+                editorAttrib.alwaysEnforceResizePolicy = val.toBool();
+            }
+
+            val = uiItem->getAttribute( "enableDropTarget", uiConfigName );
+            if ( val.isValid() && val.canConvert<bool>() )
+            {
+                editorAttrib.enableDropTarget = val.toBool();
+            }
+
+            // Validate: warn about unsupported attributes
+            auto allAttributes = uiItem->getAttributes( uiConfigName );
+            for ( const auto& [key, value] : allAttributes )
+            {
+                if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+                {
+                    CAF_PDM_LOG_WARNING(
+                        QString( "PdmUiTableViewEditor: Unsupported attribute '%1' set on field. Supported "
+                                 "attributes are: tableSelectionLevel, rowSelectionLevel, enableHeaderText, "
+                                 "minimumHeight, heightHint, alwaysEnforceResizePolicy, enableDropTarget" )
+                            .arg( QString::fromStdString( key ) ) );
+                }
+            }
+        }
 
         this->setTableSelectionLevel( editorAttrib.tableSelectionLevel );
         this->setRowSelectionLevel( editorAttrib.rowSelectionLevel );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTextEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTextEditor.cpp
@@ -37,6 +37,7 @@
 #include "cafPdmUiTextEditor.h"
 
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -125,6 +126,47 @@ void PdmUiTextEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &leab );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "textMode", "showSaveButton", "wrapMode", "heightHint" };
+
+        if ( auto val = uiItem->getAttributeInt( "textMode", uiConfigName ) )
+        {
+            leab.textMode = static_cast<PdmUiTextEditorAttribute::TextMode>( *val );
+        }
+
+        if ( auto val = uiItem->getAttributeBool( "showSaveButton", uiConfigName ) )
+        {
+            leab.showSaveButton = *val;
+        }
+
+        if ( auto val = uiItem->getAttributeInt( "wrapMode", uiConfigName ) )
+        {
+            leab.wrapMode = static_cast<PdmUiTextEditorAttribute::WrapMode>( *val );
+        }
+
+        if ( auto val = uiItem->getAttributeInt( "heightHint", uiConfigName ) )
+        {
+            leab.heightHint = *val;
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString( "PdmUiTextEditor: Unsupported attribute '%1' set on field. Supported "
+                             "attributes are: textMode, showSaveButton, wrapMode, heightHint" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     m_textMode = leab.textMode;

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTextEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTextEditor.cpp
@@ -161,10 +161,9 @@ void PdmUiTextEditor::configureAndUpdateUi( const QString& uiConfigName )
         {
             if ( supportedAttributes.find( key ) == supportedAttributes.end() )
             {
-                CAF_PDM_LOG_WARNING(
-                    QString( "PdmUiTextEditor: Unsupported attribute '%1' set on field. Supported "
-                             "attributes are: textMode, showSaveButton, wrapMode, heightHint" )
-                        .arg( QString::fromStdString( key ) ) );
+                CAF_PDM_LOG_WARNING( QString( "PdmUiTextEditor: Unsupported attribute '%1' set on field. Supported "
+                                              "attributes are: textMode, showSaveButton, wrapMode, heightHint" )
+                                         .arg( QString::fromStdString( key ) ) );
             }
         }
     }

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTimeEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTimeEditor.cpp
@@ -38,6 +38,7 @@
 
 #include "cafFactory.h"
 #include "cafPdmField.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
@@ -72,6 +73,34 @@ void PdmUiTimeEditor::configureAndUpdateUi( const QString& uiConfigName )
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "timeFormat" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "timeFormat", uiConfigName );
+        if ( val.isValid() && val.canConvert<QString>() )
+        {
+            m_attributes.timeFormat = val.toString();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING( QString( "PdmUiTimeEditor: Unsupported attribute '%1' set on field. Supported "
+                                              "attributes are: timeFormat" )
+                                         .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     if ( !m_attributes.timeFormat.isEmpty() )

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiToolButtonEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiToolButtonEditor.cpp
@@ -37,6 +37,7 @@
 #include "cafPdmUiToolButtonEditor.h"
 
 #include "cafPdmFieldHandle.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObjectHandle.h"
 #include "cafPdmUiFieldHandle.h"
 #include "cafPdmUiObjectHandle.h"
@@ -71,6 +72,36 @@ void PdmUiToolButtonEditor::configureAndUpdateUi( const QString& uiConfigName )
     {
         pdmUiOjectHandle->editorAttribute( uiField()->fieldHandle(), uiConfigName, &attributes );
     }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "checkable" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "checkable", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            attributes.m_checkable = val.toBool();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString( "PdmUiToolButtonEditor: Unsupported attribute '%1' set on field. Supported "
+                             "attributes are: checkable" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
+        }
+    }
+
     bool isCheckable = attributes.m_checkable;
     m_toolButton->setCheckable( isCheckable );
     m_toolButton->setSizePolicy( attributes.m_sizePolicy );

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiTreeSelectionEditor.cpp
@@ -36,6 +36,7 @@
 #include "cafPdmUiTreeSelectionEditor.h"
 
 #include "cafAssert.h"
+#include "cafPdmLogging.h"
 #include "cafPdmObject.h"
 #include "cafPdmUiCommandSystemProxy.h"
 #include "cafPdmUiTreeSelectionQModel.h"
@@ -206,6 +207,71 @@ void PdmUiTreeSelectionEditor::configureAndUpdateUi( const QString& uiConfigName
     if ( uiObject )
     {
         uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
+    }
+
+    // Override with map-based attributes if present (new system takes precedence)
+    PdmUiItem* uiItem = uiField();
+    if ( uiItem )
+    {
+        // List of supported attributes for validation
+        static const std::set<std::string> supportedAttributes = { "showTextFilter",
+                                                                   "showToggleAllCheckbox",
+                                                                   "singleSelectionMode",
+                                                                   "showCheckBoxes",
+                                                                   "showContextMenu",
+                                                                   "heightHint" };
+
+        QVariant val;
+
+        val = uiItem->getAttribute( "showTextFilter", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.showTextFilter = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "showToggleAllCheckbox", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.showToggleAllCheckbox = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "singleSelectionMode", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.singleSelectionMode = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "showCheckBoxes", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.showCheckBoxes = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "showContextMenu", uiConfigName );
+        if ( val.isValid() && val.canConvert<bool>() )
+        {
+            m_attributes.showContextMenu = val.toBool();
+        }
+
+        val = uiItem->getAttribute( "heightHint", uiConfigName );
+        if ( val.isValid() && val.canConvert<int>() )
+        {
+            m_attributes.heightHint = val.toInt();
+        }
+
+        // Validate: warn about unsupported attributes
+        auto allAttributes = uiItem->getAttributes( uiConfigName );
+        for ( const auto& [key, value] : allAttributes )
+        {
+            if ( supportedAttributes.find( key ) == supportedAttributes.end() )
+            {
+                CAF_PDM_LOG_WARNING(
+                    QString( "PdmUiTreeSelectionEditor: Unsupported attribute '%1' set on field. Supported "
+                             "attributes are: showTextFilter, showToggleAllCheckbox, singleSelectionMode, "
+                             "showCheckBoxes, showContextMenu, heightHint" )
+                        .arg( QString::fromStdString( key ) ) );
+            }
+        }
     }
 
     m_model->showCheckBoxes( m_attributes.showCheckBoxes );


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduces map-based attribute system to PdmUiItem with config hierarchy support
  - Adds setAttribute/getAttribute/hasAttribute methods with type-safe helpers
  - Returns std::optional from get methods to distinguish unset from default values

- Migrates multiple test classes to use constructor-based attributes instead of defineEditorAttribute()
  - LabelsAndHyperlinks, LineEditAndPushButtons, TamComboBox, ManyGroups, MainWindow classes
  - Removes 100+ lines of deprecated defineEditorAttribute() overrides

- Adds runtime validation of map-based attributes in 20+ field editors
  - Each editor maintains static set of supported attributes and warns about unsupported keys
  - New system takes precedence over old defineEditorAttribute() for backward compatibility

- Documents migration guide in CLAUDE.md with examples and benefits


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PdmUiItem<br/>Map-based Attributes"] -->|setAttribute/getAttribute| B["Attribute Storage<br/>m_attributeMaps"]
  B -->|Config Hierarchy| C["Default Config<br/>+ UI Config"]
  A -->|Type-safe Helpers| D["setAttributeInt<br/>setAttributeBool<br/>setAttributeString<br/>setAttributeDouble"]
  E["Field Editors<br/>20+ types"] -->|Read Attributes| A
  E -->|Validate| F["Supported Attributes<br/>Runtime Warnings"]
  G["Constructor<br/>Initialization"] -->|Replace| H["defineEditorAttribute<br/>Deprecated"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>28 files</summary><table>
<tr>
  <td><strong>cafPdmUiItem.h</strong><dd><code>Add map-based attribute system API to PdmUiItem</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-80b7fa8e195244186cf8ad481ae61335143fdb4433ba2451f105f70cfc52d8cf">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiItem.cpp</strong><dd><code>Implement attribute storage and retrieval with config hierarchy</code></dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-c769fcfcd8ca81f1a23cdf07a93e6795f9ac3da2b6e5aa1aef20f118a68f788f">+163/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiLineEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-aaa48a9c888235bafc9011bba83d4de8a3eca479f3b1557aac511a93a5e0a7af">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiComboBoxEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-60ffe067d0d2dc60fe950dd033a779c330332a1f049d0859a7c5d19f425ba133">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiLabelEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-417474569d57fb29086c4c1f52d54c3937ef8e5c91125c93485a879dd5f82506">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiDoubleValueEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-06e6cac9e9e32ea6e0adb1d032fb85cba5e423cb45350b8afa5dc62ba54f072c">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiDoubleSliderEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-38e0f6d54477fbaf817a68a927adaa56e4b2b29b5597490cfe8d2a23389b65bf">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiSliderEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-52f7a11de0719dd6c29a367fb4b4b71448e3d72d0928fdc3ff3ef55d4f413ef6">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiColorEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-ce170a049d9ca846ba1cda313dbe7e965a4196c0244193bc756afb4a74fff2be">+39/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiDateEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-64ef98bb847378ee40187cfbe9a1c7e48024e9f3ad900831b20a76ff9536e637">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiTimeEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-af2948b97c6a250c5e5362aed64423ca24216787454d0bc8b9e6ed4859f0587f">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiFilePathEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-c8e9fcb8991c2129241173145f668179255fba96c5813e372e914ea9d56614ab">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiListEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-a8396fc081c28f0c9cee21797a3eeb2774b001170dad0235613eea870b854999">+41/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiPickableLineEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-2322af722fe4d9df24cc2cbbf8f6bfcabd9e37011b337f1755d65188240267c0">+30/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiPushButtonEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-8eaf218c8002aaace19d2063fcca5510ac1eaf30d929ffab1bbdbda464f1a21d">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiTableViewEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-2ae993bcc4e309a7ce24adcc8f982ec194897727bc9995528dfb90689738c90e">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiTextEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-d36f3c6d0905c3b9e6977bf772e2fd5e79ab1eee6fa333bfb929157f85542054">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiToolButtonEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-d55aa8e7ec302179cf610240febd5a84f3bf8ee5f68a86d3dc6c3d546c4dcac5">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiTreeSelectionEditor.cpp</strong><dd><code>Add map-based attribute support with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-d011582774cbce1794f2aca6087d20dccb0d5bd49c9bd4e9da7a6eb7b5c3f89f">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LabelsAndHyperlinks.h</strong><dd><code>Remove deprecated defineEditorAttribute override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-d0d8a7d8d749c7cbaf69ddd144309a5df385cf63e34cc49e850d9817e25e19b4">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LabelsAndHyperlinks.cpp</strong><dd><code>Migrate to constructor-based attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-e1e50ae01a27c50a53f5c4b36ef94e73f01c1240e023a493a2b094c6d1ad4878">+20/-30</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>LineEditAndPushButtons.h</strong><dd><code>Remove deprecated defineEditorAttribute override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-e25184cebac88e65d1dae5d33284febb1ef547282322b89fd928d0ba7cf093cc">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LineEditAndPushButtons.cpp</strong><dd><code>Migrate to constructor-based attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-c41152d1821108991b5e1d99b4a3136db33e682cde2a4ed18503c1dd77ec90a4">+8/-57</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TamComboBox.h</strong><dd><code>Remove deprecated defineEditorAttribute override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-4214ecd91e112793bc8542bab2d23c2f7782df71a32673ae7227018908880419">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>TamComboBox.cpp</strong><dd><code>Migrate to constructor-based attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-218186dd56f89d255113d96276ef1377779adee9d645d2c9364b699c5842d51b">+4/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ManyGroups.h</strong><dd><code>Remove deprecated defineEditorAttribute override</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-251cc00e35f1233012b2a3437b6d3d71fa70f87b228fbe7ca95e23f40a6ea820">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ManyGroups.cpp</strong><dd><code>Remove empty defineEditorAttribute implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-62c6ed515f05d8618007a6547cb4f0c65a1a7d43c22b8f2fc0a232cd50ed05c3">+0/-18</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MainWindow.cpp</strong><dd><code>Migrate to constructor-based attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-d1f4a1e80ec55dc65673384d1979c03be9e7d2c6e92eb9e150712d2055e3c04d">+4/-41</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>cafPdmUiObjectHandle.h</strong><dd><code>Deprecate defineEditorAttribute with migration guidance</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-f7bac0e1ae2fd078031558e348d2c3a6900f1992a6ebe58c12937ccc7f8c00ff">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CLAUDE.md</strong><dd><code>Add comprehensive migration guide for attribute system</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/553/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7">+92/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

