### PR TITLE
Simplifies double editor and improves validation

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechCase.cpp
@@ -129,6 +129,10 @@ RimGeoMechCase::RimGeoMechCase()
     CAF_PDM_InitField( &m_biotCoefficientType, "BiotCoefficientType", defaultBiotCoefficientType, "Biot Coefficient" );
     CAF_PDM_InitField( &m_biotFixedCoefficient, "BiotFixedCoefficient", 1.0, "Fixed Coefficient" );
     m_biotFixedCoefficient.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_biotFixedCoefficient.setRange( 0.0, 1.0 );
+    m_biotFixedCoefficient.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_biotFixedCoefficient.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                         static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitField( &m_biotResultAddress, "BiotResultAddress", QString( "" ), "Value" );
 
@@ -1129,16 +1133,6 @@ void RimGeoMechCase::defineEditorAttribute( const caf::PdmFieldHandle* field, QS
     if ( field == &m_closeElementPropertyFileCommand )
     {
         dynamic_cast<caf::PdmUiPushButtonEditorAttribute*>( attribute )->m_buttonText = "Close Selected Properties";
-    }
-
-    if ( field == &m_biotFixedCoefficient )
-    {
-        auto uiDoubleValueEditorAttr = dynamic_cast<caf::PdmUiDoubleValueEditorAttribute*>( attribute );
-        if ( uiDoubleValueEditorAttr )
-        {
-            uiDoubleValueEditorAttr->m_decimals  = 2;
-            uiDoubleValueEditorAttr->m_validator = new QDoubleValidator( 0.0, 1.0, 2 );
-        }
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.cpp
@@ -106,6 +106,10 @@ RimGeoMechResultDefinition::RimGeoMechResultDefinition()
     CAF_PDM_InitField( &m_normalizeByHydrostaticPressure, "NormalizeByHSP", false, "Normalize by Hydrostatic Pressure" );
     CAF_PDM_InitField( &m_normalizationAirGap, "NormalizationAirGap", 0.0, "Air Gap" );
     m_normalizationAirGap.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_normalizationAirGap.setMinValue( 0.0 );
+    m_normalizationAirGap.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_normalizationAirGap.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                        static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitField( &m_compactionRefLayerUiField,
                        "CompactionRefLayerUi",
@@ -542,22 +546,6 @@ void RimGeoMechResultDefinition::initAfterRead()
     m_compactionRefLayerUiField = m_compactionRefLayer;
 
     m_timeLapseBaseTimestep.uiCapability()->setUiReadOnly( resultPositionType() == RIG_WELLPATH_DERIVED );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimGeoMechResultDefinition::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
-{
-    if ( field == &m_normalizationAirGap )
-    {
-        auto attr = dynamic_cast<caf::PdmUiDoubleValueEditorAttribute*>( attribute );
-        if ( attr )
-        {
-            attr->m_decimals  = 2;
-            attr->m_validator = new QDoubleValidator( 0.0, std::numeric_limits<double>::max(), 2 );
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.h
+++ b/ApplicationLibCode/ProjectDataModel/GeoMech/RimGeoMechResultDefinition.h
@@ -99,7 +99,6 @@ private:
     bool useUndoRedoForFieldChanged() override;
 
     void initAfterRead() override;
-    void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
     // Metadata and option build tools
 
     std::map<std::string, std::vector<std::string>> getResultMetaDataForUIFieldSetting();

--- a/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotRegressionCurve.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotRegressionCurve.cpp
@@ -71,9 +71,15 @@ RimGridCrossPlotRegressionCurve::RimGridCrossPlotRegressionCurve()
 
     CAF_PDM_InitFieldNoDefault( &m_minExtrapolationRangeX, "MinExtrapolationRangeX", "Min" );
     m_minExtrapolationRangeX.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_minExtrapolationRangeX.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_minExtrapolationRangeX.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                           static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitFieldNoDefault( &m_maxExtrapolationRangeX, "MaxExtrapolationRangeX", "Max" );
     m_maxExtrapolationRangeX.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_maxExtrapolationRangeX.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_maxExtrapolationRangeX.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                           static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitField( &m_polynomialDegree, "PolynomialDegree", 3, "Degree" );
     m_polynomialDegree.setRange( 1, 50 );
@@ -383,11 +389,6 @@ void RimGridCrossPlotRegressionCurve::defineEditorAttribute( const caf::PdmField
             myAttr->m_decimals = 3;
         }
     }
-    else if ( field == &m_minExtrapolationRangeX || field == &m_maxExtrapolationRangeX )
-    {
-        caf::PdmUiDoubleValueEditorAttribute::testAndSetFixedWithTwoDecimals( attribute );
-    }
-
     else if ( field == &m_expressionText )
     {
         auto myAttr = dynamic_cast<caf::PdmUiTextEditorAttribute*>( attribute );

--- a/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.cpp
@@ -124,6 +124,12 @@ RimDepthTrackPlot::RimDepthTrackPlot()
     CAF_PDM_InitScriptableField( &m_maxVisibleDepth, "MaximumDepth", 1000.0, "Max" );
     m_minVisibleDepth.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
     m_maxVisibleDepth.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_minVisibleDepth.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_minVisibleDepth.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                    static_cast<int>( caf::NumberFormatType::FIXED ) );
+    m_maxVisibleDepth.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_maxVisibleDepth.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                    static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_depthAxisGridVisibility, "ShowDepthGridLines", "Show Grid Lines" );
     CAF_PDM_InitScriptableField( &m_isAutoScaleDepthEnabled, "AutoScaleDepthEnabled", true, "Auto Scale" );
@@ -1215,17 +1221,6 @@ void RimDepthTrackPlot::initAfterRead()
     }
 
     performAutoNameUpdate();
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimDepthTrackPlot::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
-{
-    if ( field == &m_minVisibleDepth || field == &m_maxVisibleDepth )
-    {
-        caf::PdmUiDoubleValueEditorAttribute::testAndSetFixedWithTwoDecimals( attribute );
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h
+++ b/ApplicationLibCode/ProjectDataModel/RimDepthTrackPlot.h
@@ -192,10 +192,9 @@ protected:
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
 
-    void initAfterRead() override;
-    void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
-    void onLoadDataAndUpdate() override;
-    void updatePlots();
+    void                 initAfterRead() override;
+    void                 onLoadDataAndUpdate() override;
+    void                 updatePlots();
     caf::PdmFieldHandle* userDescriptionField() override;
 
     void uiOrderingForFonts( const QString& uiConfigName, caf::PdmUiOrdering& uiOrdering );

--- a/ApplicationLibCode/ProjectDataModel/RimMudWeightWindowParameters.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMudWeightWindowParameters.cpp
@@ -112,6 +112,8 @@ RimMudWeightWindowParameters::RimMudWeightWindowParameters()
     CAF_PDM_InitField( &m_wellDeviationType, "WellDeviationSourceType", defaultSourceType, "Well Deviation" );
     CAF_PDM_InitField( &m_wellDeviationFixed, "WellDeviationFixed", 0.0, "Fixed Well Deviation" );
     m_wellDeviationFixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_wellDeviationFixed.setRange( 0.0, 360.0 );
+    m_wellDeviationFixed.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
 
     CAF_PDM_InitField( &m_wellDeviationAddress, "WellDeviationAddress", QString( "" ), "Value" );
     m_wellDeviationAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
@@ -119,6 +121,8 @@ RimMudWeightWindowParameters::RimMudWeightWindowParameters()
     CAF_PDM_InitField( &m_wellAzimuthType, "WellAzimuthSourceType", defaultSourceType, "Well Azimuth" );
     CAF_PDM_InitField( &m_wellAzimuthFixed, "WellAzimuthFixed", 0.0, "Fixed Well Azimuth" );
     m_wellAzimuthFixed.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_wellAzimuthFixed.setRange( 0.0, 360.0 );
+    m_wellAzimuthFixed.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
 
     CAF_PDM_InitField( &m_wellAzimuthAddress, "WellAzimuthAddress", QString( "" ), "Value" );
     m_wellAzimuthAddress.uiCapability()->setUiEditorTypeName( caf::PdmUiTreeSelectionEditor::uiEditorTypeName() );
@@ -512,23 +516,6 @@ void RimMudWeightWindowParameters::defineGroup( caf::PdmUiOrdering&             
 
     fixedField->uiCapability()->setUiHidden( *typeField != RimMudWeightWindowParameters::SourceType::FIXED );
     addressField->uiCapability()->setUiHidden( *typeField != RimMudWeightWindowParameters::SourceType::PER_ELEMENT );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimMudWeightWindowParameters::defineEditorAttribute( const caf::PdmFieldHandle* field,
-                                                          QString                    uiConfigName,
-                                                          caf::PdmUiEditorAttribute* attribute )
-{
-    if ( field == &m_wellDeviationFixed || field == &m_wellAzimuthFixed )
-    {
-        auto uiDoubleValueEditorAttr = dynamic_cast<caf::PdmUiDoubleValueEditorAttribute*>( attribute );
-        if ( uiDoubleValueEditorAttr )
-        {
-            uiDoubleValueEditorAttr->m_validator = new QDoubleValidator( 0.0, 360.0, 3 );
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimMudWeightWindowParameters.h
+++ b/ApplicationLibCode/ProjectDataModel/RimMudWeightWindowParameters.h
@@ -105,7 +105,6 @@ public:
 private:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
-    void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
 

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimNonNetLayers.cpp
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimNonNetLayers.cpp
@@ -46,6 +46,8 @@ RimNonNetLayers::RimNonNetLayers()
 
     CAF_PDM_InitScriptableField( &m_cutOff, "Cutoff", 0.0, "Cutoff" );
     m_cutOff.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_cutOff.setRange( 0.0, 1.0 );
+    m_cutOff.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_facies, "Facies", "Facies" );
 
@@ -84,21 +86,6 @@ QList<caf::PdmOptionItemInfo> RimNonNetLayers::calculateValueOptions( const caf:
     }
 
     return options;
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RimNonNetLayers::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
-{
-    if ( field == &m_cutOff )
-    {
-        auto uiDoubleValueEditorAttr = dynamic_cast<caf::PdmUiDoubleValueEditorAttribute*>( attribute );
-        if ( uiDoubleValueEditorAttr )
-        {
-            uiDoubleValueEditorAttr->m_validator = new QDoubleValidator( 0.0, 1.0, 2 );
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimNonNetLayers.h
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimNonNetLayers.h
@@ -56,7 +56,6 @@ protected:
     void                          defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
     QList<caf::PdmOptionItemInfo> calculateValueOptions( const caf::PdmFieldHandle* fieldNeedingOptions ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
-    void defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
 
     RimColorLegend* getFaciesColorLegend();
 

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.cpp
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModel.cpp
@@ -216,16 +216,25 @@ RimStimPlanModel::RimStimPlanModel()
     CAF_PDM_InitScriptableField( &m_formationDip, "FormationDip", 0.0, "Formation Dip" );
     m_formationDip.uiCapability()->setUiReadOnly( true );
     m_formationDip.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_formationDip.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_formationDip.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                 static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitScriptableField( &m_autoComputeBarrier, "AutoComputeBarrier", true, "Auto Compute Barrier" );
     CAF_PDM_InitScriptableField( &m_hasBarrier, "Barrier", true, "Barrier" );
     CAF_PDM_InitScriptableField( &m_distanceToBarrier, "DistanceToBarrier", 0.0, "Distance To Barrier [m]" );
     m_distanceToBarrier.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
     m_distanceToBarrier.uiCapability()->setUiReadOnly( true );
+    m_distanceToBarrier.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_distanceToBarrier.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                      static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitScriptableField( &m_barrierDip, "BarrierDip", 0.0, "Barrier Dip" );
     m_barrierDip.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
     m_barrierDip.uiCapability()->setUiReadOnly( true );
+    m_barrierDip.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_barrierDip.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                               static_cast<int>( caf::NumberFormatType::FIXED ) );
     CAF_PDM_InitScriptableField( &m_wellPenetrationLayer, "WellPenetrationLayer", 2, "Well Penetration Layer" );
 
     CAF_PDM_InitScriptableField( &m_showOnlyBarrierFault, "ShowOnlyBarrierFault", false, "Show Only Barrier Fault" );
@@ -894,11 +903,6 @@ void RimStimPlanModel::defineUiOrdering( QString uiConfigName, caf::PdmUiOrderin
 //--------------------------------------------------------------------------------------------------
 void RimStimPlanModel::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_formationDip || field == &m_barrierDip || field == &m_distanceToBarrier )
-    {
-        caf::PdmUiDoubleValueEditorAttribute::testAndSetFixedWithTwoDecimals( attribute );
-    }
-
     if ( field == &m_MD )
     {
         caf::PdmUiDoubleSliderEditorAttribute* myAttr = dynamic_cast<caf::PdmUiDoubleSliderEditorAttribute*>( attribute );

--- a/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelTemplate.cpp
+++ b/ApplicationLibCode/ProjectDataModel/StimPlanModel/RimStimPlanModelTemplate.cpp
@@ -111,9 +111,15 @@ RimStimPlanModelTemplate::RimStimPlanModelTemplate()
 
     CAF_PDM_InitScriptableField( &m_verticalStress, "VerticalStress", defaultStress, "Vertical Stress" );
     m_verticalStress.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_verticalStress.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_verticalStress.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                   static_cast<int>( caf::NumberFormatType::FIXED ) );
     CAF_PDM_InitScriptableField( &m_verticalStressGradient, "VerticalStressGradient", defaultStressGradient, "Vertical Stress Gradient" );
     CAF_PDM_InitScriptableField( &m_stressDepth, "StressDepth", defaultStressDepth, "Stress Depth" );
     m_stressDepth.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_stressDepth.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_stressDepth.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitScriptableField( &m_referenceTemperature, "ReferenceTemperature", 70.0, "Temperature [C]" );
     CAF_PDM_InitScriptableField( &m_referenceTemperatureGradient, "ReferenceTemperatureGradient", 0.025, "Temperature Gradient [C/m]" );
@@ -305,11 +311,6 @@ void RimStimPlanModelTemplate::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiT
 //--------------------------------------------------------------------------------------------------
 void RimStimPlanModelTemplate::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
-    if ( field == &m_stressDepth || field == &m_verticalStress )
-    {
-        caf::PdmUiDoubleValueEditorAttribute::testAndSetFixedWithTwoDecimals( attribute );
-    }
-
     if ( field == &m_faciesInitialPressureConfigs )
     {
         auto tvAttribute = dynamic_cast<caf::PdmUiTableViewEditorAttribute*>( attribute );

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimDepthSurface.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimDepthSurface.cpp
@@ -45,8 +45,14 @@ RimDepthSurface::RimDepthSurface()
 
     CAF_PDM_InitField( &m_depthLowerLimit, "DepthLowerLimit", 0.0, "Lower Limit" );
     m_depthLowerLimit.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_depthLowerLimit.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_depthLowerLimit.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                    static_cast<int>( caf::NumberFormatType::FIXED ) );
     CAF_PDM_InitField( &m_depthUpperLimit, "DepthUpperLimit", 100000.0, "Upper Limit" );
     m_depthUpperLimit.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_depthUpperLimit.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_depthUpperLimit.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                    static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     m_minX.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );
     m_maxX.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleSliderEditor::uiEditorTypeName() );
@@ -151,8 +157,6 @@ void RimDepthSurface::fieldChangedByUi( const caf::PdmFieldHandle* changedField,
 void RimDepthSurface::defineEditorAttribute( const caf::PdmFieldHandle* field, QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
 {
     RimSurface::defineEditorAttribute( field, uiConfigName, attribute );
-
-    caf::PdmUiDoubleValueEditorAttribute::testAndSetFixedWithTwoDecimals( attribute );
 
     if ( field == &m_depth )
     {

--- a/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementInView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellMeasurement/RimWellMeasurementInView.cpp
@@ -82,6 +82,10 @@ RimWellMeasurementInView::RimWellMeasurementInView()
 
     CAF_PDM_InitField( &m_radiusScaleFactor, "RadiusScaleFactor", 2.5, "Radius Scale" );
     m_radiusScaleFactor.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_radiusScaleFactor.setRange( 0.001, 100.0 );
+    m_radiusScaleFactor.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_radiusScaleFactor.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT,
+                                                      static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     setName( "Well Measurement" );
 
@@ -144,16 +148,6 @@ void RimWellMeasurementInView::defineEditorAttribute( const caf::PdmFieldHandle*
         {
             myAttr->m_minimum = m_minimumResultValue;
             myAttr->m_maximum = m_maximumResultValue;
-        }
-    }
-
-    if ( field == &m_radiusScaleFactor )
-    {
-        caf::PdmUiDoubleValueEditorAttribute* uiDoubleValueEditorAttr = dynamic_cast<caf::PdmUiDoubleValueEditorAttribute*>( attribute );
-        if ( uiDoubleValueEditorAttr )
-        {
-            uiDoubleValueEditorAttr->m_decimals  = 2;
-            uiDoubleValueEditorAttr->m_validator = new QDoubleValidator( 0.001, 100.0, 2 );
         }
     }
 }

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimWellPathGeometryDef.cpp
@@ -72,6 +72,9 @@ RimWellPathGeometryDef::RimWellPathGeometryDef()
 
     CAF_PDM_InitScriptableField( &m_airGap, "AirGap", 0.0, "Air Gap" );
     m_airGap.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
+    m_airGap.setMinValue( 0.0 );
+    m_airGap.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 2 );
+    m_airGap.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::NUMBER_FORMAT, static_cast<int>( caf::NumberFormatType::FIXED ) );
 
     CAF_PDM_InitScriptableField( &m_mdAtFirstTarget, "MdAtFirstTarget", 0.0, "MD at First Target" );
     m_mdAtFirstTarget.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
@@ -773,16 +776,6 @@ void RimWellPathGeometryDef::defineEditorAttribute( const caf::PdmFieldHandle* f
             uiDisplayStringAttr->m_displayString = QString::number( m_referencePointUtmXyd()[0], 'f', 2 ) + " " +
                                                    QString::number( m_referencePointUtmXyd()[1], 'f', 2 ) + " " +
                                                    QString::number( m_referencePointUtmXyd()[2], 'f', 2 );
-        }
-    }
-
-    if ( field == &m_airGap )
-    {
-        auto uiDoubleValueEditorAttr = dynamic_cast<caf::PdmUiDoubleValueEditorAttribute*>( attribute );
-        if ( uiDoubleValueEditorAttr )
-        {
-            uiDoubleValueEditorAttr->m_decimals  = 2;
-            uiDoubleValueEditorAttr->m_validator = new QDoubleValidator( 0.0, std::numeric_limits<double>::max(), 2 );
         }
     }
 }

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmCore_UnitTests/cafPdmCoreBasicTest.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmCore_UnitTests/cafPdmCoreBasicTest.cpp
@@ -779,6 +779,74 @@ TEST( BaseTest, FieldRangeValidation )
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Test of pair<bool, double> field range validation
+//--------------------------------------------------------------------------------------------------
+TEST( BaseTest, PairBoolDoubleRangeValidation )
+{
+    class TestObject : public caf::PdmObjectHandle
+    {
+    public:
+        TestObject() { this->addField( &m_toggleValue, "toggleValue" ); }
+
+        caf::PdmDataValueField<std::pair<bool, double>> m_toggleValue;
+    };
+
+    TestObject* obj = new TestObject;
+
+    // Test setRange with min only
+    obj->m_toggleValue.setMinValue( 0.00001 );
+
+    obj->m_toggleValue.setValue( std::make_pair( true, 5.0 ) );
+    EXPECT_TRUE( obj->m_toggleValue.isValid() );
+    EXPECT_TRUE( obj->m_toggleValue.validate().isEmpty() );
+
+    obj->m_toggleValue.setValue( std::make_pair( true, 0.0 ) );
+    EXPECT_FALSE( obj->m_toggleValue.isValid() );
+    EXPECT_TRUE( obj->m_toggleValue.validate().contains( "below minimum" ) );
+
+    // Bool state should not affect validation
+    obj->m_toggleValue.setValue( std::make_pair( false, 0.0 ) );
+    EXPECT_FALSE( obj->m_toggleValue.isValid() );
+
+    // Test setRange with both min and max
+    obj->m_toggleValue.setRange( 1.0, 100.0 );
+
+    obj->m_toggleValue.setValue( std::make_pair( true, 50.0 ) );
+    EXPECT_TRUE( obj->m_toggleValue.isValid() );
+
+    obj->m_toggleValue.setValue( std::make_pair( true, 1.0 ) );
+    EXPECT_TRUE( obj->m_toggleValue.isValid() );
+
+    obj->m_toggleValue.setValue( std::make_pair( true, 100.0 ) );
+    EXPECT_TRUE( obj->m_toggleValue.isValid() );
+
+    obj->m_toggleValue.setValue( std::make_pair( true, 0.5 ) );
+    EXPECT_FALSE( obj->m_toggleValue.isValid() );
+    EXPECT_TRUE( obj->m_toggleValue.validate().contains( "below minimum" ) );
+
+    obj->m_toggleValue.setValue( std::make_pair( true, 200.0 ) );
+    EXPECT_FALSE( obj->m_toggleValue.isValid() );
+    EXPECT_TRUE( obj->m_toggleValue.validate().contains( "exceeds maximum" ) );
+
+    // Test clearRange
+    obj->m_toggleValue.clearRange();
+    obj->m_toggleValue.setValue( std::make_pair( true, -1000.0 ) );
+    EXPECT_TRUE( obj->m_toggleValue.isValid() );
+
+    // Test clampValue
+    obj->m_toggleValue.setRange( 0.0, 10.0 );
+    auto clamped = obj->m_toggleValue.clampValue( std::make_pair( true, 15.0 ) );
+    EXPECT_EQ( 10.0, clamped.second );
+    EXPECT_TRUE( clamped.first );
+
+    clamped = obj->m_toggleValue.clampValue( std::make_pair( false, -5.0 ) );
+    EXPECT_EQ( 0.0, clamped.second );
+    EXPECT_FALSE( clamped.first );
+
+    delete obj;
+}
+
+//--------------------------------------------------------------------------------------------------
 /// Test of independent min/max value validation
 //--------------------------------------------------------------------------------------------------
 TEST( BaseTest, IndependentMinMaxValidation )

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmDataValueField.h
@@ -73,6 +73,16 @@ public:
     {
     };
 
+    // Type trait to detect std::pair<bool, ArithmeticType>
+    template <typename T>
+    struct is_bool_arithmetic_pair : public std::false_type
+    {
+    };
+    template <typename T>
+    struct is_bool_arithmetic_pair<std::pair<bool, T>> : public std::integral_constant<bool, std::is_arithmetic<T>::value>
+    {
+    };
+
     typedef DataType FieldDataType;
     PdmDataValueField()
         : m_fieldValue( DataType() )
@@ -172,6 +182,46 @@ public:
         m_maxValue.reset();
     }
 
+    // Range validation for std::pair<bool, ArithmeticType> - validates the second (value) element
+    template <typename T = DataType>
+    typename std::enable_if<is_bool_arithmetic_pair<T>::value>::type
+        setRange( const typename T::second_type& minValue, const typename T::second_type& maxValue )
+    {
+        m_minValue = DataType( false, std::min( minValue, maxValue ) );
+        m_maxValue = DataType( false, std::max( minValue, maxValue ) );
+    }
+
+    template <typename T = DataType>
+    typename std::enable_if<is_bool_arithmetic_pair<T>::value>::type setMinValue( const typename T::second_type& minValue )
+    {
+        m_minValue = DataType( false, minValue );
+    }
+
+    template <typename T = DataType>
+    typename std::enable_if<is_bool_arithmetic_pair<T>::value>::type setMaxValue( const typename T::second_type& maxValue )
+    {
+        m_maxValue = DataType( false, maxValue );
+    }
+
+    template <typename T = DataType>
+    typename std::enable_if<is_bool_arithmetic_pair<T>::value>::type clearRange()
+    {
+        m_minValue.reset();
+        m_maxValue.reset();
+    }
+
+    template <typename T = DataType>
+    typename std::enable_if<is_bool_arithmetic_pair<T>::value>::type clearMinValue()
+    {
+        m_minValue.reset();
+    }
+
+    template <typename T = DataType>
+    typename std::enable_if<is_bool_arithmetic_pair<T>::value>::type clearMaxValue()
+    {
+        m_maxValue.reset();
+    }
+
     // Override validate from PdmFieldHandle
     QString validate() const override;
 
@@ -188,6 +238,19 @@ public:
             if ( m_maxValue.has_value() && clampedValue > m_maxValue.value() )
             {
                 clampedValue = m_maxValue.value();
+            }
+            return clampedValue;
+        }
+        else if constexpr ( is_bool_arithmetic_pair<DataType>::value )
+        {
+            DataType clampedValue = value;
+            if ( m_minValue.has_value() && clampedValue.second < m_minValue.value().second )
+            {
+                clampedValue.second = m_minValue.value().second;
+            }
+            if ( m_maxValue.has_value() && clampedValue.second > m_maxValue.value().second )
+            {
+                clampedValue.second = m_maxValue.value().second;
             }
             return clampedValue;
         }
@@ -257,6 +320,17 @@ QString caf::PdmDataValueField<DataType>::validate() const
         if ( m_maxValue.has_value() && m_fieldValue > m_maxValue.value() )
         {
             return QString( "Value %1 exceeds maximum %2" ).arg( m_fieldValue ).arg( m_maxValue.value() );
+        }
+    }
+    else if constexpr ( is_bool_arithmetic_pair<DataType>::value )
+    {
+        if ( m_minValue.has_value() && m_fieldValue.second < m_minValue.value().second )
+        {
+            return QString( "Value %1 is below minimum %2" ).arg( m_fieldValue.second ).arg( m_minValue.value().second );
+        }
+        if ( m_maxValue.has_value() && m_fieldValue.second > m_maxValue.value().second )
+        {
+            return QString( "Value %1 exceeds maximum %2" ).arg( m_fieldValue.second ).arg( m_maxValue.value().second );
         }
     }
     return executeCustomValidation();

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafInternalPdmUiFieldCapability.inl
@@ -95,6 +95,13 @@ void PdmFieldUiCap<FieldType>::setValueFromUiEditor( const QVariant& uiValue, bo
     {
         typename FieldType::FieldDataType value;
         PdmUiFieldSpecialization<typename FieldType::FieldDataType>::setFromVariant( uiValue, value );
+
+        // Clamp value if the field has a clampValue method
+        if constexpr ( requires { m_field->clampValue( value ); } )
+        {
+            value = m_field->clampValue( value );
+        }
+
         m_field->setValue( value );
     }
 

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldEditorHandle.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiFieldEditorHandle.cpp
@@ -48,6 +48,8 @@
 #include <QLineEdit>
 #include <QMenu>
 #include <QStyle>
+#include <QTimer>
+#include <QToolTip>
 
 namespace caf
 {
@@ -338,8 +340,13 @@ void PdmUiFieldEditorHandle::applyValidationStyling( QWidget* widget, const QStr
         // Valid - remove error icon if present
         if ( m_validationErrorAction )
         {
-            widget->removeAction( m_validationErrorAction );
+            if ( auto* parentWidget = qobject_cast<QWidget*>( m_validationErrorAction->parent() ) )
+            {
+                parentWidget->removeAction( m_validationErrorAction );
+            }
             delete m_validationErrorAction;
+            m_validationErrorAction = nullptr;
+            QToolTip::hideText();
         }
     }
     else
@@ -353,6 +360,11 @@ void PdmUiFieldEditorHandle::applyValidationStyling( QWidget* widget, const QStr
 
             // For QLineEdit, use TrailingPosition to show icon inside the widget
             QLineEdit* lineEdit = qobject_cast<QLineEdit*>( widget );
+            if ( !lineEdit )
+            {
+                // Search for a QLineEdit child in composite editor widgets (e.g. checkbox + line edit)
+                lineEdit = widget->findChild<QLineEdit*>();
+            }
             if ( lineEdit )
             {
                 m_validationErrorAction = lineEdit->addAction( warningIcon, QLineEdit::TrailingPosition );
@@ -363,6 +375,27 @@ void PdmUiFieldEditorHandle::applyValidationStyling( QWidget* widget, const QStr
                 widget->addAction( m_validationErrorAction );
             }
             m_validationErrorAction->setToolTip( errorMessage );
+
+            // Defer tooltip display until after all UI updates and pending key events are processed.
+            // A 100 ms delay is used because Qt dismisses tooltips on any key event. When the user
+            // presses Enter, both a key press and key release event are generated. A 0 ms delay would
+            // show the tooltip between these events, and the key release would immediately dismiss it.
+            QWidget* tooltipWidget = lineEdit ? static_cast<QWidget*>( lineEdit ) : widget;
+            if ( tooltipWidget->isVisible() )
+            {
+                QPointer<QWidget> safeWidget( tooltipWidget );
+                QString           msg = errorMessage;
+                QTimer::singleShot( 100,
+                                    tooltipWidget,
+                                    [safeWidget, msg]()
+                                    {
+                                        if ( safeWidget )
+                                        {
+                                            QPoint pos = safeWidget->mapToGlobal( QPoint( safeWidget->width(), 0 ) );
+                                            QToolTip::showText( pos, msg, safeWidget );
+                                        }
+                                    } );
+            }
         }
         else
         {

--- a/Fwk/AppFwk/cafTests/cafTestApplication/ValidationTest.cpp
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/ValidationTest.cpp
@@ -1,5 +1,7 @@
 #include "ValidationTest.h"
 
+#include "cafPdmUiDoubleValueEditor.h"
+
 #include <QDebug>
 
 CAF_PDM_SOURCE_INIT( ValidationTestObject, "ValidationTestObject" );
@@ -13,7 +15,7 @@ ValidationTestObject::ValidationTestObject()
 
     // Temperature field: -273.15 to 1000.0 Celsius
     CAF_PDM_InitField( &m_temperature, "temperature", 20.0, "Temperature (°C)", "", "", "" );
-    m_temperature.uiCapability()->setUiToolTip( "Valid range: -273.15 to 1000.0 °C" );
+    //m_temperature.uiCapability()->setUiToolTip( "Valid range: -273.15 to 1000.0 °C" );
     m_temperature.setRange( -273.15, 1000.0 );
 
     // Age field: 0 to 150 years
@@ -23,8 +25,10 @@ ValidationTestObject::ValidationTestObject()
 
     // Percentage field: 0 to 100
     CAF_PDM_InitField( &m_percentage, "percentage", 50.0, "Percentage (%)", "", "", "" );
-    m_percentage.uiCapability()->setUiToolTip( "Valid range: 0 to 100%" );
+    m_percentage.uiCapability()->setUiToolTip( "Valid range: 0 to 100%, 4 significant digits" );
     m_percentage.setRange( 0.0, 100.0 );
+    m_percentage.uiCapability()->setAttribute( caf::PdmUiDoubleValueEditor::Keys::DECIMALS, 4 );
+    m_percentage.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 
     // Count field: minimum value only (>= 0) and must be even (custom callback)
     CAF_PDM_InitField( &m_count, "count", 0, "Count", "", "", "" );
@@ -61,6 +65,12 @@ ValidationTestObject::ValidationTestObject()
     CAF_PDM_InitField( &m_rangeField, "rangeField", 0.0, "Range Field", "", "", "" );
     m_rangeField.uiCapability()->setUiToolTip( "Valid range: -100.0 to 100.0" );
     m_rangeField.setRange( -100.0, 100.0 );
+
+    // Toggle+double field with range validation: 0.001 to 1000.0
+    CAF_PDM_InitField( &m_toggleDoubleField, "toggleDoubleField", std::make_pair( false, 1.0 ), "Toggle Double", "", "", "" );
+    m_toggleDoubleField.uiCapability()->setUiToolTip( "Valid range: 0.001 to 1000.0" );
+    m_toggleDoubleField.setRange( 0.001, 1000.0 );
+    m_toggleDoubleField.uiCapability()->setUiEditorTypeName( caf::PdmUiDoubleValueEditor::uiEditorTypeName() );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/Fwk/AppFwk/cafTests/cafTestApplication/ValidationTest.h
+++ b/Fwk/AppFwk/cafTests/cafTestApplication/ValidationTest.h
@@ -32,4 +32,7 @@ public:
 
     // Field with both min and max validation
     caf::PdmField<double> m_rangeField;
+
+    // Toggle+value field with range validation on the value
+    caf::PdmField<std::pair<bool, double>> m_toggleDoubleField;
 };

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleValueEditor.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleValueEditor.cpp
@@ -45,7 +45,6 @@
 #include "cafPdmUiDefaultObjectEditor.h"
 #include "cafPdmUiFieldEditorHandle.h"
 
-#include <QDoubleValidator>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
@@ -64,13 +63,6 @@ PdmUiDoubleValueEditor::PdmUiDoubleValueEditor()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-PdmUiDoubleValueEditor::~PdmUiDoubleValueEditor()
-{
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 void PdmUiDoubleValueEditor::configureAndUpdateUi( const QString& uiConfigName )
 {
     CAF_ASSERT( !m_lineEdit.isNull() );
@@ -79,46 +71,10 @@ void PdmUiDoubleValueEditor::configureAndUpdateUi( const QString& uiConfigName )
 
     m_lineEdit->setEnabled( !uiField()->isUiReadOnly( uiConfigName ) );
 
-    caf::PdmUiObjectHandle* uiObject = uiObj( uiField()->fieldHandle()->ownerObject() );
-    if ( uiObject )
-    {
-        uiObject->editorAttribute( uiField()->fieldHandle(), uiConfigName, &m_attributes );
-        if ( m_attributes.m_validator )
-        {
-            m_lineEdit->setValidator( m_attributes.m_validator );
-        }
-    }
+    // Validate: warn about unsupported attributes
+    uiField()->validateAttributes( "PdmUiDoubleValueEditor", SUPPORTED_ATTRIBUTES, uiConfigName );
 
-    // Override with map-based attributes if present (new system takes precedence)
-    if ( auto uiItem = uiField() )
-    {
-        if ( auto val = uiItem->attribute<int>( Keys::DECIMALS, uiConfigName ) )
-        {
-            m_attributes.m_decimals = val.value();
-        }
-
-        if ( auto val = uiItem->attribute<int>( Keys::NUMBER_FORMAT, uiConfigName ) )
-        {
-            m_attributes.m_numberFormat = static_cast<NumberFormatType>( val.value() );
-        }
-
-        // Validate: warn about unsupported attributes
-        uiItem->validateAttributes( "PdmUiDoubleValueEditor", SUPPORTED_ATTRIBUTES, uiConfigName );
-    }
-
-    bool    valueOk = false;
-    double  value   = uiField()->uiValue().toDouble( &valueOk );
-    QString textValue;
-    if ( valueOk )
-    {
-        textValue = PdmUiNumberFormat::valueToText( value, m_attributes.m_numberFormat, m_attributes.m_decimals );
-    }
-    else
-    {
-        textValue = uiField()->uiValue().toString();
-    }
-
-    m_lineEdit->setText( textValue );
+    m_lineEdit->setText( formattedValue() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -154,9 +110,46 @@ void PdmUiDoubleValueEditor::slotEditingFinished()
 void PdmUiDoubleValueEditor::writeValueToField()
 {
     QString  textValue = m_lineEdit->text();
-    QVariant v;
-    v = textValue;
+    QVariant v         = textValue;
+
     this->setValueToField( v );
+
+    // This is required if the user entered an invalid value, we want to reset the text to the current value in the field
+    m_lineEdit->setText( formattedValue() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString PdmUiDoubleValueEditor::formattedValue()
+{
+    if ( !uiField() )
+    {
+        return {};
+    }
+    auto uiFieldHandle = uiField();
+
+    NumberFormatType numberFormat = NumberFormatType::AUTO;
+    int              precision    = 6;
+
+    if ( auto val = uiFieldHandle->attribute<int>( Keys::DECIMALS ) )
+    {
+        precision = val.value();
+    }
+
+    if ( auto val = uiFieldHandle->attribute<int>( Keys::NUMBER_FORMAT ) )
+    {
+        numberFormat = static_cast<NumberFormatType>( val.value() );
+    }
+
+    bool   valueOk = false;
+    double value   = uiFieldHandle->uiValue().toDouble( &valueOk );
+    if ( valueOk )
+    {
+        return PdmUiNumberFormat::valueToText( value, numberFormat, precision );
+    }
+
+    return uiFieldHandle->uiValue().toString();
 }
 
 } // end namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleValueEditor.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiDoubleValueEditor.h
@@ -39,7 +39,6 @@
 #include "cafPdmUiFieldLabelEditorHandle.h"
 #include "cafPdmUiNumberFormat.h"
 
-#include <QDoubleValidator>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLineEdit>
@@ -49,38 +48,6 @@
 
 namespace caf
 {
-//==================================================================================================
-///
-//==================================================================================================
-class PdmUiDoubleValueEditorAttribute : public PdmUiEditorAttribute
-{
-public:
-    PdmUiDoubleValueEditorAttribute()
-    {
-        m_decimals     = 6;
-        m_numberFormat = NumberFormatType::AUTO;
-    }
-
-    void setFixedWithTwoDecimals()
-    {
-        m_decimals     = 2;
-        m_numberFormat = NumberFormatType::FIXED;
-    }
-
-    // Convenience function to set the number format to fixed with two decimals
-    static void testAndSetFixedWithTwoDecimals( caf::PdmUiEditorAttribute* attr )
-    {
-        if ( auto doubleAttr = dynamic_cast<caf::PdmUiDoubleValueEditorAttribute*>( attr ) )
-        {
-            doubleAttr->setFixedWithTwoDecimals();
-        }
-    }
-
-public:
-    int                        m_decimals;
-    NumberFormatType           m_numberFormat;
-    QPointer<QDoubleValidator> m_validator;
-};
 
 //==================================================================================================
 ///
@@ -92,7 +59,6 @@ class PdmUiDoubleValueEditor : public PdmUiFieldLabelEditorHandle
 
 public:
     PdmUiDoubleValueEditor();
-    ~PdmUiDoubleValueEditor() override;
 
     // Attribute key constants for compile-time safety and discoverability
     struct Keys
@@ -112,12 +78,11 @@ protected slots:
     void slotEditingFinished();
 
 private:
-    void writeValueToField();
+    void    writeValueToField();
+    QString formattedValue();
 
 private:
     QPointer<QLineEdit> m_lineEdit;
-
-    PdmUiDoubleValueEditorAttribute m_attributes;
 };
 
 } // end namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiNumberFormat.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiNumberFormat.cpp
@@ -25,23 +25,8 @@ QString PdmUiNumberFormat::valueToText( double value, NumberFormatType numberFor
         case NumberFormatType::SCIENTIFIC:
             return QString::number( value, 'e', precision );
         default:
-            return QString::number( value );
+            return QString::number( value, 'g', precision );
     }
 }
 
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-QString PdmUiNumberFormat::sprintfFormat( NumberFormatType numberFormat, int precision )
-{
-    switch ( numberFormat )
-    {
-        case NumberFormatType::FIXED:
-            return QString( "%.%1f" ).arg( precision );
-        case NumberFormatType::SCIENTIFIC:
-            return QString( "%.%1e" ).arg( precision );
-        default:
-            return QString( "%.%1g" ).arg( precision );
-    }
-}
 } // namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafPdmUiNumberFormat.h
+++ b/Fwk/AppFwk/cafUserInterface/cafPdmUiNumberFormat.h
@@ -15,6 +15,5 @@ class PdmUiNumberFormat
 {
 public:
     static QString valueToText( double value, NumberFormatType numberFormat, int precision );
-    static QString sprintfFormat( NumberFormatType numberFormat, int precision );
 };
 } // namespace caf

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiNumberFormatTest.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiNumberFormatTest.cpp
@@ -21,7 +21,7 @@ TEST( PdmUiNumberFormatTest, ValueToText )
         { 3.14159,      "3.14",         NumberFormatType::FIXED,      2 },
         { 0.0,          "0.000",        NumberFormatType::FIXED,      3 },
         { -1.5,         "-1.5",         NumberFormatType::FIXED,      1 },
-        { 1.0 / 3.0,   "0.33333333",    NumberFormatType::FIXED,      8 },
+        { 1.0 / 3.0,    "0.33333333",   NumberFormatType::FIXED,      8 },
         { 3.7,          "4",            NumberFormatType::FIXED,      0 },
         { -2.3,         "-2",           NumberFormatType::FIXED,      0 },
         { 1234567.89,   "1234567.89",   NumberFormatType::FIXED,      2 },

--- a/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiNumberFormatTest.cpp
+++ b/Fwk/AppFwk/cafUserInterface/cafUserInterface_UnitTests/cafPdmUiNumberFormatTest.cpp
@@ -5,47 +5,48 @@
 
 using namespace caf;
 
-TEST( PdmUiNumberFormatTest, ValueToTextFixed )
+TEST( PdmUiNumberFormatTest, ValueToText )
 {
-    QString result = PdmUiNumberFormat::valueToText( 3.14159, NumberFormatType::FIXED, 2 );
-    EXPECT_EQ( result.toStdString(), "3.14" );
+    struct TestCase
+    {
+        double           value;
+        std::string      expected;
+        NumberFormatType format;
+        int              precision;
+    };
 
-    result = PdmUiNumberFormat::valueToText( 0.0, NumberFormatType::FIXED, 3 );
-    EXPECT_EQ( result.toStdString(), "0.000" );
+    // clang-format off
+    std::vector<TestCase> testCases = {
+        // Fixed format
+        { 3.14159,      "3.14",         NumberFormatType::FIXED,      2 },
+        { 0.0,          "0.000",        NumberFormatType::FIXED,      3 },
+        { -1.5,         "-1.5",         NumberFormatType::FIXED,      1 },
+        { 1.0 / 3.0,   "0.33333333",    NumberFormatType::FIXED,      8 },
+        { 3.7,          "4",            NumberFormatType::FIXED,      0 },
+        { -2.3,         "-2",           NumberFormatType::FIXED,      0 },
+        { 1234567.89,   "1234567.89",   NumberFormatType::FIXED,      2 },
 
-    result = PdmUiNumberFormat::valueToText( -1.5, NumberFormatType::FIXED, 1 );
-    EXPECT_EQ( result.toStdString(), "-1.5" );
-}
+        // Scientific format
+        { 1000.0,       "1.00e+03",     NumberFormatType::SCIENTIFIC, 2 },
+        { 0.001,        "1.0e-03",      NumberFormatType::SCIENTIFIC, 1 },
+        { -5.67e8,      "-5.670e+08",   NumberFormatType::SCIENTIFIC, 3 },
+        { 1.23e-10,     "1.23e-10",     NumberFormatType::SCIENTIFIC, 2 },
 
-TEST( PdmUiNumberFormatTest, ValueToTextScientific )
-{
-    QString result = PdmUiNumberFormat::valueToText( 1000.0, NumberFormatType::SCIENTIFIC, 2 );
-    EXPECT_EQ( result.toStdString(), "1.00e+03" );
+        // Auto format
+        { 42.0,         "42",           NumberFormatType::AUTO,       6 },
+        { 0.000123,     "0.000123",     NumberFormatType::AUTO,       3 },
+        { 0.0000001,    "1e-07",        NumberFormatType::AUTO,       3 },
+        { 1.23456e8,    "1.235e+08",    NumberFormatType::AUTO,       4 },
+        { 3.14159265,   "3.1",          NumberFormatType::AUTO,       2 },
+        { 3.14159265,   "3.14159",      NumberFormatType::AUTO,       6 },
+    };
+    // clang-format on
 
-    result = PdmUiNumberFormat::valueToText( 0.001, NumberFormatType::SCIENTIFIC, 1 );
-    EXPECT_EQ( result.toStdString(), "1.0e-03" );
-}
-
-TEST( PdmUiNumberFormatTest, ValueToTextAuto )
-{
-    QString result = PdmUiNumberFormat::valueToText( 42.0, NumberFormatType::AUTO, 6 );
-    EXPECT_EQ( result.toStdString(), "42" );
-}
-
-TEST( PdmUiNumberFormatTest, SprintfFormatFixed )
-{
-    QString result = PdmUiNumberFormat::sprintfFormat( NumberFormatType::FIXED, 3 );
-    EXPECT_EQ( result.toStdString(), "%.3f" );
-}
-
-TEST( PdmUiNumberFormatTest, SprintfFormatScientific )
-{
-    QString result = PdmUiNumberFormat::sprintfFormat( NumberFormatType::SCIENTIFIC, 2 );
-    EXPECT_EQ( result.toStdString(), "%.2e" );
-}
-
-TEST( PdmUiNumberFormatTest, SprintfFormatAuto )
-{
-    QString result = PdmUiNumberFormat::sprintfFormat( NumberFormatType::AUTO, 4 );
-    EXPECT_EQ( result.toStdString(), "%.4g" );
+    for ( const auto& tc : testCases )
+    {
+        QString result = PdmUiNumberFormat::valueToText( tc.value, tc.format, tc.precision );
+        EXPECT_EQ( result.toStdString(), tc.expected )
+            << "Failed for value=" << tc.value << " format=" << static_cast<int>( tc.format )
+            << " precision=" << tc.precision;
+    }
 }


### PR DESCRIPTION
### **User description**
Refactors the double value editor configuration and enhances validation in field editors.

- Replaces the custom `PdmUiDoubleValueEditorAttribute` with the standard `setRange()` and `setAttribute()` methods for more straightforward configuration.
- Moves number formatting functionality to `cafPdmUiNumberFormat`, improving code organization.
- Enhances validation error handling by displaying tooltips and icons within field editors.
- Adds support for range validation to `pair` fields, ensuring data integrity.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Migrates number formatting from application layer to CAF framework
  - Moves `RiaNumberFormat` to `cafPdmUiNumberFormat` in CAF
  - Updates all references across application code

- Refactors double value editor configuration using map-based attributes
  - Replaces custom `PdmUiDoubleValueEditorAttribute` with `setAttribute()` calls
  - Removes `QDoubleValidator` dependency from editor
  - Simplifies configuration in constructors using `setRange()` and `setAttribute()`

- Adds range validation support for `pair<bool, double>` fields
  - Implements validation on the numeric component of pair fields
  - Supports `setRange()`, `setMinValue()`, `setMaxValue()` for pair types

- Improves validation error handling in field editors
  - Displays warning icons and tooltips for validation errors
  - Handles composite editor widgets (checkbox + line edit)
  - Defers tooltip display to avoid dismissal by key events


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RiaNumberFormat<br/>Application Layer"] -->|Migrate| B["cafPdmUiNumberFormat<br/>CAF Framework"]
  C["PdmUiDoubleValueEditorAttribute<br/>Custom Attribute Class"] -->|Replace| D["setAttribute/setRange<br/>Map-based Configuration"]
  E["QDoubleValidator<br/>Qt Validator"] -->|Remove| F["Range Validation<br/>in PdmDataValueField"]
  G["Double Fields"] -->|Support| H["pair&lt;bool, double&gt;<br/>Range Validation"]
  I["Field Editors"] -->|Improve| J["Validation Error UI<br/>Icons & Tooltips"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>RiaNumberFormat.h</strong><dd><code>Remove deprecated number format header</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-aae918fd53f6b23523d49e4fc27d1f17ab5b673372adea27e8d8f231d4ec7577">+0/-38</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RiaNumberFormat.cpp</strong><dd><code>Remove deprecated number format implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-942d9f2bb258e52c6c36659daa094ee3f5e38e27bd290791392192f2e32ce8bd">+0/-69</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>35 files</summary><table>
<tr>
  <td><strong>cafPdmUiNumberFormat.h</strong><dd><code>Add CAF number format header with enum and utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-247604014578d942e5e5deab3f4651f30ab0a7de583fb496add038bf950d6ae9">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiNumberFormat.cpp</strong><dd><code>Implement CAF number format conversion functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-b53ab2231f10b1bee85500c6b84bbf60889c267d6dfb4b80f451f3bebc4b5de0">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiDoubleValueEditor.h</strong><dd><code>Remove custom attribute class and validator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-21beb23bc8ea61886a3bf9ac7e074a53e0f462fc94d235c9ce168e65ec72cbf7">+1/-42</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiDoubleValueEditor.cpp</strong><dd><code>Refactor to use map-based attributes instead of custom class</code></dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-06e6cac9e9e32ea6e0adb1d032fb85cba5e423cb45350b8afa5dc62ba54f072c">+7/-26</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiCheckBoxAndTextEditor.h</strong><dd><code>Add attribute keys and supported attributes set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-c07f4387d450b3c07be7dbea921c9ec21c772919213ca9eb78daf967c7160b24">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmUiCheckBoxAndTextEditor.cpp</strong><dd><code>Implement number format support for checkbox+text editor</code>&nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-6be3d705547f21a3342c3bb4f1231b52b617ca332bb4ad914834824508dd3e3b">+32/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmDataValueField.h</strong><dd><code>Add range validation for pair<bool, arithmetic> fields</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-c0c5a4a8b4a6854a11335fc565d2fc7f838fdf61440f6c95644e9cc8c6525bed">+74/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RivContourMapProjectionPartMgr.h</strong><dd><code>Update to use CAF number format type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-52bf6b30ce8152bdfd75a9fecffff41538de7ab8362d99371e785f4c3728ac5b">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RivContourMapProjectionPartMgr.cpp</strong><dd><code>Replace RiaNumberFormat with cafPdmUiNumberFormat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-08a8059bf945b9535987487de98a40b61b78091561000dc9933d5a67ea86779b">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimRegularLegendConfig.h</strong><dd><code>Update to use CAF number format type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-74587e5147f4329c6a310e219d4227f4b18c54ceb96c73a21633a8d2abae157d">+14/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RimRegularLegendConfig.cpp</strong><dd><code>Replace RiaNumberFormat with cafPdmUiNumberFormat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-249e876b25662f17f4edd99c6d6783316b836f3cb9ffd7888bd833ce80c5f69f">+9/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimEnsembleFractureStatistics.cpp</strong><dd><code>Replace RiaNumberFormat with cafPdmUiNumberFormat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-780bc6de8781b72fa09357b412dd635f9564f0e042e30f7b3cc4d1c61fd502c6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimStimPlanFractureTemplate.cpp</strong><dd><code>Replace RiaNumberFormat with cafPdmUiNumberFormat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-6fe1e4266c965114321db0bc37d6b8989a7e1c66c9543c988e5ff4f653e615d8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RigEnsembleFractureStatisticsCalculator.h</strong><dd><code>Update to use CAF number format type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-2890ce875dd39ba47362d7a51174e644ac2d77833d9d1f170e70334200b9f46c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RigEnsembleFractureStatisticsCalculator.cpp</strong><dd><code>Replace RiaNumberFormat with cafPdmUiNumberFormat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-b6c83eded1a90567745f4a55f588dfb81867cda904bec50a7a602ddfae306297">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimGeoMechCase.cpp</strong><dd><code>Refactor to use setAttribute and setRange for validation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-be83aec068d7dfb770cd5544845fd2038376e27675b56aa766d02086bd6ff2ae">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimGeoMechResultDefinition.cpp</strong><dd><code>Refactor to use setAttribute and setRange for validation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-18c74d78124f318d623b3c24388870ef669ea6f40033e73ad9b2b323b4b41749">+4/-16</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimGeoMechResultDefinition.h</strong><dd><code>Remove defineEditorAttribute override method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-028160deefa3b1db0143e3a8535c7522434e3c9448438151acd3f2bb02f2d86a">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimGridCrossPlotRegressionCurve.cpp</strong><dd><code>Refactor to use setAttribute for number format configuration</code></dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-28184f43c381133ec6028790671926f6e0e5d54bbbfa692fbfb860fc4fbec432">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimDepthTrackPlot.cpp</strong><dd><code>Refactor to use setAttribute and setRange for validation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-9a1fa90e4704a751ca789bd39831cfcf826b15dfe0f9ab6f3cda8f35f93eccf4">+6/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimDepthTrackPlot.h</strong><dd><code>Remove defineEditorAttribute override method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-b40d9deb4f0bbbf4f89515a35bead6e9fd0284fda280fc2890ff9a9948d9ec60">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimMudWeightWindowParameters.cpp</strong><dd><code>Refactor to use setRange for validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-7b42d84543f1ca20da985c174a4c61bbb1d3451b528a1ebfcaa4152d8e4eecbb">+2/-17</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimMudWeightWindowParameters.h</strong><dd><code>Remove defineEditorAttribute override method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-9a9fba059086446c3f52fb44b02cd26eee029caee08ca9470738d3d47a67d7cf">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimNonNetLayers.cpp</strong><dd><code>Refactor to use setRange for validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-7dc4465b85e8a15f6fc2aa46cfa426e7aec9de810c1c57e541eace37368a029b">+1/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimNonNetLayers.h</strong><dd><code>Remove defineEditorAttribute override method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-f5e86da248f80db924814de377ecc204fda9dc13c2e2504d6d6efb3cbc2640c4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimStimPlanModel.cpp</strong><dd><code>Refactor to use setAttribute for number format configuration</code></dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-f2ec778c9637d769fe222b82f377881c38bf285a23eedfee00e35789479c250a">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimStimPlanModelTemplate.cpp</strong><dd><code>Refactor to use setAttribute for number format configuration</code></dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-a67b5b77ec1445dd6849c9d0dbdd9499ff25d87ea9297f31b126276596dc3248">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimSummaryMultiPlot.cpp</strong><dd><code>Replace RiaNumberFormat with cafPdmUiNumberFormat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-da3d1cc16d0b85881829bce34b38479a81e172aaffa14db775c8db28e9cdb513">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimSummaryPlotAxisFormatter.cpp</strong><dd><code>Remove RiaNumberFormat include</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-83a37ed420884772f4970ef59c9c6d3ad47b737291c1bb26514fbd1750f16fd9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimDepthSurface.cpp</strong><dd><code>Refactor to use setAttribute for number format configuration</code></dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-03f8ae713c4019a36245ef16cc32f8289fb02714154406354476a09432d7424a">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimWellMeasurementInView.cpp</strong><dd><code>Refactor to use setAttribute and setRange for validation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-c2682bc8854a62c9063e6170fb303c4347ec55759dcbbe1b3fcc5e41d8a43729">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RimWellPathGeometryDef.cpp</strong><dd><code>Refactor to use setAttribute and setRange for validation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-c89cda20a5422dde3e7fb7174e08484818961f0716a9bfbe1cc833e357ed538e">+4/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RiuFemTimeHistoryResultAccessor.cpp</strong><dd><code>Replace RiaNumberFormat with cafPdmUiNumberFormat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-cac719249bfe88fdc36faa0519e96502a74c950ffc34fa7ab505ea256f5739fc">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RiuScalarMapperLegendFrame.h</strong><dd><code>Update to use CAF number format type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-f88aae08f3f8609d93a65a1f9a1b98f353527a20270d7d1dc27001543387d6b3">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RiuScalarMapperLegendFrame.cpp</strong><dd><code>Replace RiaNumberFormat with cafPdmUiNumberFormat</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-69cd2884facdcdee4bd6f037fb07a0c9fd8fa5d05d7d332fe548249598d97424">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>cafPdmUiNumberFormatTest.cpp</strong><dd><code>Add unit tests for number format functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-1d5dc118efe0c189b25fd4f8d5b52b7ced3ccf80521eadec1d8843f37c96a32b">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cafPdmCoreBasicTest.cpp</strong><dd><code>Add comprehensive tests for pair<bool, double> range validation</code></dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-c570f686577b05e5b7f9c574ee171a0bc80d00e17c98738985bfef3856e1fc50">+68/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ValidationTest.h</strong><dd><code>Add toggle double field to validation test object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-9affdf84c42b4622c3e636a3be978d05d801d487342e9d0e4aba0c24064a303b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ValidationTest.cpp</strong><dd><code>Initialize toggle double field with range validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-bb333d0d08745e9400e01732b9474adefee0c1afba72d5d5e646a35630262561">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>cafPdmUiFieldEditorHandle.cpp</strong><dd><code>Improve validation error icon and tooltip handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-351c2dfe97c00feb9a67863e9cf84cb128ab251112f451be420ac871b2d9192a">+33/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>CMakeLists_files.cmake</strong><dd><code>Remove RiaNumberFormat from build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-85e8ef82e62d2136b16e21e90bbc85a4f97c0ed31afd9c0a393646b9cd793fbc">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CMakeLists.txt</strong><dd><code>Add cafPdmUiNumberFormat to build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-c9ee08cba1702bf23ce62f25e50f3ee6da4bdfdb1782bb44b2427e949adf0f51">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CMakeLists.txt</strong><dd><code>Add number format unit test to build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/679/files#diff-8e906cb7ca94ab300b0316e9433b234734fafe469595efbb521f804a0d00f428">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

