### PR TITLE
Revert "Configures Azure Blob Storage for vcpkg cache"

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -80,6 +80,7 @@ jobs:
       BUILD_TYPE: Release
       BUILDCACHE_DIR: ${{ github.workspace }}/buildcache_dir
       BUILDCACHE_ACCURACY: SLOPPY
+      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
     steps:
       - name: Checkout
@@ -194,6 +195,13 @@ jobs:
         run: |
           ThirdParty/vcpkg/${{ matrix.config.vcpkg-bootstrap }}
 
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: TAServers/vcpkg-cache@e5c219f91ccf7908fc284fb64f4d928715f4a154
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: vcpkg-${{ matrix.config.cxx}}/
+          
       - name: Print CMake version
         shell: bash
         run: |
@@ -208,8 +216,8 @@ jobs:
       - name: Configure
         shell: bash
         env:
-          VCPKG_FEATURE_FLAGS: "binarycaching"
-          VCPKG_BINARY_SOURCES: ${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT && format('clear;x-azblob,https://{0}.blob.core.windows.net/vcpkg-binaries,{1},readwrite', secrets.AZURE_VCPKG_STORAGE_ACCOUNT, secrets.AZURE_VCPKG_SAS_TOKEN) || 'clear' }}
+          VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
           CC: ${{ matrix.config.cc }}
           CXX: ${{ matrix.config.cxx }}
         run: >

--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Restore vcpkg cache
         id: vcpkg-cache
-        uses: TAServers/vcpkg-cache@e5c219f91ccf7908fc284fb64f4d928715f4a154
+        uses: TAServers/vcpkg-cache@f645f5b5c4a8a6546911a64b3b02ac86b76f584c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           prefix: vcpkg-${{ matrix.config.cxx}}/

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: TAServers/vcpkg-cache@v3
+      - uses: TAServers/vcpkg-cache@f645f5b5c4a8a6546911a64b3b02ac86b76f584c
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           submodules: true
 
+      - uses: TAServers/vcpkg-cache@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Linux dependencies
         run: |
           sudo apt-get update --option="APT::Acquire::Retries=3"
@@ -41,10 +45,17 @@ jobs:
       - name: vcpkg bootstrap
         run: ThirdParty/vcpkg/bootstrap-vcpkg.sh
   
+      - name: Restore vcpkg cache
+        id: vcpkg-cache
+        uses: TAServers/vcpkg-cache@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create compile commands and run clang-tidy
+        # https://clang.llvm.org/extra/doxygen/run-clang-tidy_8py_source.html
         env:
-          VCPKG_FEATURE_FLAGS: "binarycaching"
-          VCPKG_BINARY_SOURCES: "clear;x-azblob,https://${{ secrets.AZURE_VCPKG_STORAGE_ACCOUNT }}.blob.core.windows.net/vcpkg-binaries,${{ secrets.AZURE_VCPKG_SAS_TOKEN }},readwrite"
+          VCPKG_FEATURE_FLAGS: "binarycaching" # Possibly redundant, but explicitly sets the binary caching feature flag
+          VCPKG_BINARY_SOURCES: "clear;files,${{ steps.vcpkg-cache.outputs.path }},readwrite"
         run: |
           mkdir build
           cd build


### PR DESCRIPTION
### **User description**
This reverts commit 006a3167492d37b9900ab0537863c4c3be489546.


___

### **PR Type**
Enhancement


___

### **Description**
- Replace Azure Blob Storage with GitHub Actions native caching

- Add vcpkg-cache action for binary caching support

- Configure VCPKG_BINARY_SOURCES to use GHA cache

- Simplify caching by removing Azure secrets dependency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Azure Blob Storage<br/>with SAS Token"] -->|Replace| B["GitHub Actions<br/>Native Cache"]
  B --> C["vcpkg-cache Action"]
  C --> D["Local Cache Files"]
  E["VCPKG_BINARY_SOURCES<br/>Environment Variable"] -->|Updated| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ResInsightWithCache.yml</strong><dd><code>Migrate vcpkg caching to GitHub Actions native</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ResInsightWithCache.yml

<ul><li>Added <code>VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"</code> to workflow env <br>for GHA caching<br> <li> Integrated <code>TAServers/vcpkg-cache</code> action to restore vcpkg cache with <br>GitHub token<br> <li> Updated Configure step to use local cache files instead of Azure Blob <br>Storage<br> <li> Replaced Azure SAS token logic with simpler GHA cache path reference<br> <li> Added clarifying comment on <code>VCPKG_FEATURE_FLAGS</code> setting</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/658/files#diff-27914a34bf192504fe6b6653e2cd323c4380f2b23e309b6cb19a0821a2148b8c">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

