### PR TITLE
Add SurfaceColorMode setting to control surface visualization

### DIFF
--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.cpp
@@ -27,6 +27,7 @@
 #include "RimRegularLegendConfig.h"
 #include "RimSurface.h"
 #include "RimSurfaceInView.h"
+#include "RimSurfaceInViewCollection.h"
 #include "RimSurfaceResultDefinition.h"
 
 #include "RivIntersectionGeometryGeneratorInterface.h"
@@ -131,7 +132,16 @@ void RivSurfacePartMgr::updateCellResultColor( int timeStepIndex )
 //--------------------------------------------------------------------------------------------------
 void RivSurfacePartMgr::appendIntersectionGeometryPartsToModel( cvf::ModelBasicList* model, cvf::Transform* scaleTransform )
 {
-    if ( m_surfaceInView->surface() && m_surfaceInView->surface()->showIntersectionCellResults() &&
+    if ( !m_surfaceInView ) return;
+
+    using SurfaceColorMode = RimSurfaceInView::SurfaceColorMode;
+
+    SurfaceColorMode surfaceColorMode = m_surfaceInView->effectiveSurfaceColorMode();
+
+    bool includeCellResults  = ( surfaceColorMode == SurfaceColorMode::BOTH || surfaceColorMode == SurfaceColorMode::RESULT_COLORS );
+    bool includeSurfaceColor = ( surfaceColorMode == SurfaceColorMode::BOTH || surfaceColorMode == SurfaceColorMode::SURFACE_COLOR );
+
+    if ( includeCellResults && m_surfaceInView->surface() && m_surfaceInView->surface()->showIntersectionCellResults() &&
          !m_surfaceInView->surfaceResultDefinition()->isChecked() )
     {
         if ( m_intersectionFaces.isNull() )
@@ -165,7 +175,10 @@ void RivSurfacePartMgr::appendIntersectionGeometryPartsToModel( cvf::ModelBasicL
         }
     }
 
-    appendNativeGeometryPartsToModel( model, scaleTransform );
+    if ( includeSurfaceColor )
+    {
+        appendNativeGeometryPartsToModel( model, scaleTransform );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.h
+++ b/ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "cafPdmPointer.h"
+
 #include "cvfArray.h"
 #include "cvfObject.h"
 

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.cpp
@@ -27,6 +27,7 @@
 #include "RimGridView.h"
 #include "RimRegularLegendConfig.h"
 #include "RimSurface.h"
+#include "RimSurfaceInViewCollection.h"
 #include "RimSurfaceResultDefinition.h"
 
 #include "RiuViewer.h"
@@ -34,6 +35,21 @@
 #include "RivSurfacePartMgr.h"
 
 CAF_PDM_SOURCE_INIT( RimSurfaceInView, "SurfaceInView" );
+
+namespace caf
+{
+template <>
+void caf::AppEnum<RimSurfaceInView::SurfaceColorMode>::setUp()
+{
+    addItem( RimSurfaceInView::SurfaceColorMode::DEFAULT, "DEFAULT", "Default (from Collection)" );
+    addItem( RimSurfaceInView::SurfaceColorMode::BOTH, "BOTH", "Both" );
+    addItem( RimSurfaceInView::SurfaceColorMode::SURFACE_COLOR, "SURFACE_COLOR", "Surface Color" );
+    addItem( RimSurfaceInView::SurfaceColorMode::RESULT_COLORS, "RESULT_COLORS", "Result Colors" );
+
+    setDefault( RimSurfaceInView::SurfaceColorMode::DEFAULT );
+}
+
+} // namespace caf
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -50,6 +66,8 @@ RimSurfaceInView::RimSurfaceInView()
     m_surface.uiCapability()->setUiHidden( true );
 
     CAF_PDM_InitField( &m_showMeshLines, "ShowMeshLines", false, "Show Mesh Lines" );
+
+    CAF_PDM_InitField( &m_surfaceColorMode, "SurfaceColorMode", caf::AppEnum<SurfaceColorMode>( SurfaceColorMode::DEFAULT ), "Color Mode" );
 
     CAF_PDM_InitFieldNoDefault( &m_resultDefinition, "ResultDefinition", "Result Definition" );
     m_resultDefinition.uiCapability()->setUiTreeChildrenHidden( true );
@@ -104,6 +122,30 @@ void RimSurfaceInView::setSurface( RimSurface* surf )
     }
 
     m_resultDefinition->updateMinMaxValues( -1 );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceInView::SurfaceColorMode RimSurfaceInView::surfaceColorMode() const
+{
+    return m_surfaceColorMode();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceInView::SurfaceColorMode RimSurfaceInView::effectiveSurfaceColorMode() const
+{
+    if ( m_surfaceColorMode() == SurfaceColorMode::DEFAULT )
+    {
+        if ( auto collection = firstAncestorOfType<RimSurfaceInViewCollection>(); )
+        {
+            return collection->surfaceColorMode();
+        }
+        return SurfaceColorMode::BOTH;
+    }
+    return m_surfaceColorMode();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -255,7 +297,7 @@ void RimSurfaceInView::fieldChangedByUi( const caf::PdmFieldHandle* changedField
         scheduleRedraw = true;
     }
 
-    if ( changedField == &m_showInactiveCells || changedField == &m_showMeshLines )
+    if ( changedField == &m_showInactiveCells || changedField == &m_showMeshLines || changedField == &m_surfaceColorMode )
     {
         clearGeometry();
         scheduleRedraw = true;
@@ -274,6 +316,7 @@ void RimSurfaceInView::fieldChangedByUi( const caf::PdmFieldHandle* changedField
 void RimSurfaceInView::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering )
 {
     uiOrdering.add( &m_name );
+    uiOrdering.add( &m_surfaceColorMode );
     uiOrdering.add( &m_showInactiveCells );
 
     defineSeparateDataSourceUi( uiConfigName, uiOrdering );

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.h
@@ -17,6 +17,9 @@
 /////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include "RimIntersection.h"
+
+#include "cafAppEnum.h"
 #include "cafPdmChildField.h"
 #include "cafPdmField.h"
 #include "cafPdmObject.h"
@@ -24,8 +27,6 @@
 #include "cafPdmPtrField.h"
 
 #include "cvfObject.h"
-
-#include "RimIntersection.h"
 
 class RimSurface;
 class RimSurfaceResultDefinition;
@@ -41,12 +42,24 @@ class RimSurfaceInView : public RimIntersection
     CAF_PDM_HEADER_INIT;
 
 public:
+    enum class SurfaceColorMode
+    {
+        DEFAULT,
+        BOTH,
+        SURFACE_COLOR,
+        RESULT_COLORS
+    };
+
+public:
     RimSurfaceInView();
     ~RimSurfaceInView() override;
 
     QString     name() const override;
     RimSurface* surface() const;
     void        setSurface( RimSurface* surf );
+
+    SurfaceColorMode surfaceColorMode() const;
+    SurfaceColorMode effectiveSurfaceColorMode() const;
 
     bool                        isNativeSurfaceResultsActive() const;
     RimSurfaceResultDefinition* surfaceResultDefinition();
@@ -76,6 +89,8 @@ private:
     caf::PdmProxyValueField<QString> m_name;
     caf::PdmPtrField<RimSurface*>    m_surface;
     caf::PdmField<bool>              m_showMeshLines;
+
+    caf::PdmField<caf::AppEnum<SurfaceColorMode>> m_surfaceColorMode;
 
     caf::PdmChildField<RimSurfaceResultDefinition*> m_resultDefinition;
 

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.cpp
@@ -33,6 +33,7 @@
 #include "RivSurfacePartMgr.h"
 
 #include "cafPdmUiTreeOrdering.h"
+
 #include "cvfModelBasicList.h"
 
 CAF_PDM_SOURCE_INIT( RimSurfaceInViewCollection, "SurfaceInViewCollection" );
@@ -54,6 +55,10 @@ RimSurfaceInViewCollection::RimSurfaceInViewCollection()
 
     CAF_PDM_InitFieldNoDefault( &m_surfaceCollection, "SurfaceCollectionRef", "SurfaceCollection" );
     m_surfaceCollection.uiCapability()->setUiHidden( true );
+
+    CAF_PDM_InitField( &m_surfaceColorMode, "SurfaceColorMode", caf::AppEnum<SurfaceColorMode>( SurfaceColorMode::BOTH ), "Color Mode" );
+    caf::AppEnum<SurfaceColorMode>::setEnumSubset( &m_surfaceColorMode,
+                                                   { SurfaceColorMode::BOTH, SurfaceColorMode::SURFACE_COLOR, SurfaceColorMode::RESULT_COLORS } );
 
     nameField()->uiCapability()->setUiHidden( true );
 }
@@ -97,6 +102,14 @@ QString RimSurfaceInViewCollection::name() const
     if ( m_surfaceCollection ) return m_surfaceCollection->collectionName();
 
     return "";
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimSurfaceInViewCollection::SurfaceColorMode RimSurfaceInViewCollection::surfaceColorMode() const
+{
+    return m_surfaceColorMode();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -316,7 +329,7 @@ void RimSurfaceInViewCollection::fieldChangedByUi( const caf::PdmFieldHandle* ch
 {
     updateUiIconFromToggleField();
 
-    if ( changedField == &m_isChecked )
+    if ( changedField == &m_isChecked || changedField == &m_surfaceColorMode )
     {
         auto ownerView = firstAncestorOrThisOfTypeAsserted<Rim3dView>();
         ownerView->scheduleCreateDisplayModelAndRedraw();

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "RimCheckableNamedObject.h"
+#include "RimSurfaceInView.h"
 
 #include "cafPdmChildArrayField.h"
 #include "cafPdmField.h"
@@ -44,12 +45,15 @@ class RimSurfaceInViewCollection : public RimCheckableNamedObject
 {
     CAF_PDM_HEADER_INIT;
 
+    using SurfaceColorMode = RimSurfaceInView::SurfaceColorMode;
+
 public:
     RimSurfaceInViewCollection();
     ~RimSurfaceInViewCollection() override;
 
     QString name() const override;
 
+    SurfaceColorMode      surfaceColorMode() const;
     RimSurfaceCollection* surfaceCollection() const;
     void                  setSurfaceCollection( RimSurfaceCollection* surfcoll );
 
@@ -89,5 +93,6 @@ private:
     caf::PdmChildArrayField<RimSurfaceInView*>           m_surfacesInView;
     caf::PdmChildArrayField<RimSurfaceInViewCollection*> m_collectionsInView;
 
-    caf::PdmPtrField<RimSurfaceCollection*> m_surfaceCollection;
+    caf::PdmPtrField<RimSurfaceCollection*>       m_surfaceCollection;
+    caf::PdmField<caf::AppEnum<SurfaceColorMode>> m_surfaceColorMode;
 };


### PR DESCRIPTION
### **User description**
Add a Color Mode dropdown to surfaces and surface collections that
controls how surfaces are rendered:
- Both: Show surface color and cell result colors
- Surface Color: Show only the uniform surface color
- Cell Result Colors: Show only cell results mapped to surface

Individual surfaces default to inherit from their parent collection
but can override with their own setting.


___

### **PR Type**
Enhancement


___

### **Description**
- Add SurfaceColorMode enum to control surface visualization rendering

- Implement color mode dropdown in surfaces and collections with three options

- Support inheritance of color mode from collection to individual surfaces

- Conditionally render surface color and cell result colors based on mode


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RimSurfaceInViewCollection<br/>SurfaceColorMode"] -->|"defines default"| B["RimSurfaceInView<br/>SurfaceColorMode"]
  B -->|"effectiveSurfaceColorMode"| C["RivSurfacePartMgr<br/>Rendering Logic"]
  C -->|"BOTH"| D["Surface Color +<br/>Cell Results"]
  C -->|"SURFACE_COLOR"| E["Surface Color Only"]
  C -->|"RESULT_COLORS"| F["Cell Results Only"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RimSurfaceInView.h</strong><dd><code>Add SurfaceColorMode enum and field to RimSurfaceInView</code>&nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.h

<ul><li>Define SurfaceColorMode enum with DEFAULT, BOTH, SURFACE_COLOR, <br>RESULT_COLORS options<br> <li> Add m_surfaceColorMode field to store individual surface color mode <br>preference<br> <li> Add public methods surfaceColorMode() and effectiveSurfaceColorMode() <br>for mode retrieval<br> <li> Include cafAppEnum.h for enum support</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/620/files#diff-11256dc1afc8194a30c6da6b41586ced242edb7f10ccd19edad1aa6e1626331a">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimSurfaceInView.cpp</strong><dd><code>Implement SurfaceColorMode enum and inheritance logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInView.cpp

<ul><li>Register SurfaceColorMode enum with CAF framework with four options<br> <li> Initialize m_surfaceColorMode field with DEFAULT as initial value<br> <li> Implement effectiveSurfaceColorMode() to resolve inherited mode from <br>collection<br> <li> Add m_surfaceColorMode to UI ordering and field change detection<br> <li> Include RimSurfaceInViewCollection.h for collection access</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/620/files#diff-2e4cfadb6fd6f3e68933c1d11e48b8fe4eaeb8ec2ca85a3685f3db400526b8e4">+56/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimSurfaceInViewCollection.h</strong><dd><code>Add SurfaceColorMode enum to collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.h

<ul><li>Define SurfaceColorMode enum with BOTH, SURFACE_COLOR, RESULT_COLORS <br>options<br> <li> Add m_surfaceColorMode field to store collection-level color mode<br> <li> Add public surfaceColorMode() getter method<br> <li> Include cafAppEnum.h for enum support</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/620/files#diff-66d87ab0c4d501cc09c6e0530c94071d5faa56de846396bc583077bb99319252">+12/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimSurfaceInViewCollection.cpp</strong><dd><code>Implement SurfaceColorMode enum in collection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceInViewCollection.cpp

<ul><li>Register SurfaceColorMode enum with CAF framework with three options<br> <li> Initialize m_surfaceColorMode field with BOTH as default<br> <li> Implement surfaceColorMode() getter method<br> <li> Trigger display model update when color mode changes</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/620/files#diff-ac9dc698ca968d3fab60edbb8b531c7951f30c2efafd02057af713268cb08eab">+26/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RivSurfacePartMgr.cpp</strong><dd><code>Apply color mode logic to surface rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.cpp

<ul><li>Query effective surface color mode from RimSurfaceInView<br> <li> Conditionally render cell results based on BOTH or RESULT_COLORS modes<br> <li> Conditionally render native surface geometry based on BOTH or <br>SURFACE_COLOR modes<br> <li> Add SurfaceColorMode type alias for cleaner code<br> <li> Include RimSurfaceInViewCollection.h header</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/620/files#diff-9272b7e94767b45e633ed57834db89077e7578f545be056e19460561b91abff0">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RivSurfacePartMgr.h</strong><dd><code>Minor formatting adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ModelVisualization/Surfaces/RivSurfacePartMgr.h

<ul><li>Add blank line after cafPdmPointer.h include for formatting <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/620/files#diff-97c6b092eeac585aa2f0d2b6645f798877ae439ca88c4346c0020a26db8f970f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

