### PR TITLE
Support std::pair

### DIFF
--- a/Fwk/AppFwk/cafPdmScripting/cafPdmFieldScriptingCapability.h
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmFieldScriptingCapability.h
@@ -46,6 +46,7 @@
 
 #include <QIODevice>
 #include <QTextStream>
+#include <utility>
 
 namespace
 {
@@ -397,6 +398,81 @@ struct PdmFieldScriptingCapabilityIOHandler<std::optional<T>>
             auto realValue = fieldValue.value();
             PdmFieldScriptingCapabilityIOHandler<T>::readFromField( realValue, outputStream, quoteStrings, quoteNonBuiltins );
         }
+    }
+};
+
+template <typename T, typename U>
+struct PdmFieldScriptingCapabilityIOHandler<std::pair<T, U>>
+{
+    static void writeToField( std::pair<T, U>&     fieldValue,
+                              QTextStream&         inputStream,
+                              PdmScriptIOMessages* errorMessageContainer,
+                              bool                 stringsAreQuoted     = true,
+                              bool                 allowExtraCharacters = true )
+    {
+        errorMessageContainer->skipWhiteSpaceWithLineNumberCount( inputStream );
+        QChar chr = errorMessageContainer->readCharWithLineNumberCount( inputStream );
+        if ( chr == QChar( '(' ) )
+        {
+            QString  firstStr;
+            QString  secondStr;
+            QString* currentStr = &firstStr;
+
+            while ( !inputStream.atEnd() )
+            {
+                errorMessageContainer->skipWhiteSpaceWithLineNumberCount( inputStream );
+                QChar nextChar = errorMessageContainer->peekNextChar( inputStream );
+                if ( nextChar == QChar( ')' ) )
+                {
+                    errorMessageContainer->readCharWithLineNumberCount( inputStream );
+                    break;
+                }
+                else if ( nextChar == QChar( ',' ) && currentStr == &firstStr )
+                {
+                    errorMessageContainer->readCharWithLineNumberCount( inputStream );
+                    currentStr = &secondStr;
+                }
+                else
+                {
+                    *currentStr += errorMessageContainer->readCharWithLineNumberCount( inputStream );
+                }
+            }
+
+            {
+                QTextStream firstStream( &firstStr, QIODevice::ReadOnly );
+                PdmFieldScriptingCapabilityIOHandler<T>::writeToField( fieldValue.first,
+                                                                       firstStream,
+                                                                       errorMessageContainer,
+                                                                       stringsAreQuoted,
+                                                                       allowExtraCharacters );
+            }
+            {
+                QTextStream secondStream( &secondStr, QIODevice::ReadOnly );
+                PdmFieldScriptingCapabilityIOHandler<U>::writeToField( fieldValue.second,
+                                                                       secondStream,
+                                                                       errorMessageContainer,
+                                                                       stringsAreQuoted,
+                                                                       allowExtraCharacters );
+            }
+        }
+        else
+        {
+            errorMessageContainer->addError( "Tuple argument is missing start '('. \"" +
+                                             errorMessageContainer->currentArgument + "\" argument of the command: \"" +
+                                             errorMessageContainer->currentCommand + "\"" );
+        }
+    }
+
+    static void readFromField( const std::pair<T, U>& fieldValue,
+                               QTextStream&           outputStream,
+                               bool                   quoteStrings     = true,
+                               bool                   quoteNonBuiltins = false )
+    {
+        outputStream << "(";
+        PdmFieldScriptingCapabilityIOHandler<T>::readFromField( fieldValue.first, outputStream, quoteStrings, quoteNonBuiltins );
+        outputStream << ", ";
+        PdmFieldScriptingCapabilityIOHandler<U>::readFromField( fieldValue.second, outputStream, quoteStrings, quoteNonBuiltins );
+        outputStream << ")";
     }
 };
 

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.cpp
@@ -631,6 +631,7 @@ QString PdmPythonGenerator::dataTypeString( const PdmFieldHandle* field, bool us
         { QString::fromStdString( typeid( std::optional<bool> ).name() ), "Optional[bool]" },
         { QString::fromStdString( typeid( std::optional<QString> ).name() ), "Optional[str]" },
         { QString::fromStdString( typeid( std::pair<bool, double> ).name() ), "Tuple[bool, float]" },
+        { QString::fromStdString( typeid( std::pair<bool, float> ).name() ), "Tuple[bool, float]" },
     };
 
 #ifndef CAF_EXCLUDE_CVF

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.cpp
@@ -58,6 +58,7 @@
 #include <list>
 #include <memory>
 #include <set>
+#include <utility>
 
 using namespace caf;
 
@@ -442,7 +443,7 @@ QString caf::PdmPythonGenerator::generate( PdmObjectFactory* factory, std::vecto
     out << "from rips.pdmobject import PdmObjectBase\n";
     out << "import PdmObject_pb2\n";
     out << "import grpc\n";
-    out << "from typing import Optional, Dict, List, Type\n";
+    out << "from typing import Optional, Dict, List, Tuple, Type\n";
     out << "\n";
 
     for ( std::shared_ptr<PdmObject> object : dummyObjects )
@@ -629,6 +630,7 @@ QString PdmPythonGenerator::dataTypeString( const PdmFieldHandle* field, bool us
         { QString::fromStdString( typeid( std::optional<int> ).name() ), "Optional[int]" },
         { QString::fromStdString( typeid( std::optional<bool> ).name() ), "Optional[bool]" },
         { QString::fromStdString( typeid( std::optional<QString> ).name() ), "Optional[str]" },
+        { QString::fromStdString( typeid( std::pair<bool, double> ).name() ), "Tuple[bool, float]" },
     };
 
 #ifndef CAF_EXCLUDE_CVF

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt
@@ -17,9 +17,13 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} # required for gtest-all.cpp
 )
 
 set(PROJECT_FILES
-    cafPdmScripting_UnitTests.cpp gtest/gtest-all.cpp
-    cafPdmScriptingBasicTest.cpp cafPdmFieldSerializationTest.cpp
-    cafPdmObjectMethodTest.cpp cafPdmPythonGeneratorTest.cpp cafMockObjects.cpp
+    cafPdmScripting_UnitTests.cpp
+    gtest/gtest-all.cpp
+    cafPdmScriptingBasicTest.cpp
+    cafPdmFieldSerializationTest.cpp
+    cafPdmObjectMethodTest.cpp
+    cafPdmPythonGeneratorTest.cpp
+    cafMockObjects.cpp
 )
 
 qt_add_executable(${PROJECT_NAME} ${PROJECT_FILES})

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR} # required for gtest-all.cpp
 set(PROJECT_FILES
     cafPdmScripting_UnitTests.cpp gtest/gtest-all.cpp
     cafPdmScriptingBasicTest.cpp cafPdmFieldSerializationTest.cpp
-    cafPdmObjectMethodTest.cpp cafMockObjects.cpp
+    cafPdmObjectMethodTest.cpp cafPdmPythonGeneratorTest.cpp cafMockObjects.cpp
 )
 
 qt_add_executable(${PROJECT_NAME} ${PROJECT_FILES})

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.cpp
@@ -146,6 +146,7 @@ InheritedDemoObj::InheritedDemoObj()
     CAF_PDM_InitScriptableFieldNoDefault( &m_numbers, "Numbers", "Some words" );
     CAF_PDM_InitScriptableFieldNoDefault( &m_optionalNumber, "OptionalNumber", "Optional Number" );
     CAF_PDM_InitScriptableField( &m_pairField, "PairField", std::make_pair( false, 0.0 ), "Pair Field" );
+    CAF_PDM_InitScriptableField( &m_pairFloatField, "PairFloatField", std::make_pair( false, 0.0f ), "Pair Float Field" );
     CAF_PDM_InitFieldNoDefault( &m_testEnumField, "TestEnumValue", "An Enum" );
     CAF_PDM_InitScriptableFieldNoDefault( &m_myAppEnum, "MyAppEnumValue", "My App Enum" );
 

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.cpp
@@ -145,6 +145,7 @@ InheritedDemoObj::InheritedDemoObj()
     CAF_PDM_InitScriptableFieldNoDefault( &m_texts, "Texts", "Some words" );
     CAF_PDM_InitScriptableFieldNoDefault( &m_numbers, "Numbers", "Some words" );
     CAF_PDM_InitScriptableFieldNoDefault( &m_optionalNumber, "OptionalNumber", "Optional Number" );
+    CAF_PDM_InitScriptableField( &m_pairField, "PairField", std::make_pair( false, 0.0 ), "Pair Field" );
     CAF_PDM_InitFieldNoDefault( &m_testEnumField, "TestEnumValue", "An Enum" );
     CAF_PDM_InitScriptableFieldNoDefault( &m_myAppEnum, "MyAppEnumValue", "My App Enum" );
 

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.h
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.h
@@ -119,11 +119,11 @@ public:
 
     InheritedDemoObj();
 
-    caf::PdmField<std::vector<QString>>  m_texts;
-    caf::PdmField<std::vector<double>>   m_numbers;
-    caf::PdmField<std::optional<double>>      m_optionalNumber;
-    caf::PdmField<std::pair<bool, double>>    m_pairField;
-    caf::PdmField<std::pair<bool, float>>     m_pairFloatField;
+    caf::PdmField<std::vector<QString>>    m_texts;
+    caf::PdmField<std::vector<double>>     m_numbers;
+    caf::PdmField<std::optional<double>>   m_optionalNumber;
+    caf::PdmField<std::pair<bool, double>> m_pairField;
+    caf::PdmField<std::pair<bool, float>>  m_pairFloatField;
 
     caf::PdmField<caf::AppEnum<TestEnumType>> m_testEnumField;
     caf::PdmChildArrayField<SimpleObj*>       m_simpleObjectsField;

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.h
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.h
@@ -123,6 +123,7 @@ public:
     caf::PdmField<std::vector<double>>   m_numbers;
     caf::PdmField<std::optional<double>>      m_optionalNumber;
     caf::PdmField<std::pair<bool, double>>    m_pairField;
+    caf::PdmField<std::pair<bool, float>>     m_pairFloatField;
 
     caf::PdmField<caf::AppEnum<TestEnumType>> m_testEnumField;
     caf::PdmChildArrayField<SimpleObj*>       m_simpleObjectsField;

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.h
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.h
@@ -121,7 +121,8 @@ public:
 
     caf::PdmField<std::vector<QString>>  m_texts;
     caf::PdmField<std::vector<double>>   m_numbers;
-    caf::PdmField<std::optional<double>> m_optionalNumber;
+    caf::PdmField<std::optional<double>>      m_optionalNumber;
+    caf::PdmField<std::pair<bool, double>>    m_pairField;
 
     caf::PdmField<caf::AppEnum<TestEnumType>> m_testEnumField;
     caf::PdmChildArrayField<SimpleObj*>       m_simpleObjectsField;

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
@@ -194,7 +194,7 @@ TEST( PdmFieldSerialization, PairBoolDouble )
     EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
 
     // text → C++ (round-trip)
-    std::pair<bool, double> result;
+    std::pair<bool, double>  result;
     caf::PdmScriptIOMessages messages;
     caf::PdmFieldScriptingCapabilityIOHandler<std::pair<bool, double>>::writeToField( result, stream, &messages );
 
@@ -207,10 +207,10 @@ TEST( PdmFieldSerialization, PairBoolDouble )
 //--------------------------------------------------------------------------------------------------
 TEST( PdmFieldSerialization, PairBoolDouble_ParseWithSpaces )
 {
-    QString source = "( false , 2.5 )";
+    QString     source = "( false , 2.5 )";
     QTextStream stream( &source );
 
-    std::pair<bool, double> result;
+    std::pair<bool, double>  result;
     caf::PdmScriptIOMessages messages;
     caf::PdmFieldScriptingCapabilityIOHandler<std::pair<bool, double>>::writeToField( result, stream, &messages );
 

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
@@ -177,6 +177,50 @@ TEST( PdmFieldSerialization, ValueList )
 
 //--------------------------------------------------------------------------------------------------
 //--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+// Pair round-trip: C++ → text checks the emitted format; text → C++ verifies parse.
+//--------------------------------------------------------------------------------------------------
+TEST( PdmFieldSerialization, PairBoolDouble )
+{
+    std::pair<bool, double> sourceValue = { true, 3.14 };
+
+    QString     text;
+    QTextStream stream( &text );
+
+    // C++ → text
+    caf::PdmFieldScriptingCapabilityIOHandler<std::pair<bool, double>>::readFromField( sourceValue, stream );
+
+    const QString expected = "(true, 3.140000000000000e+00)";
+    EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
+
+    // text → C++ (round-trip)
+    std::pair<bool, double> result;
+    caf::PdmScriptIOMessages messages;
+    caf::PdmFieldScriptingCapabilityIOHandler<std::pair<bool, double>>::writeToField( result, stream, &messages );
+
+    EXPECT_EQ( sourceValue.first, result.first );
+    EXPECT_DOUBLE_EQ( sourceValue.second, result.second );
+}
+
+//--------------------------------------------------------------------------------------------------
+// Parse a hand-written tuple with extra whitespace around delimiters.
+//--------------------------------------------------------------------------------------------------
+TEST( PdmFieldSerialization, PairBoolDouble_ParseWithSpaces )
+{
+    QString source = "( false , 2.5 )";
+    QTextStream stream( &source );
+
+    std::pair<bool, double> result;
+    caf::PdmScriptIOMessages messages;
+    caf::PdmFieldScriptingCapabilityIOHandler<std::pair<bool, double>>::writeToField( result, stream, &messages );
+
+    EXPECT_EQ( false, result.first );
+    EXPECT_DOUBLE_EQ( 2.5, result.second );
+    EXPECT_TRUE( messages.m_messages.empty() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
 TEST( PdmFieldSerialization, OptionalValues )
 {
     // See currently supported types in PdmPythonGenerator::dataTypeString

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
@@ -176,8 +176,6 @@ TEST( PdmFieldSerialization, ValueList )
 }
 
 //--------------------------------------------------------------------------------------------------
-//--------------------------------------------------------------------------------------------------
-//--------------------------------------------------------------------------------------------------
 // Pair round-trip: C++ → text checks the emitted format; text → C++ verifies parse.
 //--------------------------------------------------------------------------------------------------
 TEST( PdmFieldSerialization, PairBoolDouble )
@@ -194,7 +192,7 @@ TEST( PdmFieldSerialization, PairBoolDouble )
     EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
 
     // text → C++ (round-trip)
-    std::pair<bool, double> result;
+    std::pair<bool, double>  result;
     caf::PdmScriptIOMessages messages;
     caf::PdmFieldScriptingCapabilityIOHandler<std::pair<bool, double>>::writeToField( result, stream, &messages );
 
@@ -207,10 +205,10 @@ TEST( PdmFieldSerialization, PairBoolDouble )
 //--------------------------------------------------------------------------------------------------
 TEST( PdmFieldSerialization, PairBoolDouble_ParseWithSpaces )
 {
-    QString source = "( false , 2.5 )";
+    QString     source = "( false , 2.5 )";
     QTextStream stream( &source );
 
-    std::pair<bool, double> result;
+    std::pair<bool, double>  result;
     caf::PdmScriptIOMessages messages;
     caf::PdmFieldScriptingCapabilityIOHandler<std::pair<bool, double>>::writeToField( result, stream, &messages );
 

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
@@ -175,6 +175,15 @@ TEST( PdmPythonGenerator, DataTypeString_PairBoolDouble )
 }
 
 //--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, DataTypeString_PairBoolFloat )
+{
+    InheritedDemoObj obj;
+    EXPECT_STREQ( "Tuple[bool, float]",
+                  caf::PdmPythonGenerator::dataTypeString( &obj.m_pairFloatField, false ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
 // Child-field dataTypeName() returns the class keyword of the referenced type.  That keyword is
 // not in the builtins table, so useStrForUnknownDataTypes controls whether it is kept or replaced
 // with "str".

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
@@ -105,8 +105,7 @@ TEST( PdmPythonGenerator, PythonifyDataValue_NoChange )
 //--------------------------------------------------------------------------------------------------
 TEST( PdmPythonGenerator, PythonifyDataValue_MixedBooleans )
 {
-    EXPECT_STREQ( "True and False",
-                  caf::PdmPythonGenerator::pythonifyDataValue( "true and false" ).toStdString().c_str() );
+    EXPECT_STREQ( "True and False", caf::PdmPythonGenerator::pythonifyDataValue( "true and false" ).toStdString().c_str() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -193,6 +192,5 @@ TEST( PdmPythonGenerator, DataTypeString_ChildField )
     DemoPdmObject obj;
     EXPECT_STREQ( "SimpleObj",
                   caf::PdmPythonGenerator::dataTypeString( &obj.m_simpleObjPtrField, false ).toStdString().c_str() );
-    EXPECT_STREQ( "str",
-                  caf::PdmPythonGenerator::dataTypeString( &obj.m_simpleObjPtrField, true ).toStdString().c_str() );
+    EXPECT_STREQ( "str", caf::PdmPythonGenerator::dataTypeString( &obj.m_simpleObjPtrField, true ).toStdString().c_str() );
 }

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
@@ -36,6 +36,7 @@
 
 #include "gtest/gtest.h"
 
+#include "cafMockObjects.h"
 #include "cafPdmPythonGenerator.h"
 
 //--------------------------------------------------------------------------------------------------
@@ -106,4 +107,74 @@ TEST( PdmPythonGenerator, PythonifyDataValue_MixedBooleans )
 {
     EXPECT_STREQ( "True and False",
                   caf::PdmPythonGenerator::pythonifyDataValue( "true and false" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+// dataTypeString maps PdmFieldHandle types to Python type strings via the builtins table.
+// The builtins keys are typeid().name() strings, which is exactly what PdmXmlFieldHandle::dataTypeName()
+// returns for value fields.  Child fields return their class keyword instead.
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, DataTypeString_Double )
+{
+    DemoPdmObject obj;
+    EXPECT_STREQ( "float", caf::PdmPythonGenerator::dataTypeString( &obj.m_doubleField, false ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, DataTypeString_Int )
+{
+    DemoPdmObject obj;
+    EXPECT_STREQ( "int", caf::PdmPythonGenerator::dataTypeString( &obj.m_intField, false ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, DataTypeString_QString )
+{
+    DemoPdmObject obj;
+    EXPECT_STREQ( "str", caf::PdmPythonGenerator::dataTypeString( &obj.m_textField, false ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, DataTypeString_OptionalDouble )
+{
+    InheritedDemoObj obj;
+    EXPECT_STREQ( "Optional[float]",
+                  caf::PdmPythonGenerator::dataTypeString( &obj.m_optionalNumber, false ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+// Vector fields: dataTypeName() returns the element type; the List[] wrapper is added by the
+// caller (generate()) after checking isVectorField().
+TEST( PdmPythonGenerator, DataTypeString_VectorDouble )
+{
+    InheritedDemoObj obj;
+    EXPECT_STREQ( "float", caf::PdmPythonGenerator::dataTypeString( &obj.m_numbers, false ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+// A scriptable AppEnum field triggers the early-return path: enumScriptTexts() is non-empty, so
+// the function returns "str" without consulting the builtins table.
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, DataTypeString_ScriptableEnum )
+{
+    InheritedDemoObj obj;
+    EXPECT_STREQ( "str", caf::PdmPythonGenerator::dataTypeString( &obj.m_myAppEnum, false ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+// Child-field dataTypeName() returns the class keyword of the referenced type.  That keyword is
+// not in the builtins table, so useStrForUnknownDataTypes controls whether it is kept or replaced
+// with "str".
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, DataTypeString_ChildField )
+{
+    DemoPdmObject obj;
+    EXPECT_STREQ( "SimpleObj",
+                  caf::PdmPythonGenerator::dataTypeString( &obj.m_simpleObjPtrField, false ).toStdString().c_str() );
+    EXPECT_STREQ( "str",
+                  caf::PdmPythonGenerator::dataTypeString( &obj.m_simpleObjPtrField, true ).toStdString().c_str() );
 }

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
@@ -166,6 +166,15 @@ TEST( PdmPythonGenerator, DataTypeString_ScriptableEnum )
 }
 
 //--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, DataTypeString_PairBoolDouble )
+{
+    InheritedDemoObj obj;
+    EXPECT_STREQ( "Tuple[bool, float]",
+                  caf::PdmPythonGenerator::dataTypeString( &obj.m_pairField, false ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
 // Child-field dataTypeName() returns the class keyword of the referenced type.  That keyword is
 // not in the builtins table, so useStrForUnknownDataTypes controls whether it is kept or replaced
 // with "str".

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp
@@ -1,0 +1,109 @@
+//##################################################################################################
+//
+//   Custom Visualization Core library
+//   Copyright (C) Ceetron Solutions AS
+//
+//   This library may be used under the terms of either the GNU General Public License or
+//   the GNU Lesser General Public License as follows:
+//
+//   GNU General Public License Usage
+//   This library is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU General Public License at <<http://www.gnu.org/licenses/gpl.html>>
+//   for more details.
+//
+//   GNU Lesser General Public License Usage
+//   This library is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU Lesser General Public License as published by
+//   the Free Software Foundation; either version 2.1 of the License, or
+//   (at your option) any later version.
+//
+//   This library is distributed in the hope that it will be useful, but WITHOUT ANY
+//   WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//   FITNESS FOR A PARTICULAR PURPOSE.
+//
+//   See the GNU Lesser General Public License at <<http://www.gnu.org/licenses/lgpl-2.1.html>>
+//   for more details.
+//
+//##################################################################################################
+
+#include "gtest/gtest.h"
+
+#include "cafPdmPythonGenerator.h"
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, CamelToSnakeCase_SimpleCamel )
+{
+    EXPECT_STREQ( "my_variable", caf::PdmPythonGenerator::camelToSnakeCase( "MyVariable" ).toStdString().c_str() );
+    EXPECT_STREQ( "some_field_name", caf::PdmPythonGenerator::camelToSnakeCase( "SomeFieldName" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, CamelToSnakeCase_AlreadySnake )
+{
+    EXPECT_STREQ( "already_snake", caf::PdmPythonGenerator::camelToSnakeCase( "already_snake" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, CamelToSnakeCase_SingleWord )
+{
+    EXPECT_STREQ( "hello", caf::PdmPythonGenerator::camelToSnakeCase( "hello" ).toStdString().c_str() );
+    EXPECT_STREQ( "hello", caf::PdmPythonGenerator::camelToSnakeCase( "Hello" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, CamelToSnakeCase_AcronymPrefix )
+{
+    // Consecutive uppercase letters followed by a capitalised word
+    EXPECT_STREQ( "xml_parser", caf::PdmPythonGenerator::camelToSnakeCase( "XMLParser" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, CamelToSnakeCase_NumberInName )
+{
+    // A digit followed by an uppercase letter should produce an underscore
+    EXPECT_STREQ( "my_var2_name", caf::PdmPythonGenerator::camelToSnakeCase( "myVar2Name" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, CamelToSnakeCase_EmptyString )
+{
+    EXPECT_STREQ( "", caf::PdmPythonGenerator::camelToSnakeCase( "" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, PythonifyDataValue_BooleanLiterals )
+{
+    EXPECT_STREQ( "True", caf::PdmPythonGenerator::pythonifyDataValue( "true" ).toStdString().c_str() );
+    EXPECT_STREQ( "False", caf::PdmPythonGenerator::pythonifyDataValue( "false" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, PythonifyDataValue_NoChange )
+{
+    EXPECT_STREQ( "hello", caf::PdmPythonGenerator::pythonifyDataValue( "hello" ).toStdString().c_str() );
+    EXPECT_STREQ( "42", caf::PdmPythonGenerator::pythonifyDataValue( "42" ).toStdString().c_str() );
+}
+
+//--------------------------------------------------------------------------------------------------
+//--------------------------------------------------------------------------------------------------
+TEST( PdmPythonGenerator, PythonifyDataValue_MixedBooleans )
+{
+    EXPECT_STREQ( "True and False",
+                  caf::PdmPythonGenerator::pythonifyDataValue( "true and false" ).toStdString().c_str() );
+}


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Add std::pair<T, U> support with Python Tuple type mapping

- Implement PdmFieldScriptingCapabilityIOHandler for std::pair parsing/emission

- Add comprehensive unit tests for PdmPythonGenerator utilities

- Support std::pair<bool, double> and std::pair<bool, float> types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["std::pair&lt;T, U&gt;"] -->|"Maps to"| B["Tuple[T, U]"]
  C["PdmPythonGenerator"] -->|"dataTypeString"| B
  D["PdmFieldScriptingCapabilityIOHandler"] -->|"Parse/Emit"| E["Python tuple syntax"]
  F["Unit Tests"] -->|"Validate"| C
  F -->|"Validate"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cafPdmPythonGenerator.cpp</strong><dd><code>Add std::pair type mapping to Python Tuple</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmPythonGenerator.cpp

<ul><li>Add <code>#include <utility></code> for std::pair support<br> <li> Add <code>Tuple</code> to the typing imports in generated Python code<br> <li> Map <code>std::pair<bool, double></code> and <code>std::pair<bool, float></code> to <code>Tuple[bool, </code><br><code>float]</code> in builtins table</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/650/files#diff-4153c3ae7a68032f0db2ba5e5050b4531a205aa9492c8a6f0ac0e1daaafb2cc8">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cafPdmFieldScriptingCapability.h</strong><dd><code>Implement std::pair IOHandler with tuple parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmFieldScriptingCapability.h

<ul><li>Add <code>#include <utility></code> header<br> <li> Implement generic template specialization for <code>std::pair<T, U></code> <br>IOHandler<br> <li> Parse Python tuple syntax "(val1, val2)" with whitespace tolerance<br> <li> Emit tuple format by delegating element serialization to per-type <br>IOHandlers</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/650/files#diff-131086f14546d3848a5304269e485f9b0dfe960d874a289d34aab63ff357182d">+76/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cafPdmPythonGeneratorTest.cpp</strong><dd><code>Add comprehensive PdmPythonGenerator unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmPythonGeneratorTest.cpp

<ul><li>Create new test file with 16 unit tests for PdmPythonGenerator<br> <li> Test <code>camelToSnakeCase</code> utility with various naming patterns<br> <li> Test <code>pythonifyDataValue</code> for boolean literal conversion<br> <li> Test <code>dataTypeString</code> for builtin types, optional types, vectors, enums, <br>and std::pair types</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/650/files#diff-209ec9965c8351d24576bf996b32d9ec09770723a5444649651dd58fb2b385d2">+198/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cafPdmFieldSerializationTest.cpp</strong><dd><code>Add std::pair serialization round-trip tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp

<ul><li>Add round-trip serialization test for <code>std::pair<bool, double></code><br> <li> Verify C++ to text conversion produces correct tuple format<br> <li> Test parsing with extra whitespace around delimiters<br> <li> Validate error message handling for malformed input</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/650/files#diff-b5bfc0feddee8555f9c964e676c52e41a59bdea8fd3019752cf70323f48406ce">+44/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cafMockObjects.h</strong><dd><code>Add std::pair test fields to mock object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.h

<ul><li>Add <code>m_pairField</code> member of type <code>std::pair<bool, double></code><br> <li> Add <code>m_pairFloatField</code> member of type <code>std::pair<bool, float></code><br> <li> Align field declarations for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/650/files#diff-4df7685fe2c87e2e8458d6f6c48dc1d5217ca87effa6675b947fda9893ef2eb0">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cafMockObjects.cpp</strong><dd><code>Initialize std::pair fields in mock object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafMockObjects.cpp

<ul><li>Initialize <code>m_pairField</code> with default value <code>std::make_pair(false, 0.0)</code><br> <li> Initialize <code>m_pairFloatField</code> with default value <code>std::make_pair(false, </code><br><code>0.0f)</code><br> <li> Register fields as scriptable with appropriate descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/650/files#diff-28c36d6420e9d8e210328501db11cf393168220c9099ee48471922e565282843">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Add Python generator test to CMake build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/CMakeLists.txt

<ul><li>Add <code>cafPdmPythonGeneratorTest.cpp</code> to project files<br> <li> Reformat file list for improved readability with one file per line</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/650/files#diff-4ec706f6d5b5cab75b3039f716584690a60bde5503bc4dba7ea115b803506d17">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

