### PR TITLE
Add pytest Windows

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -25,9 +25,9 @@ jobs:
               os: windows-2022,
               cc: "cl",
               cxx: "cl",
-              build-python-module: false,
+              build-python-module: true,
               execute-unit-tests: true,
-              execute-pytests: false,
+              execute-pytests: true,
               unity-build: true,
               publish-to-pypi: false,
               vcpkg-bootstrap: bootstrap-vcpkg.bat,
@@ -273,10 +273,18 @@ jobs:
           cd GrpcInterface/Python/rips
           ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }} -m mypy *.py generated/generated_classes.py
 
-      - name: Run pytest
-        if: matrix.config.execute-pytests
+      - name: Run pytest (Linux)
+        if: matrix.config.execute-pytests && runner.os != 'Windows'
         env:
           RESINSIGHT_EXECUTABLE: ${{ runner.workspace }}/ResInsight/cmakebuild/ResInsight
+        run: |
+          cd GrpcInterface/Python/rips
+          ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }} -m pytest --console
+
+      - name: Run pytest (Windows)
+        if: matrix.config.execute-pytests && runner.os == 'Windows'
+        env:
+          RESINSIGHT_EXECUTABLE: ${{ runner.workspace }}/ResInsight/cmakebuild/ResInsight.exe
         run: |
           cd GrpcInterface/Python/rips
           ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }} -m pytest --console

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -273,18 +273,10 @@ jobs:
           cd GrpcInterface/Python/rips
           ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }} -m mypy *.py generated/generated_classes.py
 
-      - name: Run pytest (Linux)
-        if: matrix.config.execute-pytests && runner.os != 'Windows'
+      - name: Run pytest
+        if: matrix.config.execute-pytests
         env:
-          RESINSIGHT_EXECUTABLE: ${{ runner.workspace }}/ResInsight/cmakebuild/ResInsight
-        run: |
-          cd GrpcInterface/Python/rips
-          ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }} -m pytest --console
-
-      - name: Run pytest (Windows)
-        if: matrix.config.execute-pytests && runner.os == 'Windows'
-        env:
-          RESINSIGHT_EXECUTABLE: ${{ runner.workspace }}/ResInsight/cmakebuild/ResInsight.exe
+          RESINSIGHT_EXECUTABLE: ${{ runner.workspace }}/ResInsight/cmakebuild/ResInsight${{ runner.os == 'Windows' && '.exe' || '' }}
         run: |
           cd GrpcInterface/Python/rips
           ${{ steps.python-path.outputs.PYTHON_EXECUTABLE }} -m pytest --console


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Enable Python module building on Windows

- Enable pytest execution on Windows CI

- Split pytest step into OS-specific variants

- Use Windows-specific executable path for pytest


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Windows CI Config"] -->|"build-python-module: true"| B["Build Python Module"]
  A -->|"execute-pytests: true"| C["Run Pytest"]
  C -->|"OS Detection"| D["Linux Pytest"]
  C -->|"OS Detection"| E["Windows Pytest"]
  E -->|"ResInsight.exe"| F["Execute Tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ResInsightWithCache.yml</strong><dd><code>Enable Windows pytest and Python module building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ResInsightWithCache.yml

<ul><li>Enable Python module building on Windows by setting <br><code>build-python-module: true</code><br> <li> Enable pytest execution on Windows by setting <code>execute-pytests: true</code><br> <li> Split pytest step into OS-specific variants with conditional execution<br> <li> Add Windows-specific pytest step using <code>ResInsight.exe</code> executable path</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/633/files#diff-27914a34bf192504fe6b6653e2cd323c4380f2b23e309b6cb19a0821a2148b8c">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

