### PR TITLE
Add context menu actions to hide/show all geometry for well visibility

### DIFF
--- a/ApplicationLibCode/Commands/Histogram/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Commands/Histogram/CMakeLists_files.cmake
@@ -1,6 +1,6 @@
 set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RicNewDefaultHistogramPlotFeature.h
-    ${CMAKE_CURRENT_LIST_DIR}/RicNewHistogramCurveFeature.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicNewHistogramCurveFeature.h
     ${CMAKE_CURRENT_LIST_DIR}/RicNewHistogramMultiPlotFeature.h
     ${CMAKE_CURRENT_LIST_DIR}/RicPasteHistogramCurveFeature.h
 )

--- a/ApplicationLibCode/Commands/WellPathCommands/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Commands/WellPathCommands/CMakeLists_files.cmake
@@ -32,6 +32,8 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/PointTangentManipulator/RicPolylineTarget3dEditor.h
     ${CMAKE_CURRENT_LIST_DIR}/RicDuplicateWellPathFeature.h
     ${CMAKE_CURRENT_LIST_DIR}/RicSetParentWellPathFeature.h
+    ${CMAKE_CURRENT_LIST_DIR}/RicHideGridGeometryFeature.h
+    ${CMAKE_CURRENT_LIST_DIR}/RicShowAllGeometryFeature.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES
@@ -68,6 +70,8 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/PointTangentManipulator/RicPolylineTarget3dEditor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicDuplicateWellPathFeature.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RicSetParentWellPathFeature.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicHideGridGeometryFeature.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RicShowAllGeometryFeature.cpp
 )
 
 list(APPEND COMMAND_CODE_HEADER_FILES ${SOURCE_GROUP_HEADER_FILES})

--- a/ApplicationLibCode/Commands/WellPathCommands/RicHideGridGeometryFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicHideGridGeometryFeature.cpp
@@ -1,0 +1,101 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RicHideGridGeometryFeature.h"
+
+#include "RiaApplication.h"
+
+#include "RimEclipseView.h"
+#include "RimFaultInViewCollection.h"
+#include "RimGridCollection.h"
+#include "RimGridView.h"
+#include "RimIntersectionCollection.h"
+#include "RimSimWellInViewCollection.h"
+#include "RimTools.h"
+#include "WellPath/RimWellPathCollection.h"
+
+#include "RiuMainWindow.h"
+
+#include <QAction>
+
+CAF_CMD_SOURCE_INIT( RicHideGridGeometryFeature, "RicHideGridGeometryFeature" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RicHideGridGeometryFeature::isCommandEnabled() const
+{
+    Rim3dView* view = RiaApplication::instance()->activeReservoirView();
+    return dynamic_cast<RimGridView*>( view ) != nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicHideGridGeometryFeature::onActionTriggered( bool isChecked )
+{
+    Rim3dView* view = RiaApplication::instance()->activeMainOrComparisonGridView();
+    if ( !view ) return;
+
+    RimGridView* gridView = dynamic_cast<RimGridView*>( view );
+    if ( !gridView ) return;
+
+    // Hide faults (Eclipse views only)
+    if ( auto eclipseView = dynamic_cast<RimEclipseView*>( gridView ) )
+    {
+        eclipseView->faultCollection()->setActive( false );
+        eclipseView->faultCollection()->updateConnectedEditors();
+
+        // Force simulation wells visible
+        if ( auto simWellColl = eclipseView->wellCollection() )
+        {
+            simWellColl->isActive = true;
+            simWellColl->updateConnectedEditors();
+        }
+    }
+
+    // Hide intersections
+    gridView->intersectionCollection()->setActive( false );
+    gridView->intersectionCollection()->updateConnectedEditors();
+
+    // Hide all reservoir geometry
+    gridView->gridCollection()->setActive( false );
+    gridView->gridCollection()->updateConnectedEditors();
+
+    RiuMainWindow::instance()->refreshDrawStyleActions();
+    RiuMainWindow::instance()->refreshAnimationActions();
+
+    gridView->scheduleCreateDisplayModelAndRedraw();
+
+    // Force all well paths visible
+    if ( auto wellPathColl = RimTools::wellPathCollection() )
+    {
+        wellPathColl->isActive           = true;
+        wellPathColl->wellPathVisibility = RimWellPathCollection::FORCE_ALL_ON;
+        wellPathColl->updateConnectedEditors();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicHideGridGeometryFeature::setupActionLook( QAction* actionToSetup )
+{
+    actionToSetup->setText( "Hide Grid Geometry" );
+    actionToSetup->setIcon( QIcon( ":/Well.svg" ) );
+}

--- a/ApplicationLibCode/Commands/WellPathCommands/RicHideGridGeometryFeature.h
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicHideGridGeometryFeature.h
@@ -1,0 +1,34 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cafCmdFeature.h"
+
+//==================================================================================================
+///
+//==================================================================================================
+class RicHideGridGeometryFeature : public caf::CmdFeature
+{
+    CAF_CMD_HEADER_INIT;
+
+protected:
+    bool isCommandEnabled() const override;
+    void onActionTriggered( bool isChecked ) override;
+    void setupActionLook( QAction* actionToSetup ) override;
+};

--- a/ApplicationLibCode/Commands/WellPathCommands/RicShowAllGeometryFeature.cpp
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicShowAllGeometryFeature.cpp
@@ -1,0 +1,90 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RicShowAllGeometryFeature.h"
+
+#include "RiaApplication.h"
+
+#include "RimEclipseView.h"
+#include "RimFaultInViewCollection.h"
+#include "RimGridView.h"
+#include "RimIntersectionCollection.h"
+#include "RimTools.h"
+#include "WellPath/RimWellPathCollection.h"
+
+#include "RiuMainWindow.h"
+
+#include <QAction>
+
+CAF_CMD_SOURCE_INIT( RicShowAllGeometryFeature, "RicShowAllGeometryFeature" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RicShowAllGeometryFeature::isCommandEnabled() const
+{
+    Rim3dView* view = RiaApplication::instance()->activeReservoirView();
+    return dynamic_cast<RimGridView*>( view ) != nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicShowAllGeometryFeature::onActionTriggered( bool isChecked )
+{
+    Rim3dView* view = RiaApplication::instance()->activeMainOrComparisonGridView();
+    if ( !view ) return;
+
+    RimGridView* gridView = dynamic_cast<RimGridView*>( view );
+    if ( !gridView ) return;
+
+    // Show faults (Eclipse views only)
+    if ( auto eclipseView = dynamic_cast<RimEclipseView*>( gridView ) )
+    {
+        eclipseView->faultCollection()->setActive( true );
+        eclipseView->faultCollection()->updateConnectedEditors();
+    }
+
+    // Show intersections
+    gridView->intersectionCollection()->setActive( true );
+    gridView->intersectionCollection()->updateConnectedEditors();
+
+    // Show all reservoir geometry
+    gridView->showGridCells( true );
+
+    RiuMainWindow::instance()->refreshDrawStyleActions();
+    RiuMainWindow::instance()->refreshAnimationActions();
+
+    gridView->scheduleCreateDisplayModelAndRedraw();
+
+    // Restore well path visibility to individual control
+    if ( auto wellPathColl = RimTools::wellPathCollection() )
+    {
+        wellPathColl->wellPathVisibility = RimWellPathCollection::ALL_ON;
+        wellPathColl->updateConnectedEditors();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicShowAllGeometryFeature::setupActionLook( QAction* actionToSetup )
+{
+    actionToSetup->setText( "Show All Geometry" );
+    actionToSetup->setIcon( QIcon( ":/draw_style_surface_24x24.png" ) );
+}

--- a/ApplicationLibCode/Commands/WellPathCommands/RicShowAllGeometryFeature.h
+++ b/ApplicationLibCode/Commands/WellPathCommands/RicShowAllGeometryFeature.h
@@ -1,0 +1,34 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "cafCmdFeature.h"
+
+//==================================================================================================
+///
+//==================================================================================================
+class RicShowAllGeometryFeature : public caf::CmdFeature
+{
+    CAF_CMD_HEADER_INIT;
+
+protected:
+    bool isCommandEnabled() const override;
+    void onActionTriggered( bool isChecked ) override;
+    void setupActionLook( QAction* actionToSetup ) override;
+};

--- a/ApplicationLibCode/ProjectDataModel/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ProjectDataModel/CMakeLists_files.cmake
@@ -70,7 +70,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RimDialogData.h
     ${CMAKE_CURRENT_LIST_DIR}/RimTimeStepFilter.h
     ${CMAKE_CURRENT_LIST_DIR}/RimUserDefinedCalculation.h
-    ${CMAKE_CURRENT_LIST_DIR}/RimUserDefinedCalculationCollection.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RimUserDefinedCalculationCollection.h
     ${CMAKE_CURRENT_LIST_DIR}/RimUserDefinedCalculationVariable.h
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCalculation.h
     ${CMAKE_CURRENT_LIST_DIR}/RimSummaryCalculationCollection.h

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.cpp
@@ -98,6 +98,14 @@ bool RimIntersectionCollection::isActive() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimIntersectionCollection::setActive( bool active )
+{
+    m_isActive = active;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimIntersectionCollection::defineUiTreeOrdering( caf::PdmUiTreeOrdering& uiTreeOrdering, QString uiConfigName /*= "" */ )
 {
     auto gridView = firstAncestorOfType<RimGridView>();

--- a/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Intersections/RimIntersectionCollection.h
@@ -89,6 +89,7 @@ public:
     void onChildAdded( caf::PdmFieldHandle* containerForNewObject ) override;
 
     bool isActive() const;
+    void setActive( bool active );
 
 protected:
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;

--- a/ApplicationLibCode/ReservoirDataModel/ResultCalculators/CMakeLists_files.cmake
+++ b/ApplicationLibCode/ReservoirDataModel/ResultCalculators/CMakeLists_files.cmake
@@ -9,7 +9,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigCellVolumeResultCalculator.h
     ${CMAKE_CURRENT_LIST_DIR}/RigAllanUtil.h
     ${CMAKE_CURRENT_LIST_DIR}/RigCellsWithNncsCalculator.h
-    ${CMAKE_CURRENT_LIST_DIR}/RigPorvSoilSgasResultCalculator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigPorvSoilSgasResultCalculator.h
 )
 
 set(SOURCE_GROUP_SOURCE_FILES

--- a/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
+++ b/ApplicationLibCode/UserInterface/RiuViewerCommands.cpp
@@ -632,6 +632,9 @@ void RiuViewerCommands::displayContextMenu( QMouseEvent* event )
             menuBuilder << "RicShowGridStatisticsFeature";
             menuBuilder << "RicCopyGridStatisticsToClipboardFeature";
             menuBuilder << "RicSelectColorResult";
+            menuBuilder.addSeparator();
+            menuBuilder << "RicHideGridGeometryFeature";
+            menuBuilder << "RicShowAllGeometryFeature";
         }
     }
 


### PR DESCRIPTION
Closes #742

## Summary

- Add **Hide All Geometry (Show Wells)** context menu action: hides grid cells, faults, and intersections, then forces simulation wells and all well paths visible
- Add **Show All Geometry** context menu action: restores grid cells, faults, and intersections visibility
- Add `RimIntersectionCollection::setActive()` for direct state control
- Fix pre-existing Unity build issue where `.cpp` files were incorrectly listed in `SOURCE_GROUP_HEADER_FILES` sections, causing duplicate symbol linker errors

## Test plan

- [ ] Open an Eclipse case with wells, faults, and intersections
- [ ] Right-click a well path and invoke **Hide All Geometry (Show Wells)** — grid, faults, and intersections should hide; wells should remain visible
- [ ] Right-click and invoke **Show All Geometry** — grid, faults, and intersections should be restored
- [ ] Verify toolbar draw-style icons update correctly after each action
- [ ] Verify the project tree checkboxes reflect the correct state after each action