### PR TITLE
Investigation related to custom lateral lengths

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicMswTableDataTools.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicMswTableDataTools.cpp
@@ -26,6 +26,7 @@
 
 #include "Well/RigWellPath.h"
 
+#include "RimCustomSegmentIntervalCollection.h"
 #include "RimMswCompletionParameters.h"
 #include "RimPerforationInterval.h"
 #include "RimWellPath.h"
@@ -197,8 +198,11 @@ void RicMswTableDataTools::collectWelsegsSegment( RigMswTableData&              
     double startMD = segment->startMD();
     double endMD   = segment->endMD();
 
+    auto lateral   = branch->wellPath();
+    auto intervals = lateral->completionSettings()->mswCompletionParameters()->getSegmentIntervals();
+
     std::vector<std::pair<double, double>> segments =
-        RicMswTableDataTools::createSubSegmentMDPairs( startMD, endMD, maxSegmentLength, customSegmentIntervals );
+        RicMswTableDataTools::createSubSegmentMDPairs( startMD, endMD, maxSegmentLength, intervals );
 
     CVF_ASSERT( branch->wellPath() );
 

--- a/ApplicationLibCode/ProjectDataModel/Completions/RimMswCompletionParameters.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Completions/RimMswCompletionParameters.cpp
@@ -524,12 +524,6 @@ void RimMswCompletionParameters::defineUiOrdering( QString uiConfigName, caf::Pd
 
             uiOrdering.add( &m_pressureDrop );
             uiOrdering.add( &m_lengthAndDepth );
-
-            // Custom Segment Configuration section
-            auto* segmentConfigGroup = uiOrdering.addNewGroup( "Custom Segment Configuration" );
-            segmentConfigGroup->add( &m_enforceMaxSegmentLength );
-            segmentConfigGroup->add( &m_maxSegmentLength );
-            segmentConfigGroup->add( &m_customSegmentIntervals->intervalsField() );
         }
         else
         {
@@ -561,6 +555,12 @@ void RimMswCompletionParameters::defineUiOrdering( QString uiConfigName, caf::Pd
             m_diameterRoughnessMode.uiCapability()->setUiReadOnly( isReadOnly );
             m_diameterRoughnessIntervals.uiCapability()->setUiReadOnly( isReadOnly );
         }
+
+        // Custom Segment Configuration section
+        auto* segmentConfigGroup = uiOrdering.addNewGroup( "Custom Segment Configuration" );
+        segmentConfigGroup->add( &m_enforceMaxSegmentLength );
+        segmentConfigGroup->add( &m_maxSegmentLength );
+        segmentConfigGroup->add( &m_customSegmentIntervals->intervalsField() );
     }
 
     uiOrdering.skipRemainingFields( true );


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactor custom segment intervals retrieval from parameters

- Move segment configuration UI section outside conditional block

- Use well path completion settings to access segment intervals

- Improve code organization and maintainability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RicMswTableDataTools"] -->|retrieve intervals| B["RimMswCompletionParameters"]
  B -->|access via| C["RigWellPath completionSettings"]
  C -->|get| D["Segment Intervals"]
  E["UI Ordering"] -->|moved outside| F["Conditional Block"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RicMswTableDataTools.cpp</strong><dd><code>Extract segment intervals from well path settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/CompletionExportCommands/RicMswTableDataTools.cpp

<ul><li>Added include for <code>RimCustomSegmentIntervalCollection.h</code><br> <li> Extract segment intervals from lateral well path completion settings<br> <li> Pass retrieved intervals to <code>createSubSegmentMDPairs</code> instead of custom <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/686/files#diff-1d6ec486f2765165d46939651d86cc90467764971241947d4b962a2f081f5a10">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimMswCompletionParameters.cpp</strong><dd><code>Relocate segment configuration UI section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/Completions/RimMswCompletionParameters.cpp

<ul><li>Moved "Custom Segment Configuration" UI section outside the <br>conditional block<br> <li> Relocated segment configuration group definition to apply universally<br> <li> Maintains same UI elements but improves code organization</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/686/files#diff-3711b62b218dab41b2ad210c3d5c04486c6f124d0fb73517c35f183508f1ce9d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

