### PR TITLE
Use log sized bins for depth test OpenGL

### DIFF
--- a/ApplicationExeCode/Resources/vs_2dTextureCellFace.glsl
+++ b/ApplicationExeCode/Resources/vs_2dTextureCellFace.glsl
@@ -126,5 +126,8 @@ void main()
     v_ecNormal = cvfu_normalMatrix * cvfa_normal;
 
     gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;
+#ifdef CVF_LOG_DEPTH_IMPL
+    calcLogDepth(gl_Position);
+#endif
 }
 

--- a/ApplicationExeCode/Resources/vs_CellFace.glsl
+++ b/ApplicationExeCode/Resources/vs_CellFace.glsl
@@ -177,5 +177,8 @@ void main()
     v_ecNormal = cvfu_normalMatrix * cvfa_normal;
 
     gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;
+#ifdef CVF_LOG_DEPTH_IMPL
+    calcLogDepth(gl_Position);
+#endif
 }
 

--- a/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Intersections/RivExtrudedCurveIntersectionPartMgr.cpp
@@ -82,6 +82,7 @@
 #include "cvfRenderState_FF.h"
 #include "cvfStructGridGeometryGenerator.h"
 #include "cvfTransform.h"
+#include "cvfUniform.h"
 #include "cvfqtUtils.h"
 
 #include <functional>
@@ -711,12 +712,14 @@ void RivExtrudedCurveIntersectionPartMgr::createAnnotationSurfaceParts( bool use
                     // The factor value is defined by enums in
                     // EffectGenerator::createAndConfigurePolygonOffsetRenderState() Use a factor that is more negative
                     // than the existing enums
-                    const double offsetFactor = -5;
+                    const float offsetFactor = -5.0f;
+                    const float offsetUnits  = static_cast<float>( band->polygonOffsetUnit() );
                     polyOffset->setFactor( offsetFactor );
-
-                    polyOffset->setUnits( band->polygonOffsetUnit() );
+                    polyOffset->setUnits( offsetUnits );
 
                     geometryOnlyEffect->setRenderState( polyOffset.p() );
+                    geometryOnlyEffect->setUniform( new cvf::UniformFloat( "u_polygonOffsetFactor", offsetFactor ) );
+                    geometryOnlyEffect->setUniform( new cvf::UniformFloat( "u_polygonOffsetUnits", offsetUnits ) );
                 }
 
                 part->setEffect( geometryOnlyEffect.p() );
@@ -759,11 +762,14 @@ cvf::ref<cvf::Part> RivExtrudedCurveIntersectionPartMgr::createCurvePart( const 
 
         cvf::ref<cvf::RenderStatePolygonOffset> polyOffset = new cvf::RenderStatePolygonOffset;
         polyOffset->enableFillMode( true );
-        polyOffset->setFactor( -5 );
-        const double maxOffsetFactor = -1000;
-        polyOffset->setUnits( maxOffsetFactor );
+        const float lineFactor = -5.0f;
+        const float lineUnits  = -1000.0f;
+        polyOffset->setFactor( lineFactor );
+        polyOffset->setUnits( lineUnits );
 
         eff->setRenderState( polyOffset.p() );
+        eff->setUniform( new cvf::UniformFloat( "u_polygonOffsetFactor", lineFactor ) );
+        eff->setUniform( new cvf::UniformFloat( "u_polygonOffsetUnits", lineUnits ) );
 
         part->setEffect( eff.p() );
 

--- a/ApplicationLibCode/ModelVisualization/RivCellEdgeEffectGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivCellEdgeEffectGenerator.cpp
@@ -273,13 +273,8 @@ void CellEdgeEffectGenerator::updateForShaderBasedRendering( cvf::Effect* effect
     texBind->addBinding( cellTexture.p(), sampler.p(), "u_cellTexture2D" );
     eff->setRenderState( texBind.p() );
 
-    // Polygon offset
-
-    {
-        cvf::ref<cvf::RenderStatePolygonOffset> polyOffset = new cvf::RenderStatePolygonOffset;
-        polyOffset->configurePolygonPositiveOffset();
-        eff->setRenderState( polyOffset.p() );
-    }
+    // Polygon offset (render state + shader uniforms for log-depth compatibility)
+    EffectGenerator::applyPolygonOffset( eff.p(), caf::PO_1 );
 
     // Simple transparency
     if ( m_opacityLevel < 1.0f )

--- a/ApplicationLibCode/ModelVisualization/RivTernaryScalarMapperEffectGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivTernaryScalarMapperEffectGenerator.cpp
@@ -185,11 +185,7 @@ void RivTernaryScalarMapperEffectGenerator::updateCommonEffect( cvf::Effect* eff
 {
     CVF_ASSERT( effect );
 
-    if ( m_polygonOffset != caf::PO_NONE )
-    {
-        cvf::ref<cvf::RenderStatePolygonOffset> polyOffset = EffectGenerator::createAndConfigurePolygonOffsetRenderState( m_polygonOffset );
-        effect->setRenderState( polyOffset.p() );
-    }
+    EffectGenerator::applyPolygonOffset( effect, m_polygonOffset );
 
     // Simple transparency
     if ( m_opacityLevel < 1.0f )

--- a/ApplicationLibCode/ModelVisualization/Seismic/RivSeismicSectionPartMgr.cpp
+++ b/ApplicationLibCode/ModelVisualization/Seismic/RivSeismicSectionPartMgr.cpp
@@ -49,6 +49,7 @@
 #include "cvfModelBasicList.h"
 #include "cvfPart.h"
 #include "cvfScalarMapper.h"
+#include "cvfUniform.h"
 
 #include <zgyaccess/seismicslice.h>
 
@@ -243,11 +244,14 @@ void RivSeismicSectionPartMgr::appendSurfaceIntersectionLines( cvf::ModelBasicLi
 
             cvf::ref<cvf::RenderStatePolygonOffset> polyOffset = new cvf::RenderStatePolygonOffset;
             polyOffset->enableFillMode( true );
-            polyOffset->setFactor( -5 );
-            const double maxOffsetFactor = -1000;
-            polyOffset->setUnits( maxOffsetFactor );
+            const float lineFactor = -5.0f;
+            const float lineUnits  = -1000.0f;
+            polyOffset->setFactor( lineFactor );
+            polyOffset->setUnits( lineUnits );
 
             eff->setRenderState( polyOffset.p() );
+            eff->setUniform( new cvf::UniformFloat( "u_polygonOffsetFactor", lineFactor ) );
+            eff->setUniform( new cvf::UniformFloat( "u_polygonOffsetUnits", lineUnits ) );
 
             part->setEffect( eff.p() );
             part->setPriority( RivPartPriority::PartType::MeshLines );

--- a/Fwk/AppFwk/CommonCode/cafEffectGenerator.cpp
+++ b/Fwk/AppFwk/CommonCode/cafEffectGenerator.cpp
@@ -154,6 +154,44 @@ cvf::ref<cvf::RenderStatePolygonOffset>
     return rs;
 }
 
+//--------------------------------------------------------------------------------------------------
+/// Sets both the GL polygon offset render state and the equivalent shader uniforms.
+/// glPolygonOffset has no effect when gl_FragDepth is written explicitly (as in log-depth
+/// rendering), so the uniforms are required for correct depth ordering in that mode.
+//--------------------------------------------------------------------------------------------------
+void EffectGenerator::applyPolygonOffset( cvf::Effect* effect, PolygonOffset polygonOffset )
+{
+    if ( polygonOffset == PO_NONE ) return;
+
+    effect->setRenderState( createAndConfigurePolygonOffsetRenderState( polygonOffset ).p() );
+
+    float factor = 0.0f, units = 0.0f;
+    switch ( polygonOffset )
+    {
+        case PO_1:
+            factor = 1.0f;
+            units  = 1.0f;
+            break;
+        case PO_2:
+            factor = 2.0f;
+            units  = 2.0f;
+            break;
+        case PO_POS_LARGE:
+            factor = 3.0f;
+            units  = 50.0f;
+            break;
+        case PO_NEG_LARGE:
+            factor = -1.0f;
+            units  = -30.0f;
+            break;
+        default:
+            CVF_FAIL_MSG( "Unhandled polygon offset enum" );
+            return;
+    }
+    effect->setUniform( new cvf::UniformFloat( "u_polygonOffsetFactor", factor ) );
+    effect->setUniform( new cvf::UniformFloat( "u_polygonOffsetUnits", units ) );
+}
+
 //==================================================================================================
 //
 // EffectGenerator Base class
@@ -347,12 +385,7 @@ void SurfaceEffectGenerator::updateForFixedFunctionRendering( cvf::Effect* effec
 //--------------------------------------------------------------------------------------------------
 void SurfaceEffectGenerator::updateCommonEffect( cvf::Effect* effect ) const
 {
-    if ( m_polygonOffset != PO_NONE )
-    {
-        cvf::ref<cvf::RenderStatePolygonOffset> polyOffset =
-            EffectGenerator::createAndConfigurePolygonOffsetRenderState( m_polygonOffset );
-        effect->setRenderState( polyOffset.p() );
-    }
+    EffectGenerator::applyPolygonOffset( effect, m_polygonOffset );
 
     // Simple transparency
     if ( m_color.a() < 1.0f )
@@ -553,12 +586,7 @@ void ScalarMapperEffectGenerator::updateCommonEffect( cvf::Effect* effect ) cons
 {
     CVF_ASSERT( effect );
 
-    if ( m_polygonOffset != PO_NONE )
-    {
-        cvf::ref<cvf::RenderStatePolygonOffset> polyOffset =
-            EffectGenerator::createAndConfigurePolygonOffsetRenderState( m_polygonOffset );
-        effect->setRenderState( polyOffset.p() );
-    }
+    EffectGenerator::applyPolygonOffset( effect, m_polygonOffset );
 
     // Simple transparency
     if ( m_opacityLevel < 1.0f )

--- a/Fwk/AppFwk/CommonCode/cafEffectGenerator.h
+++ b/Fwk/AppFwk/CommonCode/cafEffectGenerator.h
@@ -107,6 +107,10 @@ public:
     static cvf::ref<cvf::RenderStatePolygonOffset>
         createAndConfigurePolygonOffsetRenderState( caf::PolygonOffset polygonOffset );
 
+    // Sets both the GL polygon offset render state and the shader uniforms needed for log-depth
+    // rendering (glPolygonOffset is ignored when gl_FragDepth is written explicitly).
+    static void applyPolygonOffset( cvf::Effect* effect, caf::PolygonOffset polygonOffset );
+
 protected:
     // Interface that must be implemented in base classes
     virtual bool             isEqual( const EffectGenerator* other ) const = 0;

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -509,32 +509,56 @@ bool caf::Viewer::calculateNearFarPlanes( const cvf::Rendering* rendering,
                                           double*               farPlaneDist,
                                           double*               nearPlaneDist )
 {
-    cvf::BoundingBox bb = rendering->boundingBox();
-
-    if ( !bb.isValid() ) return false;
+    if ( !rendering->boundingBox().isValid() ) return false;
 
     cvf::Vec3d eye     = rendering->camera()->position();
     cvf::Vec3d viewdir = rendering->camera()->direction();
 
-    cvf::Vec3d bboxCorners[8];
-    bb.cornerVertices( bboxCorners );
-
-    // Find the distance to the bbox corners most behind and most in front of camera
+    // Iterate per-model bounding boxes and skip models that are entirely outside the
+    // camera frustum. This avoids distant off-screen objects inflating the far plane,
+    // which would degrade depth buffer precision and cause z-fighting.
+    // Fall back to the scene-wide bounding box if no model contributes.
 
     double maxDistEyeToCornerAlongViewDir = -HUGE_VAL;
     double minDistEyeToCornerAlongViewDir = HUGE_VAL;
-    for ( int bcIdx = 0; bcIdx < 8; ++bcIdx )
+
+    cvf::Frustum    viewFrustum = rendering->camera()->frustum();
+    const cvf::Scene* scene = rendering->scene();
+    bool            anyModelContributed = false;
+
+    if ( scene )
     {
-        double distEyeBoxCornerAlongViewDir = ( bboxCorners[bcIdx] - eye ) * viewdir;
-
-        if ( distEyeBoxCornerAlongViewDir > maxDistEyeToCornerAlongViewDir )
+        for ( cvf::uint mIdx = 0; mIdx < scene->modelCount(); ++mIdx )
         {
-            maxDistEyeToCornerAlongViewDir = distEyeBoxCornerAlongViewDir;
+            const cvf::Model* model   = scene->model( mIdx );
+            cvf::BoundingBox  modelBB = model->boundingBox();
+
+            if ( !modelBB.isValid() ) continue;
+            if ( viewFrustum.isOutside( modelBB ) ) continue;
+
+            cvf::Vec3d corners[8];
+            modelBB.cornerVertices( corners );
+            for ( int cIdx = 0; cIdx < 8; ++cIdx )
+            {
+                double dist               = ( corners[cIdx] - eye ) * viewdir;
+                maxDistEyeToCornerAlongViewDir = CVF_MAX( maxDistEyeToCornerAlongViewDir, dist );
+                minDistEyeToCornerAlongViewDir = CVF_MIN( minDistEyeToCornerAlongViewDir, dist );
+            }
+            anyModelContributed = true;
         }
+    }
 
-        if ( distEyeBoxCornerAlongViewDir < minDistEyeToCornerAlongViewDir )
+    if ( !anyModelContributed )
+    {
+        // Fallback: use the scene-wide bounding box (original behaviour)
+        cvf::BoundingBox bb = rendering->boundingBox();
+        cvf::Vec3d       bboxCorners[8];
+        bb.cornerVertices( bboxCorners );
+        for ( int bcIdx = 0; bcIdx < 8; ++bcIdx )
         {
-            minDistEyeToCornerAlongViewDir = distEyeBoxCornerAlongViewDir; // Sometimes negative-> behind camera
+            double dist                    = ( bboxCorners[bcIdx] - eye ) * viewdir;
+            maxDistEyeToCornerAlongViewDir = CVF_MAX( maxDistEyeToCornerAlongViewDir, dist );
+            minDistEyeToCornerAlongViewDir = CVF_MIN( minDistEyeToCornerAlongViewDir, dist );
         }
     }
 
@@ -548,16 +572,16 @@ bool caf::Viewer::calculateNearFarPlanes( const cvf::Rendering* rendering,
 
     if ( rendering->camera()->projection() == cvf::Camera::PERSPECTIVE || isOrthoNearPlaneFollowingCamera )
     {
-        // Choose the one furthest from the camera of: 0.8*bbox distance, m_minPerspectiveNearPlaneDistance.
+        // Choose the one furthest from the camera of: 0.8*bbox distance, m_defaultPerspectiveNearPlaneDistance.
         ( *nearPlaneDist ) = CVF_MAX( m_defaultPerspectiveNearPlaneDistance, 0.8 * minDistEyeToCornerAlongViewDir );
 
-        // If we are zooming into a detail, allow the near-plane to move towards camera beyond the
-        // m_minPerspectiveNearPlaneDistance
-        if ( ( *nearPlaneDist ) == m_defaultPerspectiveNearPlaneDistance // We are inside the bounding box
-             && m_navigationPolicy.notNull() && m_navigationPolicyEnabled )
+        // If the camera is inside (or past) the bounding box, allow the near plane to move
+        // closer to the camera based on the point of interest distance, so zooming into details
+        // does not clip geometry.
+        if ( minDistEyeToCornerAlongViewDir <= 0 && m_navigationPolicy.notNull() && m_navigationPolicyEnabled )
         {
             double pointOfInterestDist = ( eye - navPointOfinterest ).length();
-            ( *nearPlaneDist )         = CVF_MIN( ( *nearPlaneDist ), pointOfInterestDist * 0.2 );
+            ( *nearPlaneDist )         = CVF_MAX( m_defaultPerspectiveNearPlaneDistance, pointOfInterestDist * 0.1 );
         }
 
         // Guard against the zero nearplane possibility
@@ -576,6 +600,15 @@ bool caf::Viewer::calculateNearFarPlanes( const cvf::Rendering* rendering,
     }
 
     if ( ( *farPlaneDist ) <= ( *nearPlaneDist ) ) ( *farPlaneDist ) = ( *nearPlaneDist ) + 1.0;
+
+    // Enforce a maximum far/near ratio to preserve depth buffer precision.
+    // A 24-bit depth buffer loses effective precision rapidly as far/near grows.
+    // Pushing the near plane forward is preferable to allowing z-fighting.
+    const double maxFarNearRatio = 3000.0;
+    if ( ( *nearPlaneDist ) > 0 && ( ( *farPlaneDist ) / ( *nearPlaneDist ) ) > maxFarNearRatio )
+    {
+        ( *nearPlaneDist ) = ( *farPlaneDist ) / maxFarNearRatio;
+    }
 
     return true;
 }

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -86,8 +86,12 @@ public:
     GlobalViewerDynUniformSet()
     {
         m_headlightPosition = new cvf::UniformFloat( "u_ecLightPosition", cvf::Vec3f( 0.5, 5.0, 7.0 ) );
+        m_logDepthFC        = new cvf::UniformFloat( "u_logDepthFC", 1.0f );
+        m_useLogDepth       = new cvf::UniformFloat( "u_useLogDepth", 1.0f );
         m_uniformSet        = new cvf::UniformSet();
         m_uniformSet->setUniform( m_headlightPosition.p() );
+        m_uniformSet->setUniform( m_logDepthFC.p() );
+        m_uniformSet->setUniform( m_useLogDepth.p() );
     }
 
     ~GlobalViewerDynUniformSet() override {}
@@ -97,12 +101,20 @@ public:
         m_headlightPosition->set( posRelativeToCamera );
     }
 
+    // FC = 2.0 / log2(farPlane + 1.0) — update each frame after clip plane calculation
+    void setLogDepthFarConstant( float fc ) { m_logDepthFC->set( fc ); }
+
+    // Enable (1.0) for perspective projection, disable (0.0) for orthographic
+    void setUseLogDepth( float use ) { m_useLogDepth->set( use ); }
+
     cvf::UniformSet* uniformSet() override { return m_uniformSet.p(); }
     void             update( cvf::Rendering* rendering ) override {};
 
 private:
     cvf::ref<cvf::UniformSet>   m_uniformSet;
     cvf::ref<cvf::UniformFloat> m_headlightPosition;
+    cvf::ref<cvf::UniformFloat> m_logDepthFC;
+    cvf::ref<cvf::UniformFloat> m_useLogDepth;
 };
 
 } // namespace caf
@@ -468,6 +480,14 @@ void caf::Viewer::optimizeClippingPlanes()
         {
             m_mainCamera->setProjectionAsOrtho( m_mainCamera->frontPlaneFrustumHeight(), nearPlaneDist, farPlaneDist );
         }
+
+        // Update the logarithmic depth buffer constant: FC = 2 / log2(far + 1).
+        // Shaders use this to compute gl_FragDepth = log2(v_logz) * FC * 0.5.
+        // Log depth only works for perspective; orthographic uses linear depth.
+        const bool isPerspective = ( m_mainCamera->projection() == cvf::Camera::PERSPECTIVE );
+        float      logDepthFC    = static_cast<float>( 2.0 / std::log2( farPlaneDist + 1.0 ) );
+        m_globalUniformSet->setLogDepthFarConstant( logDepthFC );
+        m_globalUniformSet->setUseLogDepth( isPerspective ? 1.0f : 0.0f );
     }
 
     copyCameraView( m_mainCamera.p(), m_comparisonMainCamera.p() );
@@ -522,9 +542,9 @@ bool caf::Viewer::calculateNearFarPlanes( const cvf::Rendering* rendering,
     double maxDistEyeToCornerAlongViewDir = -HUGE_VAL;
     double minDistEyeToCornerAlongViewDir = HUGE_VAL;
 
-    cvf::Frustum    viewFrustum = rendering->camera()->frustum();
-    const cvf::Scene* scene = rendering->scene();
-    bool            anyModelContributed = false;
+    cvf::Frustum      viewFrustum         = rendering->camera()->frustum();
+    const cvf::Scene* scene               = rendering->scene();
+    bool              anyModelContributed = false;
 
     if ( scene )
     {
@@ -540,7 +560,7 @@ bool caf::Viewer::calculateNearFarPlanes( const cvf::Rendering* rendering,
             modelBB.cornerVertices( corners );
             for ( int cIdx = 0; cIdx < 8; ++cIdx )
             {
-                double dist               = ( corners[cIdx] - eye ) * viewdir;
+                double dist                    = ( corners[cIdx] - eye ) * viewdir;
                 maxDistEyeToCornerAlongViewDir = CVF_MAX( maxDistEyeToCornerAlongViewDir, dist );
                 minDistEyeToCornerAlongViewDir = CVF_MIN( minDistEyeToCornerAlongViewDir, dist );
             }

--- a/Fwk/AppFwk/cafVizExtensions/cafTransparentWBRenderConfiguration.cpp
+++ b/Fwk/AppFwk/cafVizExtensions/cafTransparentWBRenderConfiguration.cpp
@@ -542,12 +542,7 @@ void WBTransparencySurfaceEffectGenerator::updateForFixedFunctionRendering( cvf:
 //--------------------------------------------------------------------------------------------------
 void WBTransparencySurfaceEffectGenerator::updateCommonEffect( cvf::Effect* effect ) const
 {
-    if ( m_polygonOffset != PO_NONE )
-    {
-        cvf::ref<cvf::RenderStatePolygonOffset> polyOffset =
-            EffectGenerator::createAndConfigurePolygonOffsetRenderState( m_polygonOffset );
-        effect->setRenderState( polyOffset.p() );
-    }
+    EffectGenerator::applyPolygonOffset( effect, m_polygonOffset );
 
     if ( m_color.a() < 1.0f )
     {

--- a/Fwk/VizFwk/LibRender/cvfShaderProgramGenerator.cpp
+++ b/Fwk/VizFwk/LibRender/cvfShaderProgramGenerator.cpp
@@ -39,6 +39,7 @@
 #include "cvfShaderProgramGenerator.h"
 #include "cvfShaderProgram.h"
 #include "cvfShaderSourceProvider.h"
+#include "cvfUniform.h"
 #include "cvfMath.h"
 
 namespace cvf {
@@ -61,6 +62,7 @@ ShaderProgramGenerator::ShaderProgramGenerator(String shaderProgramName, ShaderS
     CVF_ASSERT(sourceProvider);
     m_sourceProvider = sourceProvider;
     m_shaderProgramName = shaderProgramName;
+    m_injectLogDepth = true;
 }
 
 
@@ -140,7 +142,16 @@ void ShaderProgramGenerator::addFragmentCodeFromFile(String shaderName)
 
 
 //--------------------------------------------------------------------------------------------------
-/// 
+///
+//--------------------------------------------------------------------------------------------------
+void ShaderProgramGenerator::setInjectLogDepth(bool inject)
+{
+    m_injectLogDepth = inject;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+///
 //--------------------------------------------------------------------------------------------------
 void ShaderProgramGenerator::configureStandardHeadlightColor()
 {
@@ -170,8 +181,29 @@ ref<ShaderProgram> ShaderProgramGenerator::generate()
 {
     CVF_ASSERT((!m_vertexCodes.empty()) && (!m_fragmentCodes.empty()));
 
-    ShaderSourceCombiner vertexCombiner(m_vertexCodes, m_vertexNames);
-    ShaderSourceCombiner fragmentCombiner(m_fragmentCodes, m_fragmentNames);
+    std::vector<String> vertexCodes;
+    std::vector<String> vertexNames;
+    std::vector<String> fragmentCodes;
+    std::vector<String> fragmentNames;
+
+    if (m_injectLogDepth)
+    {
+        // Prepend the log-depth components so that the CVF_LOG_DEPTH_IMPL #define
+        // is visible to all vertex/fragment shaders that have the corresponding hooks.
+        // Screen-space shaders should call setInjectLogDepth(false) to skip this.
+        vertexCodes.push_back(m_sourceProvider->getSourceFromRepository(ShaderSourceRepository::vs_logDepth));
+        vertexNames.push_back("vs_logDepth");
+        fragmentCodes.push_back(m_sourceProvider->getSourceFromRepository(ShaderSourceRepository::fs_logDepth));
+        fragmentNames.push_back("fs_logDepth");
+    }
+
+    vertexCodes.insert(vertexCodes.end(), m_vertexCodes.begin(), m_vertexCodes.end());
+    vertexNames.insert(vertexNames.end(), m_vertexNames.begin(), m_vertexNames.end());
+    fragmentCodes.insert(fragmentCodes.end(), m_fragmentCodes.begin(), m_fragmentCodes.end());
+    fragmentNames.insert(fragmentNames.end(), m_fragmentNames.begin(), m_fragmentNames.end());
+
+    ShaderSourceCombiner vertexCombiner(vertexCodes, vertexNames);
+    ShaderSourceCombiner fragmentCombiner(fragmentCodes, fragmentNames);
     String vertexSource = vertexCombiner.combinedSource();
     String fragmentSource = fragmentCombiner.combinedSource();
 
@@ -184,6 +216,17 @@ ref<ShaderProgram> ShaderProgramGenerator::generate()
 
     prog->addShader(vertexShader.p());
     prog->addShader(fragmentShader.p());
+
+    if (m_injectLogDepth)
+    {
+        // Provide defaults so uniforms are always "set" even when the caller does not
+        // configure polygon offset or has not yet received the per-frame global uniforms.
+        // The GlobalViewerDynUniformSet overrides u_logDepthFC and u_useLogDepth each frame.
+        // Explicit applyPolygonOffset() calls on the effect override the offset defaults.
+        prog->setDefaultUniform(new UniformFloat("u_useLogDepth",         1.0f));
+        prog->setDefaultUniform(new UniformFloat("u_polygonOffsetFactor", 0.0f));
+        prog->setDefaultUniform(new UniformFloat("u_polygonOffsetUnits",  0.0f));
+    }
 
     if (!m_geometryCodes.empty())
     {

--- a/Fwk/VizFwk/LibRender/cvfShaderProgramGenerator.h
+++ b/Fwk/VizFwk/LibRender/cvfShaderProgramGenerator.h
@@ -68,11 +68,13 @@ public:
     void                configureStandardHeadlightColor();
     void                configureStandardHeadlightTexture();
 
+    void                setInjectLogDepth(bool inject);
     ref<ShaderProgram>  generate();
 
 private:
     ShaderSourceProvider*   m_sourceProvider;
     String                  m_shaderProgramName;
+    bool                    m_injectLogDepth;
 
     std::vector<String>     m_vertexCodes;
     std::vector<String>     m_fragmentCodes;

--- a/Fwk/VizFwk/LibRender/cvfShaderSourceRepository.cpp
+++ b/Fwk/VizFwk/LibRender/cvfShaderSourceRepository.cpp
@@ -123,6 +123,8 @@ const char* ShaderSourceRepository::shaderIdentString(ShaderIdent shaderIdent)
         
         CVF_IDENT_HANDLE_CASE(checkDiscard_ClipDistances);
 
+        CVF_IDENT_HANDLE_CASE(vs_logDepth);
+
         CVF_IDENT_HANDLE_CASE(vs_Standard);
         CVF_IDENT_HANDLE_CASE(vs_EnvironmentMapping);
         CVF_IDENT_HANDLE_CASE(vs_FullScreenQuad);
@@ -132,6 +134,8 @@ const char* ShaderSourceRepository::shaderIdentString(ShaderIdent shaderIdent)
         CVF_IDENT_HANDLE_CASE(vs_DistanceScaledPoints);
         CVF_IDENT_HANDLE_CASE(vs_ParticleTraceComets);
         
+        CVF_IDENT_HANDLE_CASE(fs_logDepth);
+
         CVF_IDENT_HANDLE_CASE(fs_Standard);
         CVF_IDENT_HANDLE_CASE(fs_Shadow_v33);
         CVF_IDENT_HANDLE_CASE(fs_Unlit);
@@ -184,6 +188,8 @@ bool ShaderSourceRepository::rawShaderSource(ShaderIdent shaderIdent, CharArray*
 
         CVF_SOURCE_HANDLE_CASE(checkDiscard_ClipDistances);
 
+        CVF_SOURCE_HANDLE_CASE(vs_logDepth);
+
         CVF_SOURCE_HANDLE_CASE(vs_Standard);
         CVF_SOURCE_HANDLE_CASE(vs_EnvironmentMapping);
         CVF_SOURCE_HANDLE_CASE(vs_FullScreenQuad);
@@ -192,6 +198,8 @@ bool ShaderSourceRepository::rawShaderSource(ShaderIdent shaderIdent, CharArray*
         CVF_SOURCE_HANDLE_CASE(vs_VectorDrawer);
         CVF_SOURCE_HANDLE_CASE(vs_DistanceScaledPoints);
         CVF_SOURCE_HANDLE_CASE(vs_ParticleTraceComets);
+
+        CVF_SOURCE_HANDLE_CASE(fs_logDepth);
 
         CVF_SOURCE_HANDLE_CASE(fs_Standard);
         CVF_SOURCE_HANDLE_CASE(fs_Shadow_v33);

--- a/Fwk/VizFwk/LibRender/cvfShaderSourceRepository.h
+++ b/Fwk/VizFwk/LibRender/cvfShaderSourceRepository.h
@@ -73,6 +73,8 @@ public:
 
         checkDiscard_ClipDistances,
 
+        vs_logDepth,
+
         vs_Standard,
         vs_EnvironmentMapping,
         vs_FullScreenQuad,
@@ -81,6 +83,8 @@ public:
         vs_VectorDrawer,
         vs_DistanceScaledPoints,
         vs_ParticleTraceComets,
+
+        fs_logDepth,
 
         fs_Standard,
         fs_Shadow_v33,

--- a/Fwk/VizFwk/LibRender/cvfShaderSourceStrings.h
+++ b/Fwk/VizFwk/LibRender/cvfShaderSourceStrings.h
@@ -122,6 +122,10 @@ static const char fs_CenterLitSpherePoints_inl[] =
 "    gl_FragColor = vec4(color.rgb*diffuse, color.a);                                                  \n"
 "                                                                                                      \n"
 "    //gl_FragDepth = gl_FragCoord.z - 15.0*(1.0-mag);                                                 \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    applyLogDepth();                                                                                  \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -136,6 +140,10 @@ static const char fs_FixedColorMagenta_inl[] =
 "void main()                                                                                           \n"
 "{                                                                                                     \n"
 "    gl_FragColor = vec4(1,0,1,1);                                                                     \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    applyLogDepth();                                                                                  \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -406,6 +414,10 @@ static const char fs_HighlightStencilDraw_inl[] =
 "void main()                                                                                           \n"
 "{                                                                                                     \n"
 "    gl_FragData[0] = u_color;                                                                         \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    applyLogDepth();                                                                                  \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -437,6 +449,55 @@ static const char fs_HighlightStencilMix_v33_inl[] =
 
 //#############################################################################################################################
 //#############################################################################################################################
+static const char fs_logDepth_inl[] =
+"                                                                                                           \n"
+"varying float v_logz;                                                                                      \n"
+"                                                                                                           \n"
+"uniform float u_logDepthFC;           // = 2.0 / log2(farPlane + 1.0), updated each frame                  \n"
+"uniform float u_useLogDepth;          // 1.0 = perspective (log depth), 0.0 = orthographic (linear depth)  \n"
+"uniform float u_polygonOffsetFactor;  // mirrors glPolygonOffset factor (default 0)                        \n"
+"uniform float u_polygonOffsetUnits;   // mirrors glPolygonOffset units  (default 0)                        \n"
+"                                                                                                           \n"
+"#define CVF_LOG_DEPTH_IMPL                                                                                 \n"
+"                                                                                                           \n"
+"//--------------------------------------------------------------------------------------------------       \n"
+"/// Fragment component - logarithmic depth buffer                                                          \n"
+"/// Writes a log-distributed depth to gl_FragDepth, replacing the default linear depth.                    \n"
+"/// Requires v_logz to be set by calcLogDepth() in the vertex shader.                                      \n"
+"///                                                                                                        \n"
+"/// For orthographic projection (u_useLogDepth == 0), falls back to the standard linear                    \n"
+"/// gl_FragCoord.z, since w_clip == 1 in orthographic and log depth gives no benefit.                      \n"
+"///                                                                                                        \n"
+"/// Also implements polygon offset manually, because glPolygonOffset has no effect when                    \n"
+"/// gl_FragDepth is written explicitly. Set u_polygonOffsetFactor/Units to mirror the                      \n"
+"/// glPolygonOffset parameters used on the effect.                                                         \n"
+"///                                                                                                        \n"
+"/// Reference: http://outerra.blogspot.com/2013/07/logarithmic-depth-buffer-optimizations.html             \n"
+"//--------------------------------------------------------------------------------------------------       \n"
+"void applyLogDepth()                                                                                       \n"
+"{                                                                                                          \n"
+"    float depth;                                                                                           \n"
+"    if (u_useLogDepth > 0.5)                                                                               \n"
+"    {                                                                                                      \n"
+"        depth = log2(max(1.0e-6, v_logz)) * u_logDepthFC * 0.5;                                            \n"
+"    }                                                                                                      \n"
+"    else                                                                                                   \n"
+"    {                                                                                                      \n"
+"        depth = gl_FragCoord.z;                                                                            \n"
+"    }                                                                                                      \n"
+"                                                                                                           \n"
+"    // Manual polygon offset: factor * max_slope + units * depth_resolution                                \n"
+"    // Resolution constant = 1/2^24 for a 24-bit depth buffer.                                             \n"
+"    float slope = max(abs(dFdx(depth)), abs(dFdy(depth)));                                                 \n"
+"    depth += u_polygonOffsetFactor * slope + u_polygonOffsetUnits * (1.0 / 16777216.0);                    \n"
+"                                                                                                           \n"
+"    gl_FragDepth = depth;                                                                                  \n"
+"}                                                                                                          \n";
+
+
+
+//#############################################################################################################################
+//#############################################################################################################################
 static const char fs_ParticleTraceComets_inl[] =
 "                                                                                                      \n"
 "varying vec2 v_circleFactors;                                                                         \n"
@@ -462,6 +523,10 @@ static const char fs_ParticleTraceComets_inl[] =
 "                                                                                                      \n"
 "    vec3 color = srcFragment().rgb;                                                                   \n"
 "    gl_FragColor = vec4(color*diffuse, v_alpha);                                                      \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    applyLogDepth();                                                                                  \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -538,6 +603,10 @@ static const char fs_Standard_inl[] =
 "    color = lightFragment(color, 1.0);                                                                   \n"
 "                                                                                                         \n"
 "    gl_FragColor = color;                                                                                \n"
+"                                                                                                         \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                                \n"
+"    applyLogDepth();                                                                                     \n"
+"#endif                                                                                                   \n"
 "}                                                                                                        \n";
 
 
@@ -558,6 +627,10 @@ static const char fs_Text_inl[] =
 "{                                                                                                     \n"
 "    float alpha = texture2D(u_texture2D, v_texCoord).a;                                               \n"
 "    gl_FragColor = vec4(u_color, alpha);                                                              \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    applyLogDepth();                                                                                  \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -580,6 +653,10 @@ static const char fs_Unlit_inl[] =
 "    vec4 color = srcFragment();                                                                       \n"
 "                                                                                                      \n"
 "    gl_FragColor = color;                                                                             \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    applyLogDepth();                                                                                  \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -601,6 +678,10 @@ static const char fs_VectorDrawer_inl[] =
 "#endif                                                                                                \n"
 "                                                                                                      \n"
 "    gl_FragColor = vec4(u_color*v_diffuse, 1.0);                                                      \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    applyLogDepth();                                                                                  \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -957,6 +1038,10 @@ static const char vs_DistanceScaledPoints_inl[] =
 "                                                                                                      \n"
 "    gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;                                         \n"
 "                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    calcLogDepth(gl_Position);                                                                        \n"
+"#endif                                                                                                \n"
+"                                                                                                      \n"
 "    // Compute the point diameter in window coords (pixels)                                           \n"
 "    // Scale with distance for perspective correction of the size                                     \n"
 "    float dist = length(v_ecPosition);                                                                \n"
@@ -1001,6 +1086,10 @@ static const char vs_EnvironmentMapping_inl[] =
 "                                                                                                      \n"
 "    gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;                                         \n"
 "                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    calcLogDepth(gl_Position);                                                                        \n"
+"#endif                                                                                                \n"
+"                                                                                                      \n"
 "    // Compute the texture coordinate for the environment map texture lookup                          \n"
 "    vec3 u = normalize(v_ecPosition);                                                                 \n"
 "    vec3 n = normalize(v_ecNormal);                                                                   \n"
@@ -1041,6 +1130,26 @@ static const char vs_FullScreenQuad_inl[] =
 
 //#############################################################################################################################
 //#############################################################################################################################
+static const char vs_logDepth_inl[] =
+"                                                                                                      \n"
+"varying float v_logz;                                                                                 \n"
+"                                                                                                      \n"
+"#define CVF_LOG_DEPTH_IMPL                                                                            \n"
+"                                                                                                      \n"
+"//--------------------------------------------------------------------------------------------------  \n"
+"/// Vertex component - logarithmic depth buffer (Outerra method)                                      \n"
+"/// Store (1 + w_clip) in v_logz for use in the fragment shader.                                      \n"
+"/// Call calcLogDepth(gl_Position) at the end of the vertex main() to activate.                       \n"
+"//--------------------------------------------------------------------------------------------------  \n"
+"void calcLogDepth(vec4 clipPos)                                                                       \n"
+"{                                                                                                     \n"
+"    v_logz = 1.0 + clipPos.w;                                                                         \n"
+"}                                                                                                     \n";
+
+
+
+//#############################################################################################################################
+//#############################################################################################################################
 static const char vs_Minimal_inl[] =
 "                                                                                                      \n"
 "uniform mat4 cvfu_modelViewProjectionMatrix;                                                          \n"
@@ -1057,6 +1166,10 @@ static const char vs_Minimal_inl[] =
 "void main ()                                                                                          \n"
 "{                                                                                                     \n"
 "    gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;                                         \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    calcLogDepth(gl_Position);                                                                        \n"
+"#endif                                                                                                \n"
 "                                                                                                      \n"
 "#ifdef CVF_CALC_CLIP_DISTANCES_IMPL                                                                   \n"
 "    vec3 ecPosition = (cvfu_modelViewMatrix * cvfa_vertex).xyz;                                       \n"
@@ -1087,6 +1200,10 @@ static const char vs_MinimalTexture_inl[] =
 "{                                                                                                     \n"
 "    v_texCoord = cvfa_texCoord;                                                                       \n"
 "    gl_Position = cvfu_modelViewProjectionMatrix * cvfa_vertex;                                       \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    calcLogDepth(gl_Position);                                                                        \n"
+"#endif                                                                                                \n"
 "                                                                                                      \n"
 "#ifdef CVF_CALC_CLIP_DISTANCES_IMPL                                                                   \n"
 "    vec3 ecPosition = (cvfu_modelViewMatrix * cvfa_vertex).xyz;                                       \n"
@@ -1138,6 +1255,10 @@ static const char vs_ParticleTraceComets_inl[] =
 "    v_alpha = a_alpha;                                                                                \n"
 "                                                                                                      \n"
 "    gl_Position = cvfu_projectionMatrix * ecVertex;                                                   \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    calcLogDepth(gl_Position);                                                                        \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -1180,6 +1301,10 @@ static const char vs_Standard_inl[] =
 "#endif                                                                                                \n"
 "                                                                                                      \n"
 "    gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;                                         \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    calcLogDepth(gl_Position);                                                                        \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 
@@ -1213,6 +1338,10 @@ static const char vs_VectorDrawer_inl[] =
 "                                                                                                      \n"
 "    gl_Position = cvfu_modelViewProjectionMatrix*u_transformationMatrix*cvfa_vertex;                  \n"
 "    v_diffuse = abs(normalize(cvfu_normalMatrix*mat3_transMatr*cvfa_normal).z);                       \n"
+"                                                                                                      \n"
+"#ifdef CVF_LOG_DEPTH_IMPL                                                                             \n"
+"    calcLogDepth(gl_Position);                                                                        \n"
+"#endif                                                                                                \n"
 "}                                                                                                     \n";
 
 

--- a/Fwk/VizFwk/LibRender/glsl/fs_CenterLitSpherePoints.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_CenterLitSpherePoints.glsl
@@ -29,6 +29,10 @@ void main()
     gl_FragColor = vec4(color.rgb*diffuse, color.a);
 
     //gl_FragDepth = gl_FragCoord.z - 15.0*(1.0-mag);
+
+#ifdef CVF_LOG_DEPTH_IMPL
+    applyLogDepth();
+#endif
 }
 
 

--- a/Fwk/VizFwk/LibRender/glsl/fs_FixedColorMagenta.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_FixedColorMagenta.glsl
@@ -5,4 +5,8 @@
 void main()
 {
 	gl_FragColor = vec4(1,0,1,1);
+
+#ifdef CVF_LOG_DEPTH_IMPL
+	applyLogDepth();
+#endif
 }

--- a/Fwk/VizFwk/LibRender/glsl/fs_HighlightStencilDraw.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_HighlightStencilDraw.glsl
@@ -7,5 +7,9 @@ uniform vec4 u_color;
 void main()
 {
 	gl_FragData[0] = u_color;
+
+#ifdef CVF_LOG_DEPTH_IMPL
+	applyLogDepth();
+#endif
 }
 

--- a/Fwk/VizFwk/LibRender/glsl/fs_ParticleTraceComets.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_ParticleTraceComets.glsl
@@ -22,5 +22,9 @@ void main()
 
 	vec3 color = srcFragment().rgb;
     gl_FragColor = vec4(color*diffuse, v_alpha);
+
+#ifdef CVF_LOG_DEPTH_IMPL
+    applyLogDepth();
+#endif
 }
 

--- a/Fwk/VizFwk/LibRender/glsl/fs_Standard.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_Standard.glsl
@@ -16,4 +16,8 @@ void main()
 	color = lightFragment(color, 1.0);
 
 	gl_FragColor = color;
+
+#ifdef CVF_LOG_DEPTH_IMPL
+	applyLogDepth();
+#endif
 }

--- a/Fwk/VizFwk/LibRender/glsl/fs_Text.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_Text.glsl
@@ -11,4 +11,8 @@ void main()
 {
 	float alpha = texture2D(u_texture2D, v_texCoord).a;
     gl_FragColor = vec4(u_color, alpha);
+
+#ifdef CVF_LOG_DEPTH_IMPL
+    applyLogDepth();
+#endif
 }

--- a/Fwk/VizFwk/LibRender/glsl/fs_Unlit.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_Unlit.glsl
@@ -13,4 +13,8 @@ void main()
 	vec4 color = srcFragment();
 
 	gl_FragColor = color;
+
+#ifdef CVF_LOG_DEPTH_IMPL
+	applyLogDepth();
+#endif
 }

--- a/Fwk/VizFwk/LibRender/glsl/fs_VectorDrawer.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_VectorDrawer.glsl
@@ -12,4 +12,8 @@ void main()
 #endif
 
 	gl_FragColor = vec4(u_color*v_diffuse, 1.0);
+
+#ifdef CVF_LOG_DEPTH_IMPL
+	applyLogDepth();
+#endif
 }

--- a/Fwk/VizFwk/LibRender/glsl/fs_logDepth.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/fs_logDepth.glsl
@@ -1,0 +1,43 @@
+
+varying float v_logz;
+
+uniform float u_logDepthFC;           // = 2.0 / log2(farPlane + 1.0), updated each frame
+uniform float u_useLogDepth;          // 1.0 = perspective (log depth), 0.0 = orthographic (linear depth)
+uniform float u_polygonOffsetFactor;  // mirrors glPolygonOffset factor (default 0)
+uniform float u_polygonOffsetUnits;   // mirrors glPolygonOffset units  (default 0)
+
+#define CVF_LOG_DEPTH_IMPL
+
+//--------------------------------------------------------------------------------------------------
+/// Fragment component - logarithmic depth buffer
+/// Writes a log-distributed depth to gl_FragDepth, replacing the default linear depth.
+/// Requires v_logz to be set by calcLogDepth() in the vertex shader.
+///
+/// For orthographic projection (u_useLogDepth == 0), falls back to the standard linear
+/// gl_FragCoord.z, since w_clip == 1 in orthographic and log depth gives no benefit.
+///
+/// Also implements polygon offset manually, because glPolygonOffset has no effect when
+/// gl_FragDepth is written explicitly. Set u_polygonOffsetFactor/Units to mirror the
+/// glPolygonOffset parameters used on the effect.
+///
+/// Reference: http://outerra.blogspot.com/2013/07/logarithmic-depth-buffer-optimizations.html
+//--------------------------------------------------------------------------------------------------
+void applyLogDepth()
+{
+    float depth;
+    if (u_useLogDepth > 0.5)
+    {
+        depth = log2(max(1.0e-6, v_logz)) * u_logDepthFC * 0.5;
+    }
+    else
+    {
+        depth = gl_FragCoord.z;
+    }
+
+    // Manual polygon offset: factor * max_slope + units * depth_resolution
+    // Resolution constant = 1/2^24 for a 24-bit depth buffer.
+    float slope = max(abs(dFdx(depth)), abs(dFdy(depth)));
+    depth += u_polygonOffsetFactor * slope + u_polygonOffsetUnits * (1.0 / 16777216.0);
+
+    gl_FragDepth = depth;
+}

--- a/Fwk/VizFwk/LibRender/glsl/vs_DistanceScaledPoints.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/vs_DistanceScaledPoints.glsl
@@ -24,6 +24,10 @@ void main ()
 
 	gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;
 
+#ifdef CVF_LOG_DEPTH_IMPL
+	calcLogDepth(gl_Position);
+#endif
+
 	// Compute the point diameter in window coords (pixels)
 	// Scale with distance for perspective correction of the size
     float dist = length(v_ecPosition);

--- a/Fwk/VizFwk/LibRender/glsl/vs_EnvironmentMapping.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/vs_EnvironmentMapping.glsl
@@ -31,6 +31,10 @@ void main ()
 
 	gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;
 
+#ifdef CVF_LOG_DEPTH_IMPL
+	calcLogDepth(gl_Position);
+#endif
+
 	// Compute the texture coordinate for the environment map texture lookup
 	vec3 u = normalize(v_ecPosition);
 	vec3 n = normalize(v_ecNormal);

--- a/Fwk/VizFwk/LibRender/glsl/vs_Minimal.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/vs_Minimal.glsl
@@ -14,6 +14,10 @@ void main ()
 {
 	gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;
 
+#ifdef CVF_LOG_DEPTH_IMPL
+	calcLogDepth(gl_Position);
+#endif
+
 #ifdef CVF_CALC_CLIP_DISTANCES_IMPL
 	vec3 ecPosition = (cvfu_modelViewMatrix * cvfa_vertex).xyz;
 	calcClipDistances(vec4(ecPosition, 1));

--- a/Fwk/VizFwk/LibRender/glsl/vs_MinimalTexture.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/vs_MinimalTexture.glsl
@@ -17,6 +17,10 @@ void main ()
 	v_texCoord = cvfa_texCoord;
 	gl_Position = cvfu_modelViewProjectionMatrix * cvfa_vertex;
 
+#ifdef CVF_LOG_DEPTH_IMPL
+	calcLogDepth(gl_Position);
+#endif
+
 #ifdef CVF_CALC_CLIP_DISTANCES_IMPL
 	vec3 ecPosition = (cvfu_modelViewMatrix * cvfa_vertex).xyz;
 	calcClipDistances(vec4(ecPosition, 1));

--- a/Fwk/VizFwk/LibRender/glsl/vs_ParticleTraceComets.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/vs_ParticleTraceComets.glsl
@@ -37,4 +37,8 @@ void main()
 	v_alpha = a_alpha;
 
     gl_Position = cvfu_projectionMatrix * ecVertex;
+
+#ifdef CVF_LOG_DEPTH_IMPL
+    calcLogDepth(gl_Position);
+#endif
 }

--- a/Fwk/VizFwk/LibRender/glsl/vs_Standard.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/vs_Standard.glsl
@@ -33,4 +33,8 @@ void main ()
 #endif
 
 	gl_Position = cvfu_modelViewProjectionMatrix*cvfa_vertex;
+
+#ifdef CVF_LOG_DEPTH_IMPL
+	calcLogDepth(gl_Position);
+#endif
 }

--- a/Fwk/VizFwk/LibRender/glsl/vs_VectorDrawer.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/vs_VectorDrawer.glsl
@@ -24,4 +24,8 @@ void main ()
 
 	gl_Position = cvfu_modelViewProjectionMatrix*u_transformationMatrix*cvfa_vertex;
 	v_diffuse = abs(normalize(cvfu_normalMatrix*mat3_transMatr*cvfa_normal).z);
+
+#ifdef CVF_LOG_DEPTH_IMPL
+	calcLogDepth(gl_Position);
+#endif
 }

--- a/Fwk/VizFwk/LibRender/glsl/vs_logDepth.glsl
+++ b/Fwk/VizFwk/LibRender/glsl/vs_logDepth.glsl
@@ -1,0 +1,14 @@
+
+varying float v_logz;
+
+#define CVF_LOG_DEPTH_IMPL
+
+//--------------------------------------------------------------------------------------------------
+/// Vertex component - logarithmic depth buffer (Outerra method)
+/// Store (1 + w_clip) in v_logz for use in the fragment shader.
+/// Call calcLogDepth(gl_Position) at the end of the vertex main() to activate.
+//--------------------------------------------------------------------------------------------------
+void calcLogDepth(vec4 clipPos)
+{
+    v_logz = 1.0 + clipPos.w;
+}

--- a/Fwk/VizFwk/LibViewing/cvfSingleQuadRenderingGenerator.cpp
+++ b/Fwk/VizFwk/LibViewing/cvfSingleQuadRenderingGenerator.cpp
@@ -172,8 +172,9 @@ ref<Rendering> SingleQuadRenderingGenerator::generate()
         }
     }
 
-    // Shader program
+    // Shader program — screen-space quad, no 3D depth needed
     cvf::ShaderProgramGenerator gen(m_renderingName + "ShaderProg", cvf::ShaderSourceProvider::instance());
+    gen.setInjectLogDepth(false);
 
     gen.addVertexCode(cvf::ShaderSourceRepository::vs_FullScreenQuad);
 


### PR DESCRIPTION
* Implement logarithmic depth buffer across all 3D shaders to reduce most z-fighting issues
  - Add <b><i>vs_logDepth.glsl</i></b> and <b><i>fs_logDepth.glsl</i></b> components with automatic injection
  - Update all 3D vertex/fragment shaders with log-depth hooks
  - Expose <b><i>u_logDepthFC</i></b> uniform computed from far plane each frame
* Improve near/far clipping plane calculation by iterating per-model bounding boxes
  - Skip models outside camera frustum to prevent distant objects inflating far plane
  - Enforce maximum far/near ratio of 3000.0 to preserve depth buffer precision
  - Refine near plane adjustment when zooming into point of interest
* Fix polygon offset for logarithmic depth buffer rendering
  - Implement manual polygon offset in fragment shader using derivatives
  - Add <b><i>applyPolygonOffset()</i></b> helper to set both GL state and shader uniforms
  - Update all effect generators to use new unified polygon offset method
