### PR TITLE
Simplify creation of deck records

### DIFF
--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
@@ -34,6 +34,7 @@
 
 #include "opm/input/eclipse/Deck/DeckKeyword.hpp"
 
+#include <map>
 #include <set>
 
 //--------------------------------------------------------------------------------------------------
@@ -95,16 +96,32 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
                                                        const std::vector<RimWellPath*>& wellPaths,
                                                        const QDateTime&                 date )
 {
+    // Keyword priority order for output
+    static const std::vector<QString> keywordOrder = { "WELSPECS",
+                                                       "COMPORD",
+                                                       "GRUPTREE",
+                                                       "COMPDAT",
+                                                       "COMPLUMP",
+                                                       "WELSEGS",
+                                                       "COMPSEGS",
+                                                       "WCONHIST",
+                                                       "WCONINJH",
+                                                       "WCONPROD",
+                                                       "WCONINJE",
+                                                       "WRFTPLT",
+                                                       "TUNING",
+                                                       "RPTSCHED",
+                                                       "RPTRST",
+                                                       "WSEGVALV",
+                                                       "WSEGAICD" };
+
     QString result;
 
     // Generate DATES keyword
     result += RimKeywordFactory::deckKeywordToString( RimKeywordFactory::datesKeyword( date ) ) + "\n";
 
-    // Collect all output for this date
-    QString welspecsData;
-    QString compdatData;
-    QString mswData;
-    QString wellControlData;
+    // Collect all keyword output into a map keyed by keyword name
+    std::map<QString, QString> keywordBlocks;
 
     for ( auto* well : wellPaths )
     {
@@ -113,47 +130,17 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
         QString welspecsKw = generateWelspecsForWell( timeline, eclipseCase, *well, date );
         if ( !welspecsKw.isEmpty() )
         {
-            welspecsData += welspecsKw;
+            keywordBlocks["WELSPECS"] += welspecsKw;
         }
 
         QString wellCompdat = generateCompdatForWell( timeline, eclipseCase, *well, date );
         if ( !wellCompdat.isEmpty() )
         {
-            compdatData += wellCompdat;
+            keywordBlocks["COMPDAT"] += wellCompdat;
         }
 
-        QString wellMsw = generateMswForWell( timeline, eclipseCase, *well, date );
-        if ( !wellMsw.isEmpty() )
-        {
-            mswData += wellMsw;
-        }
-
-        QString wellControl = generateWellControlForWell( timeline, *well, date );
-        if ( !wellControl.isEmpty() )
-        {
-            wellControlData += wellControl;
-        }
-    }
-
-    // Output collected data
-    if ( !welspecsData.isEmpty() )
-    {
-        result += welspecsData;
-    }
-
-    if ( !compdatData.isEmpty() )
-    {
-        result += compdatData;
-    }
-
-    if ( !mswData.isEmpty() )
-    {
-        result += mswData;
-    }
-
-    if ( !wellControlData.isEmpty() )
-    {
-        result += wellControlData;
+        generateMswForWell( timeline, eclipseCase, *well, date, keywordBlocks );
+        generateWellControlForWell( timeline, *well, date, keywordBlocks );
     }
 
     // Process schedule-level keyword events (not tied to a specific well)
@@ -168,10 +155,30 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
                 QString keywordStr = keywordEvent->generateScheduleKeyword( "" );
                 if ( !keywordStr.isEmpty() )
                 {
-                    result += keywordStr;
-                    result += "\n";
+                    keywordBlocks[keywordEvent->keywordName().toUpper()] += keywordStr + "\n";
                 }
             }
+        }
+    }
+
+    // Output keywords in priority order
+    std::set<QString> emitted;
+    for ( const auto& kw : keywordOrder )
+    {
+        auto it = keywordBlocks.find( kw );
+        if ( it != keywordBlocks.end() && !it->second.isEmpty() )
+        {
+            result += it->second;
+            emitted.insert( kw );
+        }
+    }
+
+    // Output remaining keywords not in priority list
+    for ( const auto& [kw, data] : keywordBlocks )
+    {
+        if ( emitted.find( kw ) == emitted.end() && !data.isEmpty() )
+        {
+            result += data;
         }
     }
 
@@ -250,17 +257,18 @@ QString RicScheduleDataGenerator::generateCompdatForWell( const RimWellEventTime
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline& timeline,
-                                                      RimEclipseCase&             eclipseCase,
-                                                      RimWellPath&                wellPath,
-                                                      const QDateTime&            date )
+void RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline& timeline,
+                                                   RimEclipseCase&             eclipseCase,
+                                                   RimWellPath&                wellPath,
+                                                   const QDateTime&            date,
+                                                   std::map<QString, QString>& keywordBlocks )
 {
     // Check if the well has MSW configured (from any previous tubing events applied via set_timestamp)
     // If MSW is enabled, we should generate WELSEGS/COMPSEGS instead of COMPDAT
     auto* mswParams = wellPath.mswCompletionParameters();
     if ( !mswParams )
     {
-        return QString();
+        return;
     }
 
     // Also check if there are valve or tubing events at this specific date for this well
@@ -286,7 +294,7 @@ QString RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline
     // This ensures wells only appear in schedule sections at their event dates
     if ( !hasMswEvents && !hasPerfEvents )
     {
-        return QString();
+        return;
     }
 
     // Extract MSW data using the existing infrastructure
@@ -298,11 +306,9 @@ QString RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline
                                                                                   RicWellPathExportMswTableData::CompletionType::ALL,
                                                                                   date );
 
-    if ( !mswDataResult.has_value() ) return QString();
+    if ( !mswDataResult.has_value() ) return;
 
     const auto& mswData = mswDataResult.value();
-
-    QString result;
 
     // Generate WELSEGS keyword
     int              maxSegments = 0;
@@ -310,46 +316,41 @@ QString RicScheduleDataGenerator::generateMswForWell( const RimWellEventTimeline
     Opm::DeckKeyword welsegsKw   = RimKeywordFactory::welsegsKeyword( mswData, maxSegments, maxBranches );
     if ( welsegsKw.isDataKeyword() || welsegsKw.size() > 0 )
     {
-        result += RimKeywordFactory::deckKeywordToString( welsegsKw );
-        result += "\n";
+        keywordBlocks["WELSEGS"] += RimKeywordFactory::deckKeywordToString( welsegsKw ) + "\n";
     }
 
     // Generate COMPSEGS keyword
     Opm::DeckKeyword compsegsKw = RimKeywordFactory::compsegsKeyword( mswData );
     if ( compsegsKw.isDataKeyword() || compsegsKw.size() > 0 )
     {
-        result += RimKeywordFactory::deckKeywordToString( compsegsKw );
-        result += "\n";
+        keywordBlocks["COMPSEGS"] += RimKeywordFactory::deckKeywordToString( compsegsKw ) + "\n";
     }
 
     // Generate WSEGVALV keyword (for valve events)
     Opm::DeckKeyword wsegvalvKw = RimKeywordFactory::wsegvalvKeyword( mswData );
     if ( wsegvalvKw.isDataKeyword() || wsegvalvKw.size() > 0 )
     {
-        result += RimKeywordFactory::deckKeywordToString( wsegvalvKw );
-        result += "\n";
+        keywordBlocks["WSEGVALV"] += RimKeywordFactory::deckKeywordToString( wsegvalvKw ) + "\n";
     }
 
     // Generate WSEGAICD keyword (if AICD data present)
     Opm::DeckKeyword wsegaicdKw = RimKeywordFactory::wsegaicdKeyword( mswData );
     if ( wsegaicdKw.isDataKeyword() || wsegaicdKw.size() > 0 )
     {
-        result += RimKeywordFactory::deckKeywordToString( wsegaicdKw );
-        result += "\n";
+        keywordBlocks["WSEGAICD"] += RimKeywordFactory::deckKeywordToString( wsegaicdKw ) + "\n";
     }
-
-    return result;
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RicScheduleDataGenerator::generateWellControlForWell( const RimWellEventTimeline& timeline, const RimWellPath& well, const QDateTime& date )
+void RicScheduleDataGenerator::generateWellControlForWell( const RimWellEventTimeline& timeline,
+                                                           const RimWellPath&          well,
+                                                           const QDateTime&            date,
+                                                           std::map<QString, QString>& keywordBlocks )
 {
     // Get state and control events at this exact date for this well
     auto events = timeline.getEventsAtDate( date );
-
-    QString result;
 
     for ( auto* event : events )
     {
@@ -358,10 +359,28 @@ QString RicScheduleDataGenerator::generateWellControlForWell( const RimWellEvent
         QString keywordStr = RifEventKeywordFormatter::formatWellEvent( event, well.name() );
         if ( !keywordStr.isEmpty() )
         {
-            result += keywordStr;
-            result += "\n";
+            QString kwName = extractKeywordName( keywordStr );
+            if ( !kwName.isEmpty() )
+            {
+                keywordBlocks[kwName] += keywordStr + "\n";
+            }
         }
     }
+}
 
-    return result;
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RicScheduleDataGenerator::extractKeywordName( const QString& block )
+{
+    const auto lines = block.split( '\n' );
+    for ( const auto& line : lines )
+    {
+        QString trimmed = line.trimmed();
+        if ( !trimmed.isEmpty() && !trimmed.startsWith( "--" ) )
+        {
+            return trimmed;
+        }
+    }
+    return {};
 }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp
@@ -101,6 +101,7 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
     result += RimKeywordFactory::deckKeywordToString( RimKeywordFactory::datesKeyword( date ) ) + "\n";
 
     // Collect all output for this date
+    QString welspecsData;
     QString compdatData;
     QString mswData;
     QString wellControlData;
@@ -108,6 +109,12 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
     for ( auto* well : wellPaths )
     {
         if ( !well ) continue;
+
+        QString welspecsKw = generateWelspecsForWell( timeline, eclipseCase, *well, date );
+        if ( !welspecsKw.isEmpty() )
+        {
+            welspecsData += welspecsKw;
+        }
 
         QString wellCompdat = generateCompdatForWell( timeline, eclipseCase, *well, date );
         if ( !wellCompdat.isEmpty() )
@@ -129,6 +136,11 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
     }
 
     // Output collected data
+    if ( !welspecsData.isEmpty() )
+    {
+        result += welspecsData;
+    }
+
     if ( !compdatData.isEmpty() )
     {
         result += compdatData;
@@ -162,6 +174,41 @@ QString RicScheduleDataGenerator::generateDateSection( const RimWellEventTimelin
             }
         }
     }
+
+    return result;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RicScheduleDataGenerator::generateWelspecsForWell( const RimWellEventTimeline& timeline,
+                                                           RimEclipseCase&             eclipseCase,
+                                                           RimWellPath&                well,
+                                                           const QDateTime&            date )
+{
+    // Get perforation events at this exact date for this well
+    auto events = timeline.getEventsAtDate( date );
+
+    bool hasEvents = false;
+    for ( auto* event : events )
+    {
+        if ( ( event->eventType() == RimWellEvent::EventType::PERF || event->eventType() == RimWellEvent::EventType::VALVE ||
+               event->eventType() == RimWellEvent::EventType::TUBING ) &&
+             event->wellName() == well.name() )
+        {
+            hasEvents = true;
+            break;
+        }
+    }
+
+    if ( !hasEvents ) return QString();
+
+    std::string wellGroupName = well.completionSettings()->groupNameForExport().toStdString();
+    auto        welspecsKw    = RimKeywordFactory::welspecsKeyword( wellGroupName, &eclipseCase, &well );
+
+    QString result;
+    result += RimKeywordFactory::deckKeywordToString( welspecsKw );
+    result += "\n";
 
     return result;
 }

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
@@ -21,6 +21,7 @@
 #include <QDateTime>
 #include <QString>
 
+#include <map>
 #include <vector>
 
 class RimEclipseCase;
@@ -59,10 +60,19 @@ private:
     static QString
         generateCompdatForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );
 
-    // Generate WELSEGS and COMPSEGS for a well at a specific date
-    static QString
-        generateMswForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );
+    // Generate WELSEGS and COMPSEGS for a well at a specific date, populating keyword blocks map
+    static void generateMswForWell( const RimWellEventTimeline& timeline,
+                                    RimEclipseCase&             eclipseCase,
+                                    RimWellPath&                well,
+                                    const QDateTime&            date,
+                                    std::map<QString, QString>& keywordBlocks );
 
-    // Generate well control keywords (WCONPROD, WCONINJE, WELOPEN) for a well at a specific date
-    static QString generateWellControlForWell( const RimWellEventTimeline& timeline, const RimWellPath& well, const QDateTime& date );
+    // Generate well control keywords (WCONPROD, WCONINJE, WELOPEN) for a well at a specific date, populating keyword blocks map
+    static void generateWellControlForWell( const RimWellEventTimeline& timeline,
+                                            const RimWellPath&          well,
+                                            const QDateTime&            date,
+                                            std::map<QString, QString>& keywordBlocks );
+
+    // Extract keyword name from the first non-comment line of a keyword block
+    static QString extractKeywordName( const QString& block );
 };

--- a/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
+++ b/ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h
@@ -52,6 +52,9 @@ private:
                                         const std::vector<RimWellPath*>& wellPaths,
                                         const QDateTime&                 date );
 
+    static QString
+        generateWelspecsForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );
+
     // Generate COMPDAT for a well at a specific date based on events
     static QString
         generateCompdatForWell( const RimWellEventTimeline& timeline, RimEclipseCase& eclipseCase, RimWellPath& well, const QDateTime& date );

--- a/ApplicationLibCode/FileInterface/RifOpmDeckTools.cpp
+++ b/ApplicationLibCode/FileInterface/RifOpmDeckTools.cpp
@@ -19,6 +19,7 @@
 #include "RifOpmDeckTools.h"
 
 #include "opm/input/eclipse/Deck/DeckItem.hpp"
+#include "opm/input/eclipse/Deck/DeckRecord.hpp"
 #include "opm/input/eclipse/Units/Dimension.hpp"
 
 namespace RifOpmDeckTools
@@ -133,6 +134,20 @@ Opm::DeckItem optionalItem( std::string name, std::optional<float> value )
         return item( name, (double)value.value() );
     }
     return defaultItem( name );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+Opm::DeckRecord createRecord( std::initializer_list<NamedValue> namedValues )
+{
+    std::vector<Opm::DeckItem> items;
+    items.reserve( namedValues.size() );
+    for ( const auto& nv : namedValues )
+    {
+        items.push_back( std::visit( [&nv]( const auto& val ) { return RifOpmDeckTools::item( nv.name, val ); }, nv.value ) );
+    }
+    return Opm::DeckRecord{ std::move( items ) };
 }
 
 } // namespace RifOpmDeckTools

--- a/ApplicationLibCode/FileInterface/RifOpmDeckTools.h
+++ b/ApplicationLibCode/FileInterface/RifOpmDeckTools.h
@@ -47,12 +47,36 @@ struct NamedValue
     std::string                            name;
     std::variant<std::string, int, double> value;
 
-    NamedValue( std::string n, std::string v ) : name( std::move( n ) ), value( std::move( v ) ) {}
-    NamedValue( std::string n, const char* v ) : name( std::move( n ) ), value( std::string( v ) ) {}
-    NamedValue( std::string n, int v ) : name( std::move( n ) ), value( v ) {}
-    NamedValue( std::string n, size_t v ) : name( std::move( n ) ), value( (int)v ) {}
-    NamedValue( std::string n, double v ) : name( std::move( n ) ), value( v ) {}
-    NamedValue( std::string n, float v ) : name( std::move( n ) ), value( (double)v ) {}
+    NamedValue( std::string n, std::string v )
+        : name( std::move( n ) )
+        , value( std::move( v ) )
+    {
+    }
+    NamedValue( std::string n, const char* v )
+        : name( std::move( n ) )
+        , value( std::string( v ) )
+    {
+    }
+    NamedValue( std::string n, int v )
+        : name( std::move( n ) )
+        , value( v )
+    {
+    }
+    NamedValue( std::string n, size_t v )
+        : name( std::move( n ) )
+        , value( (int)v )
+    {
+    }
+    NamedValue( std::string n, double v )
+        : name( std::move( n ) )
+        , value( v )
+    {
+    }
+    NamedValue( std::string n, float v )
+        : name( std::move( n ) )
+        , value( (double)v )
+    {
+    }
 };
 
 Opm::DeckRecord createRecord( std::initializer_list<NamedValue> items );

--- a/ApplicationLibCode/FileInterface/RifOpmDeckTools.h
+++ b/ApplicationLibCode/FileInterface/RifOpmDeckTools.h
@@ -44,6 +44,7 @@ Opm::DeckItem defaultItem( std::string name );
 
 struct NamedValue
 {
+    // Test
     std::string                            name;
     std::variant<std::string, int, double> value;
 

--- a/ApplicationLibCode/FileInterface/RifOpmDeckTools.h
+++ b/ApplicationLibCode/FileInterface/RifOpmDeckTools.h
@@ -18,12 +18,15 @@
 
 #pragma once
 
+#include <initializer_list>
 #include <optional>
 #include <string>
+#include <variant>
 
 namespace Opm
 {
 class DeckItem;
+class DeckRecord;
 } // namespace Opm
 
 namespace RifOpmDeckTools
@@ -38,5 +41,20 @@ Opm::DeckItem item( std::string name, double value );
 Opm::DeckItem optionalItem( std::string name, std::optional<float> value );
 Opm::DeckItem optionalItem( std::string name, std::optional<double> value );
 Opm::DeckItem defaultItem( std::string name );
+
+struct NamedValue
+{
+    std::string                            name;
+    std::variant<std::string, int, double> value;
+
+    NamedValue( std::string n, std::string v ) : name( std::move( n ) ), value( std::move( v ) ) {}
+    NamedValue( std::string n, const char* v ) : name( std::move( n ) ), value( std::string( v ) ) {}
+    NamedValue( std::string n, int v ) : name( std::move( n ) ), value( v ) {}
+    NamedValue( std::string n, size_t v ) : name( std::move( n ) ), value( (int)v ) {}
+    NamedValue( std::string n, double v ) : name( std::move( n ) ), value( v ) {}
+    NamedValue( std::string n, float v ) : name( std::move( n ) ), value( (double)v ) {}
+};
+
+Opm::DeckRecord createRecord( std::initializer_list<NamedValue> items );
 
 } // namespace RifOpmDeckTools

--- a/ApplicationLibCode/ProjectDataModel/Jobs/RimKeywordFactory.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Jobs/RimKeywordFactory.cpp
@@ -209,14 +209,13 @@ Opm::DeckKeyword complumpKeyword( const std::vector<RigCompletionData>& compdata
         {
             continue;
         }
-        std::vector<Opm::DeckItem> items;
-        items.push_back( RifOpmDeckTools::item( C::WELL::itemName, wellName ) );
-        items.push_back( RifOpmDeckTools::item( C::I::itemName, cd.completionDataGridCell().localCellIndexI() + 1 ) );
-        items.push_back( RifOpmDeckTools::item( C::J::itemName, cd.completionDataGridCell().localCellIndexJ() + 1 ) );
-        items.push_back( RifOpmDeckTools::item( C::K1::itemName, cd.completionDataGridCell().localCellIndexK() + 1 ) );
-        items.push_back( RifOpmDeckTools::item( C::K2::itemName, cd.completionDataGridCell().localCellIndexK() + 1 ) );
-        items.push_back( RifOpmDeckTools::item( C::N::itemName, cd.completionNumber().value() ) );
-        kw.addRecord( Opm::DeckRecord{ std::move( items ) } );
+        kw.addRecord( RifOpmDeckTools::createRecord( {
+            { C::WELL::itemName, wellName },
+            { C::I::itemName, cd.completionDataGridCell().localCellIndexI() + 1 },
+            { C::J::itemName, cd.completionDataGridCell().localCellIndexJ() + 1 },
+            { C::K1::itemName, cd.completionDataGridCell().localCellIndexK() + 1 },
+            { C::K2::itemName, cd.completionDataGridCell().localCellIndexK() + 1 },
+            { C::N::itemName, cd.completionNumber().value() } } ) );
     }
     return kw;
 }

--- a/ApplicationLibCode/ProjectDataModel/Jobs/RimKeywordFactory.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Jobs/RimKeywordFactory.cpp
@@ -209,13 +209,12 @@ Opm::DeckKeyword complumpKeyword( const std::vector<RigCompletionData>& compdata
         {
             continue;
         }
-        kw.addRecord( RifOpmDeckTools::createRecord( {
-            { C::WELL::itemName, wellName },
-            { C::I::itemName, cd.completionDataGridCell().localCellIndexI() + 1 },
-            { C::J::itemName, cd.completionDataGridCell().localCellIndexJ() + 1 },
-            { C::K1::itemName, cd.completionDataGridCell().localCellIndexK() + 1 },
-            { C::K2::itemName, cd.completionDataGridCell().localCellIndexK() + 1 },
-            { C::N::itemName, cd.completionNumber().value() } } ) );
+        kw.addRecord( RifOpmDeckTools::createRecord( { { C::WELL::itemName, wellName },
+                                                       { C::I::itemName, cd.completionDataGridCell().localCellIndexI() + 1 },
+                                                       { C::J::itemName, cd.completionDataGridCell().localCellIndexJ() + 1 },
+                                                       { C::K1::itemName, cd.completionDataGridCell().localCellIndexK() + 1 },
+                                                       { C::K2::itemName, cd.completionDataGridCell().localCellIndexK() + 1 },
+                                                       { C::N::itemName, cd.completionNumber().value() } } ) );
     }
     return kw;
 }

--- a/GrpcInterface/RiaGrpcWellPathService.cpp
+++ b/GrpcInterface/RiaGrpcWellPathService.cpp
@@ -89,8 +89,7 @@ void populateReply( RimEclipseCase* eclipseCase, RimWellPath* wellPath, ::rips::
 
     // Multisegment wells
 
-    int  timeStep         = 0;
-    auto mswDataContainer = RicWellPathExportMswTableData::extractSingleWellMswData( eclipseCase, wellPath, timeStep );
+    auto mswDataContainer = RicWellPathExportMswTableData::extractSingleWellMswData( eclipseCase, wellPath );
     if ( mswDataContainer.has_value() )
     {
         auto tables = mswDataContainer.value();


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactor schedule keyword generation to emit keywords in priority order
  - Collect all keywords into map, then output in defined sequence (WELSPECS, COMPORD, GRUPTREE, etc.)

- Add WELSPECS keyword generation for wells with perforation/valve/tubing events

- Simplify DeckRecord creation with new `createRecord()` helper and `NamedValue` struct
  - Enables one-liner typed record construction via initializer lists

- Fix implicit int-to-bool conversion in gRPC MSW export by removing stale timeStep parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Schedule Generation"] -->|"Collect keywords into map"| B["Keyword Map"]
  B -->|"Sort by priority order"| C["WELSPECS, COMPORD, GRUPTREE..."]
  C -->|"Emit in sequence"| D["Ordered Schedule Output"]
  E["NamedValue Struct"] -->|"Variant over string/int/double"| F["createRecord Helper"]
  F -->|"Dispatch via std::visit"| G["DeckRecord Creation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RicScheduleDataGenerator.cpp</strong><dd><code>Implement keyword priority ordering in schedule generation</code></dd></summary>
<hr>

ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.cpp

<ul><li>Refactored <code>generateDateSection()</code> to collect keyword output into <br><code>std::map<QString, QString></code> keyed by keyword name<br> <li> Added static <code>keywordOrder</code> vector defining priority sequence for <br>keyword emission (WELSPECS, COMPORD, GRUPTREE, COMPDAT, etc.)<br> <li> Implemented two-pass output: first emit keywords in priority order, <br>then append remaining keywords<br> <li> Added new <code>generateWelspecsForWell()</code> method to generate WELSPECS <br>keyword for wells with events<br> <li> Changed <code>generateMswForWell()</code> return type from <code>QString</code> to <code>void</code>, now <br>populates <code>keywordBlocks</code> map directly<br> <li> Changed <code>generateWellControlForWell()</code> return type from <code>QString</code> to <code>void</code>, <br>now populates <code>keywordBlocks</code> map<br> <li> Added <code>extractKeywordName()</code> helper to parse keyword name from first <br>non-comment line</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/693/files#diff-fd1b328ba7d75c4710870afbf95ff35e65d113e6127c3db9fe43a8920ab48ac8">+124/-58</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RifOpmDeckTools.h</strong><dd><code>Add NamedValue struct and createRecord helper function</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/FileInterface/RifOpmDeckTools.h

<ul><li>Added <code>NamedValue</code> struct with variant over <code>std::string</code>, <code>int</code>, and <code>double</code> <br>types<br> <li> Implemented multiple constructors for <code>NamedValue</code> to support common <br>type conversions (string, const char*, int, size_t, double, float)<br> <li> Added <code>createRecord()</code> function that accepts <code>std::initializer_list<NamedValue></code> and <br>returns <code>Opm::DeckRecord</code><br> <li> Added necessary includes: <code><initializer_list></code> and <code><variant></code><br> <li> Added forward declaration for <code>Opm::DeckRecord</code></ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/693/files#diff-f226b5f9c1d9118a6c0c6592ce282d4622f9b879bdaa809798b255c00d214c46">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RifOpmDeckTools.cpp</strong><dd><code>Implement createRecord function with variant dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/FileInterface/RifOpmDeckTools.cpp

<ul><li>Implemented <code>createRecord()</code> function that converts <br><code>std::initializer_list<NamedValue></code> to <code>Opm::DeckRecord</code><br> <li> Uses <code>std::visit</code> to dispatch variant values to appropriate <code>item()</code> <br>overloads<br> <li> Reserves vector capacity for efficiency<br> <li> Added include for <code>DeckRecord.hpp</code></ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/693/files#diff-7a7599ba50a4abe83f45f3657d0ff509e75f5b035635e55d2d9c9a44dfbb3c2e">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimKeywordFactory.cpp</strong><dd><code>Simplify COMPLUMP keyword record creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/Jobs/RimKeywordFactory.cpp

<ul><li>Refactored <code>complumpKeyword()</code> inner loop to use new <code>createRecord()</code> <br>helper<br> <li> Replaced manual vector construction and item pushing with single <br><code>createRecord()</code> call using initializer list<br> <li> Demonstrates simplified one-liner DeckRecord construction pattern</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/693/files#diff-585d5e432b77588c8b4a73db0807cbf6d65f2181663a821072520cd170787b1f">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RicScheduleDataGenerator.h</strong><dd><code>Update method signatures for keyword map population</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/CompletionExportCommands/RicScheduleDataGenerator.h

<ul><li>Updated function signatures for <code>generateMswForWell()</code> and <br><code>generateWellControlForWell()</code> to return <code>void</code> instead of <code>QString</code><br> <li> Added <code>std::map<QString, QString>&</code> parameter to both functions for <br>populating keyword blocks<br> <li> Added new <code>generateWelspecsForWell()</code> method declaration<br> <li> Added <code>extractKeywordName()</code> helper method declaration<br> <li> Added <code><map></code> include</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/693/files#diff-2d6533f7f08358adb7e706150d9f5d766e23627fd70eb51176363a6c63457465">+18/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RiaGrpcWellPathService.cpp</strong><dd><code>Fix implicit int-to-bool conversion in gRPC MSW export</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

GrpcInterface/RiaGrpcWellPathService.cpp

<ul><li>Removed stale <code>timeStep</code> variable initialization (int timeStep = 0)<br> <li> Fixed implicit int-to-bool conversion by removing timeStep parameter <br>from <code>extractSingleWellMswData()</code> call<br> <li> Function now uses correct default parameters instead of silently <br>converting int to bool</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/693/files#diff-b7fe1334b22b9fd464a8d1fbe5ba7fac91654d09041b260739c60e45521a8223">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

