### PR TITLE
RFT: Fix use of formation colors

### DIFF
--- a/ApplicationLibCode/Commands/RicImportFormationNamesFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportFormationNamesFeature.cpp
@@ -70,26 +70,12 @@ RimFormationNames* RicImportFormationNamesFeature::importFormationFiles( const Q
     std::vector<RimFormationNames*> formationNames = fomNameColl->importFiles( fileNames );
     fomNameColl->updateConnectedEditors();
 
-    for ( int i = 0; i < fileNames.size(); i++ )
+    RimColorLegendCollection* colorLegendCollection = proj->colorLegendCollection;
+    for ( auto* fmNames : formationNames )
     {
-        auto colors = formationNames[i]->formationNamesData()->formationColors();
-
-        bool anyValidColor = false;
-        for ( const auto& color : colors )
-        {
-            if ( color.isValid() )
-            {
-                anyValidColor = true;
-                break;
-            }
-        }
-
-        if ( anyValidColor )
-        {
-            QString baseName = QFileInfo( fileNames[i] ).baseName();
-            RicImportFormationNamesFeature::addCustomColorLegend( baseName, formationNames[i] );
-        }
+        colorLegendCollection->createColorLegendFromFormationNames( fmNames );
     }
+    colorLegendCollection->updateConnectedEditors();
 
     if ( !formationNames.empty() ) return formationNames.back();
 
@@ -163,16 +149,6 @@ void RicImportFormationNamesFeature::setupActionLook( QAction* actionToSetup )
 {
     actionToSetup->setIcon( QIcon( ":/FormationCollection16x16.png" ) );
     actionToSetup->setText( "Import Formations" );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RicImportFormationNamesFeature::addCustomColorLegend( QString& name, RimFormationNames* rimFormationNames )
-{
-    RimColorLegendCollection* colorLegendCollection = RimProject::current()->colorLegendCollection;
-    colorLegendCollection->createColorLegendFromFormationNames( rimFormationNames );
-    colorLegendCollection->updateConnectedEditors();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/RicImportFormationNamesFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportFormationNamesFeature.cpp
@@ -170,32 +170,8 @@ void RicImportFormationNamesFeature::setupActionLook( QAction* actionToSetup )
 //--------------------------------------------------------------------------------------------------
 void RicImportFormationNamesFeature::addCustomColorLegend( QString& name, RimFormationNames* rimFormationNames )
 {
-    RigFormationNames* rigFormationNames = rimFormationNames->formationNamesData();
-    if ( !rigFormationNames ) return;
-
-    const std::vector<QString>&      formationNames  = rigFormationNames->formationNames();
-    const std::vector<cvf::Color3f>& formationColors = rigFormationNames->formationColors();
-
-    // return if no formation names or colors (latter e.g. in case of FMU input or LYR without colors)
-    if ( formationNames.empty() || formationColors.empty() ) return;
-
-    auto* colorLegend = new RimColorLegend;
-    colorLegend->setColorLegendName( name );
-
-    for ( size_t i = 0; i < formationColors.size(); i++ )
-    {
-        auto* colorLegendItem = new RimColorLegendItem;
-
-        colorLegendItem->setValues( formationNames[i], (int)i, formationColors[i] );
-
-        colorLegend->appendColorLegendItem( colorLegendItem );
-    }
-
-    RimProject* proj = RimProject::current();
-
-    RimColorLegendCollection* colorLegendCollection = proj->colorLegendCollection;
-
-    colorLegendCollection->appendCustomColorLegend( colorLegend );
+    RimColorLegendCollection* colorLegendCollection = RimProject::current()->colorLegendCollection;
+    colorLegendCollection->createColorLegendFromFormationNames( rimFormationNames );
     colorLegendCollection->updateConnectedEditors();
 }
 

--- a/ApplicationLibCode/Commands/RicImportFormationNamesFeature.h
+++ b/ApplicationLibCode/Commands/RicImportFormationNamesFeature.h
@@ -37,7 +37,5 @@ protected:
     void setupActionLook( QAction* actionToSetup ) override;
 
 private:
-    static void addCustomColorLegend( QString& name, RimFormationNames* formationNames );
-
     void setFormationCellResultAndLegend( Rim3dView* activeView, QString& legendName );
 };

--- a/ApplicationLibCode/ProjectDataModel/Formations/RimFormationNames.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Formations/RimFormationNames.cpp
@@ -105,10 +105,10 @@ QString RimFormationNames::fileName()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-QString RimFormationNames::fileNameWoPath()
+QString RimFormationNames::shortName()
 {
     QFileInfo fnameFileInfo( m_formationNamesFileName().path() );
-    return fnameFileInfo.fileName();
+    return fnameFileInfo.baseName();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -159,5 +159,5 @@ QString RimFormationNames::layerZoneTableFileName()
 //--------------------------------------------------------------------------------------------------
 void RimFormationNames::updateUiTreeName()
 {
-    uiCapability()->setUiName( fileNameWoPath() );
+    uiCapability()->setUiName( shortName() );
 }

--- a/ApplicationLibCode/ProjectDataModel/Formations/RimFormationNames.h
+++ b/ApplicationLibCode/ProjectDataModel/Formations/RimFormationNames.h
@@ -38,7 +38,7 @@ public:
 
     void    setFileName( const QString& fileName );
     QString fileName();
-    QString fileNameWoPath();
+    QString shortName();
 
     RigFormationNames* formationNamesData() { return m_formationNamesData.p(); }
     void               updateConnectedViews();

--- a/ApplicationLibCode/ProjectDataModel/Formations/RimFormationNamesCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Formations/RimFormationNamesCollection.cpp
@@ -20,7 +20,9 @@
 
 #include "RiaLogging.h"
 #include "RimCase.h"
+#include "RimColorLegendCollection.h"
 #include "RimFormationNames.h"
+#include "RimProject.h"
 
 CAF_PDM_SOURCE_INIT( RimFormationNamesCollection, "FormationNamesCollectionObject" );
 
@@ -44,6 +46,7 @@ void RimFormationNamesCollection::readAllFormationNames()
     for ( RimFormationNames* fmNames : m_formationNamesList )
     {
         fmNames->readFormationNamesFile( nullptr );
+        RimProject::current()->colorLegendCollection->createColorLegendFromFormationNames( fmNames );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/RimCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimCase.cpp
@@ -272,7 +272,7 @@ QList<caf::PdmOptionItemInfo> RimCase::calculateValueOptions( const caf::PdmFiel
         {
             for ( RimFormationNames* fnames : proj->activeOilField()->formationNamesCollection()->formationNamesList() )
             {
-                options.push_back( caf::PdmOptionItemInfo( fnames->fileNameWoPath(), fnames, false, fnames->uiCapability()->uiIconProvider() ) );
+                options.push_back( caf::PdmOptionItemInfo( fnames->shortName(), fnames, false, fnames->uiCapability()->uiIconProvider() ) );
             }
         }
 

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
@@ -236,7 +236,7 @@ void RimColorLegendCollection::createColorLegendFromFormationNames( RimFormation
     }
     if ( !anyValidColor ) return;
 
-    QString legendName = QFileInfo( rimFormationNames->fileName() ).baseName();
+    QString legendName = rimFormationNames->shortName();
 
     // Do not create duplicate legends
     if ( findByName( legendName ) != nullptr ) return;

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
@@ -21,11 +21,15 @@
 #include "RiaColorTables.h"
 #include "RiaFractureDefines.h"
 
+#include "Formations/RimFormationNames.h"
 #include "RimColorLegend.h"
 #include "RimColorLegendItem.h"
 #include "RimProject.h"
 #include "RimRegularLegendConfig.h"
 
+#include "RigFormationNames.h"
+
+#include <QFileInfo>
 #include <QString>
 
 CAF_PDM_SOURCE_INIT( RimColorLegendCollection, "ColorLegendCollection" );
@@ -204,6 +208,50 @@ std::vector<RimColorLegend*> RimColorLegendCollection::allColorLegends() const
     }
 
     return allLegends;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimColorLegendCollection::createColorLegendFromFormationNames( RimFormationNames* rimFormationNames )
+{
+    if ( !rimFormationNames ) return;
+
+    RigFormationNames* rigFormationNames = rimFormationNames->formationNamesData();
+    if ( !rigFormationNames ) return;
+
+    const std::vector<QString>&      formationNames  = rigFormationNames->formationNames();
+    const std::vector<cvf::Color3f>& formationColors = rigFormationNames->formationColors();
+
+    if ( formationNames.empty() || formationColors.empty() ) return;
+
+    bool anyValidColor = false;
+    for ( const auto& color : formationColors )
+    {
+        if ( color.isValid() )
+        {
+            anyValidColor = true;
+            break;
+        }
+    }
+    if ( !anyValidColor ) return;
+
+    QString legendName = QFileInfo( rimFormationNames->fileName() ).baseName();
+
+    // Do not create duplicate legends
+    if ( findByName( legendName ) != nullptr ) return;
+
+    auto* colorLegend = new RimColorLegend;
+    colorLegend->setColorLegendName( legendName );
+
+    for ( size_t i = 0; i < formationColors.size(); i++ )
+    {
+        auto* item = new RimColorLegendItem;
+        item->setValues( formationNames[i], (int)i, formationColors[i] );
+        colorLegend->appendColorLegendItem( item );
+    }
+
+    appendCustomColorLegend( colorLegend );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
@@ -223,6 +223,7 @@ void RimColorLegendCollection::createColorLegendFromFormationNames( RimFormation
     const std::vector<cvf::Color3f>& formationColors = rigFormationNames->formationColors();
 
     if ( formationNames.empty() || formationColors.empty() ) return;
+    if ( formationNames.size() != formationColors.size() ) return;
 
     bool anyValidColor = false;
     for ( const auto& color : formationColors )

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp
@@ -21,15 +21,14 @@
 #include "RiaColorTables.h"
 #include "RiaFractureDefines.h"
 
+#include "RigFormationNames.h"
+
 #include "Formations/RimFormationNames.h"
 #include "RimColorLegend.h"
 #include "RimColorLegendItem.h"
 #include "RimProject.h"
 #include "RimRegularLegendConfig.h"
 
-#include "RigFormationNames.h"
-
-#include <QFileInfo>
 #include <QString>
 
 CAF_PDM_SOURCE_INIT( RimColorLegendCollection, "ColorLegendCollection" );

--- a/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.h
@@ -24,6 +24,7 @@
 
 class RimColorLegend;
 class RimColorLegendItem;
+class RimFormationNames;
 
 namespace caf
 {
@@ -48,6 +49,7 @@ public:
     void deleteCustomColorLegends();
 
     RimColorLegend* createColorLegend( const QString& colorLegendName, const std::map<int, QString>& valuesAndNames );
+    void            createColorLegendFromFormationNames( RimFormationNames* rimFormationNames );
     void            deleteColorLegend( int caseId, const QString& resultName );
     void            setDefaultColorLegendForResult( int caseId, const QString& resultName, RimColorLegend* colorLegend );
 

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseResultCase.cpp
@@ -784,7 +784,7 @@ QList<caf::PdmOptionItemInfo> RimEclipseResultCase::calculateValueOptions( const
             QList<caf::PdmOptionItemInfo> options;
             if ( m_activeFormationNames() )
             {
-                options.push_back( caf::PdmOptionItemInfo( m_activeFormationNames->fileNameWoPath(), m_activeFormationNames(), false ) );
+                options.push_back( caf::PdmOptionItemInfo( m_activeFormationNames->shortName(), m_activeFormationNames(), false ) );
             }
             else
             {

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinitionTools.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinitionTools.cpp
@@ -49,6 +49,8 @@
 
 #include <QString>
 
+#include <map>
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -675,11 +677,29 @@ void RimEclipseResultDefinitionTools::updateCellResultLegend( const RimEclipseRe
             categoryMapper->setCategories( visibleCategoryValues );
             categoryMapper->setInterpolateColors( legendBaseColors );
 
+            // Build a direct value-to-color map from legend items so that LYR-file specified
+            // colors are honored regardless of which categories are visible.
+            // Related to https://github.com/OPM/ResInsight/issues/12974
+            std::map<int, cvf::Color3ub> legendItemColors;
+            for ( auto* item : legendConfigToUpdate->colorLegend()->colorLegendItems() )
+            {
+                legendItemColors[item->categoryValue()] = cvf::Color3ub( item->color() );
+            }
+
             std::vector<std::tuple<QString, int, cvf::Color3ub>> categoryVector;
 
             for ( auto value : visibleCategoryValues )
             {
-                cvf::Color3ub categoryColor = categoryMapper->mapToColor( value );
+                cvf::Color3ub categoryColor;
+                auto          colorIt = legendItemColors.find( value );
+                if ( colorIt != legendItemColors.end() )
+                {
+                    categoryColor = colorIt->second;
+                }
+                else
+                {
+                    categoryColor = categoryMapper->mapToColor( value );
+                }
 
                 QString valueTxt;
                 if ( resultDefinition->resultType() == RiaDefines::ResultCatType::FORMATION_NAMES )

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
@@ -107,6 +107,7 @@
 #include <QWheelEvent>
 
 #include <algorithm>
+#include <map>
 #include <memory>
 #include <set>
 
@@ -2701,23 +2702,41 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
             std::vector<std::pair<double, double>> convertedYValues =
                 RiaWellLogUnitTools<double>::convertDepths( yValues, fromDepthUnit, toDepthUnit );
 
-            // TODO: This is not working as expected, and the colors used are always using the regular legend colors.
-            // The recent refactoring in 93bd0b9c9d768f55c1994385ba431fbbc7a9606f ended up with a nullptr for the color legend in
-            // RimWellLogTrack, which is why we need to fall back to the regular legend colors.
+            // Build color table ordered by formation name to ensure correct color mapping
+            // when using a legend based on a LYR-file. Falls back to palette index for
+            // formations not found in the legend (e.g., when using a generic color palette).
             // Related to https://github.com/OPM/ResInsight/issues/12974
-            cvf::Color3ubArray colors;
-            if ( m_regionAnnotationSettings->colorShadingLegend() )
-            {
-                colors = m_regionAnnotationSettings->colorShadingLegend()->colorArray();
-            }
-            else if ( auto defaultLegend = RimRegularLegendConfig::mapToColorLegend( RimRegularLegendConfig::ColorRangesType::NORMAL ) )
-            {
-                colors = defaultLegend->colorArray();
-            }
+            RimColorLegend* legend = m_regionAnnotationSettings->colorShadingLegend();
+            if ( !legend )
+                legend = RimRegularLegendConfig::mapToColorLegend( RimRegularLegendConfig::ColorRangesType::NORMAL );
 
-            if ( colors.size() > 0 )
+            if ( legend && !formationNamesToPlot.empty() )
             {
-                caf::ColorTable colorTable( colors );
+                std::map<QString, cvf::Color3ub> nameToColor;
+                for ( auto* item : legend->colorLegendItems() )
+                {
+                    nameToColor[item->categoryName()] = cvf::Color3ub( item->color() );
+                }
+
+                cvf::Color3ubArray paletteColors = legend->colorArray();
+                size_t             colorCount    = std::max( size_t( 2 ), formationNamesToPlot.size() );
+                cvf::Color3ubArray orderedColors( colorCount );
+                orderedColors.setAll( cvf::Color3ub::GRAY );
+
+                for ( size_t i = 0; i < formationNamesToPlot.size(); i++ )
+                {
+                    auto it = nameToColor.find( formationNamesToPlot[i] );
+                    if ( it != nameToColor.end() )
+                    {
+                        orderedColors.set( i, it->second );
+                    }
+                    else if ( paletteColors.size() > 0 )
+                    {
+                        orderedColors.set( i, paletteColors[i % paletteColors.size()] );
+                    }
+                }
+
+                caf::ColorTable colorTable( orderedColors );
 
                 m_annotationTool->attachNamedRegions( m_plotWidget->qwtPlot(),
                                                       formationNamesToPlot,

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
@@ -119,6 +119,21 @@
 
 CAF_PDM_SOURCE_INIT( RimWellLogTrack, "WellLogPlotTrack" );
 
+namespace internal
+{
+void setColorShadingLegendFromFormationCase( RimWellLogRegionAnnotationSettings* settings, RimCase* rimCase )
+{
+    if ( !rimCase ) return;
+
+    auto* formationNames = rimCase->activeFormationNames();
+    if ( !formationNames ) return;
+
+    QString legendName = formationNames->shortName();
+    auto*   legend     = RimProject::current()->colorLegendCollection->findByName( legendName );
+    if ( legend ) settings->setColorShadingLegend( legend );
+}
+} // namespace Internal
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
@@ -1221,21 +1236,6 @@ void RimWellLogTrack::onLoadDataAndUpdate()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RimWellLogTrack::setColorShadingLegendFromFormationCase( RimCase* rimCase )
-{
-    if ( !rimCase ) return;
-
-    auto* formationNames = rimCase->activeFormationNames();
-    if ( !formationNames ) return;
-
-    QString legendName = formationNames->shortName();
-    auto*   legend     = RimProject::current()->colorLegendCollection->findByName( legendName );
-    if ( legend ) m_regionAnnotationSettings->setColorShadingLegend( legend );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setAndUpdateWellPathFormationNamesData( RimCase* rimCase, RimWellPath* wellPath )
 {
     m_formationSettings->setFormationCase( rimCase );
@@ -1244,7 +1244,7 @@ void RimWellLogTrack::setAndUpdateWellPathFormationNamesData( RimCase* rimCase, 
     m_formationSettings->setSimWellName( "" );
     m_formationSettings->setBranchIndex( -1 );
 
-    setColorShadingLegendFromFormationCase( rimCase );
+    internal::setColorShadingLegendFromFormationCase( m_regionAnnotationSettings, rimCase );
     updateConnectedEditors();
 
     if ( m_regionAnnotationSettings->annotationType() != RiaDefines::RegionAnnotationType::NO_ANNOTATIONS )
@@ -1277,7 +1277,7 @@ void RimWellLogTrack::setAndUpdateSimWellFormationNamesData( RimCase* rimCase, c
     m_formationSettings->setWellPathForSourceCase( nullptr );
     m_formationSettings->setSimWellName( simWellName );
 
-    setColorShadingLegendFromFormationCase( rimCase );
+    internal::setColorShadingLegendFromFormationCase( m_regionAnnotationSettings, rimCase );
     updateConnectedEditors();
 
     if ( m_regionAnnotationSettings->annotationType() != RiaDefines::RegionAnnotationType::NO_ANNOTATIONS )

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
@@ -59,6 +59,7 @@
 #include "RimMainPlotCollection.h"
 #include "RimPerforationCollection.h"
 #include "RimPerforationInterval.h"
+#include "Formations/RimFormationNames.h"
 #include "RimProject.h"
 #include "RimRftTopologyCurve.h"
 #include "RimTools.h"
@@ -104,6 +105,7 @@
 
 #include "qwt_scale_map.h"
 
+#include <QFileInfo>
 #include <QWheelEvent>
 
 #include <algorithm>
@@ -1220,6 +1222,21 @@ void RimWellLogTrack::onLoadDataAndUpdate()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimWellLogTrack::setColorShadingLegendFromFormationCase( RimCase* rimCase )
+{
+    if ( !rimCase ) return;
+
+    auto* formationNames = rimCase->activeFormationNames();
+    if ( !formationNames ) return;
+
+    QString legendName = QFileInfo( formationNames->fileName() ).baseName();
+    auto*   legend     = RimProject::current()->colorLegendCollection->findByName( legendName );
+    if ( legend ) m_regionAnnotationSettings->setColorShadingLegend( legend );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimWellLogTrack::setAndUpdateWellPathFormationNamesData( RimCase* rimCase, RimWellPath* wellPath )
 {
     m_formationSettings->setFormationCase( rimCase );
@@ -1228,6 +1245,7 @@ void RimWellLogTrack::setAndUpdateWellPathFormationNamesData( RimCase* rimCase, 
     m_formationSettings->setSimWellName( "" );
     m_formationSettings->setBranchIndex( -1 );
 
+    setColorShadingLegendFromFormationCase( rimCase );
     updateConnectedEditors();
 
     if ( m_regionAnnotationSettings->annotationType() != RiaDefines::RegionAnnotationType::NO_ANNOTATIONS )
@@ -1260,6 +1278,7 @@ void RimWellLogTrack::setAndUpdateSimWellFormationNamesData( RimCase* rimCase, c
     m_formationSettings->setWellPathForSourceCase( nullptr );
     m_formationSettings->setSimWellName( simWellName );
 
+    setColorShadingLegendFromFormationCase( rimCase );
     updateConnectedEditors();
 
     if ( m_regionAnnotationSettings->annotationType() != RiaDefines::RegionAnnotationType::NO_ANNOTATIONS )

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
@@ -123,7 +123,7 @@ namespace internal
 {
 void setColorShadingLegendFromFormationCase( RimWellLogRegionAnnotationSettings* settings, RimCase* rimCase )
 {
-    if ( !rimCase ) return;
+    if ( !settings || !rimCase ) return;
 
     auto* formationNames = rimCase->activeFormationNames();
     if ( !formationNames ) return;
@@ -132,7 +132,7 @@ void setColorShadingLegendFromFormationCase( RimWellLogRegionAnnotationSettings*
     auto*   legend     = RimProject::current()->colorLegendCollection->findByName( legendName );
     if ( legend ) settings->setColorShadingLegend( legend );
 }
-} // namespace Internal
+} // namespace internal
 
 //--------------------------------------------------------------------------------------------------
 ///

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp
@@ -46,6 +46,7 @@
 #include "Well/RigWellPath.h"
 #include "Well/RigWellPathFormations.h"
 
+#include "Formations/RimFormationNames.h"
 #include "RimCase.h"
 #include "RimColorLegend.h"
 #include "RimColorLegendCollection.h"
@@ -59,7 +60,6 @@
 #include "RimMainPlotCollection.h"
 #include "RimPerforationCollection.h"
 #include "RimPerforationInterval.h"
-#include "Formations/RimFormationNames.h"
 #include "RimProject.h"
 #include "RimRftTopologyCurve.h"
 #include "RimTools.h"
@@ -105,7 +105,6 @@
 
 #include "qwt_scale_map.h"
 
-#include <QFileInfo>
 #include <QWheelEvent>
 
 #include <algorithm>
@@ -1229,7 +1228,7 @@ void RimWellLogTrack::setColorShadingLegendFromFormationCase( RimCase* rimCase )
     auto* formationNames = rimCase->activeFormationNames();
     if ( !formationNames ) return;
 
-    QString legendName = QFileInfo( formationNames->fileName() ).baseName();
+    QString legendName = formationNames->shortName();
     auto*   legend     = RimProject::current()->colorLegendCollection->findByName( legendName );
     if ( legend ) m_regionAnnotationSettings->setColorShadingLegend( legend );
 }
@@ -2726,8 +2725,7 @@ void RimWellLogTrack::updateFormationNamesOnPlot()
             // formations not found in the legend (e.g., when using a generic color palette).
             // Related to https://github.com/OPM/ResInsight/issues/12974
             RimColorLegend* legend = m_regionAnnotationSettings->colorShadingLegend();
-            if ( !legend )
-                legend = RimRegularLegendConfig::mapToColorLegend( RimRegularLegendConfig::ColorRangesType::NORMAL );
+            if ( !legend ) legend = RimRegularLegendConfig::mapToColorLegend( RimRegularLegendConfig::ColorRangesType::NORMAL );
 
             if ( legend && !formationNamesToPlot.empty() )
             {

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
@@ -242,8 +242,6 @@ protected:
 private:
     RiuPlotWidget* doCreatePlotViewWidget( QWidget* mainWindowParent = nullptr ) override;
 
-    void setColorShadingLegendFromFormationCase( RimCase* rimCase );
-
     void cleanupBeforeClose();
     void detachAllPlotItems();
     void calculatePropertyValueZoomRange();

--- a/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
+++ b/ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h
@@ -242,6 +242,8 @@ protected:
 private:
     RiuPlotWidget* doCreatePlotViewWidget( QWidget* mainWindowParent = nullptr ) override;
 
+    void setColorShadingLegendFromFormationCase( RimCase* rimCase );
+
     void cleanupBeforeClose();
     void detachAllPlotItems();
     void calculatePropertyValueZoomRange();


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix formation color mapping to use LYR-file colors instead of palette interpolation

- Auto-set formation color legend when formation case assigned to well log track

- Create color legends from LYR-files during project load for immediate availability

- Refactor color legend creation logic into centralized RimColorLegendCollection method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Formation Names File<br/>LYR-file"] -->|"readAllFormationNames()"| B["RimFormationNamesCollection"]
  B -->|"createColorLegendFromFormationNames()"| C["RimColorLegendCollection"]
  C -->|"creates legend"| D["RimColorLegend"]
  E["Well Log Track<br/>Formation Case Set"] -->|"setColorShadingLegendFromFormationCase()"| F["Color Legend Lookup"]
  F -->|"applies colors"| G["Region Annotations"]
  H["Formation Names Import"] -->|"createColorLegendFromFormationNames()"| C
  I["Eclipse Result Legend"] -->|"direct value-to-color map"| J["Visible Categories"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RicImportFormationNamesFeature.cpp</strong><dd><code>Simplify formation import to use centralized legend creation</code></dd></summary>
<hr>

ApplicationLibCode/Commands/RicImportFormationNamesFeature.cpp

<ul><li>Removed <code>addCustomColorLegend()</code> helper method and its implementation<br> <li> Simplified import logic to call <code>createColorLegendFromFormationNames()</code> <br>directly<br> <li> Iterate over formation names objects instead of file names for cleaner <br>code<br> <li> Call <code>updateConnectedEditors()</code> on color legend collection after import</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/700/files#diff-f5c0cb2f3d711beb8bbedb6509c5a1908c011f14938665cdde9a235a39d8f28a">+4/-52</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RicImportFormationNamesFeature.h</strong><dd><code>Remove addCustomColorLegend method declaration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/Commands/RicImportFormationNamesFeature.h

<ul><li>Removed <code>addCustomColorLegend()</code> static method declaration<br> <li> Kept public <code>importFormationFiles()</code> and private <br><code>setFormationCellResultAndLegend()</code> methods</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/700/files#diff-cd6f41b468e3ba85727c1b8944a48202ae0a72b75333b0c880c5ee68687b26dd">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RimFormationNamesCollection.cpp</strong><dd><code>Create color legends during formation names file read</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/Formations/RimFormationNamesCollection.cpp

<ul><li>Added includes for <code>RimColorLegendCollection</code> and <code>RimProject</code><br> <li> Call <code>createColorLegendFromFormationNames()</code> in <code>readAllFormationNames()</code> <br>to create legends during project load<br> <li> Ensures color legends are available immediately after project is <br>loaded</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/700/files#diff-0c7753a72891cd6e56e478bc9885bc50fbf94136464285313d764d01c825cc00">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimColorLegendCollection.h</strong><dd><code>Add formation names color legend creation method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.h

<ul><li>Added forward declaration for <code>RimFormationNames</code> class<br> <li> Added new public method <code>createColorLegendFromFormationNames()</code> to <br>create legends from formation data</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/700/files#diff-abca04d3bd28f8e7e6aa1adc218efd8eaf56838f8c2299a3d89cd690c0f99db5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimColorLegendCollection.cpp</strong><dd><code>Implement centralized formation color legend creation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/RimColorLegendCollection.cpp

<ul><li>Added includes for <code>RimFormationNames</code>, <code>RigFormationNames</code>, and <code>QFileInfo</code><br> <li> Implemented <code>createColorLegendFromFormationNames()</code> method that creates <br>color legends from formation names and colors<br> <li> Validates that colors exist and are valid before creating legend<br> <li> Prevents duplicate legends by checking if legend with same name <br>already exists<br> <li> Builds legend items from formation names and their corresponding <br>colors</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/700/files#diff-c485ce2dba80eb4b9bf0caf5c3d69a1a092434c9694c35c16ccb9a7ec9a7895f">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimWellLogTrack.h</strong><dd><code>Add formation case color legend setter method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.h

<ul><li>Added private method <code>setColorShadingLegendFromFormationCase()</code> <br>declaration<br> <li> Method automatically sets color legend when formation case is assigned</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/700/files#diff-9d95454ae63582f047f5371c10fed9eb4e3c0dcbe6fcca8b237b1cb7f8c8cd07">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RimEclipseResultDefinitionTools.cpp</strong><dd><code>Honor legend item colors for visible categories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/RimEclipseResultDefinitionTools.cpp

<ul><li>Added <code>#include <map></code> for standard library map container<br> <li> Build direct <code>categoryValue-to-color</code> map from legend items before <br>processing visible categories<br> <li> Use legend item colors when available instead of always using palette <br>interpolation<br> <li> Falls back to palette interpolation for categories not found in legend <br>items</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/700/files#diff-d6ff34de13c8d2b54d7c9a990bae2bd190f7c92d9031b55ca9a72916bfd61d94">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RimWellLogTrack.cpp</strong><dd><code>Auto-set legend and fix formation color mapping on plot</code>&nbsp; &nbsp; </dd></summary>
<hr>

ApplicationLibCode/ProjectDataModel/WellLog/WellLogTrack/RimWellLogTrack.cpp

<ul><li>Added includes for <code>RimFormationNames</code>, <code>QFileInfo</code>, and <code><map></code><br> <li> Implemented <code>setColorShadingLegendFromFormationCase()</code> to auto-set <br>legend from formation case<br> <li> Call new method in both <code>setAndUpdateWellPathFormationNamesData()</code> and <br><code>setAndUpdateSimWellFormationNamesData()</code><br> <li> Refactored <code>updateFormationNamesOnPlot()</code> to build color table ordered <br>by formation name<br> <li> Create <code>nameToColor</code> map from legend items to ensure LYR-file colors are <br>used<br> <li> Fall back to palette colors for formations not in legend items<br> <li> Initialize color array with gray and populate based on formation name <br>lookup</ul>


</details>


  </td>
  <td><a href="https://github.com/magnesj/ResInsight/pull/700/files#diff-0285f4f565f99c0d407b08eead18f6c9e22dd62924a9d6f056b74f50a1574701">+52/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

