### PR TITLE
VTK: Improve displacement support for GeoMech models

### DIFF
--- a/ApplicationLibCode/FileInterface/RifVtkImportUtil.cpp
+++ b/ApplicationLibCode/FileInterface/RifVtkImportUtil.cpp
@@ -58,8 +58,13 @@ std::vector<cvf::Vec3f> RifVtkImportUtil::readDisplacements( const pugi::xml_nod
     auto dataArray = pointData.child( "DataArray" );
     if ( !dataArray || std::string( dataArray.attribute( "Name" ).value() ) != "disp" ) return {};
 
-    std::string_view text = dataArray.text().get();
-    return parseVec3fs( text );
+    std::string_view        text          = dataArray.text().get();
+    std::vector<cvf::Vec3f> displacements = parseVec3fs( text );
+
+    for ( cvf::Vec3f& d : displacements )
+        d.z() = -d.z();
+
+    return displacements;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPart.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPart.cpp
@@ -30,6 +30,7 @@ RigFemPart::RigFemPart()
     : m_elementPartId( -1 )
     , m_characteristicElementSize( std::numeric_limits<float>::infinity() )
     , m_enabled( true )
+    , m_invertIJKInStructGrid( false )
 {
 }
 
@@ -227,10 +228,18 @@ const RigFemPartGrid* RigFemPart::getOrCreateStructGrid() const
     if ( m_structGrid.isNull() )
     {
         m_structGrid = new RigFemPartGrid();
-        m_structGrid->setFemPart( this );
+        m_structGrid->setFemPart( this, m_invertIJKInStructGrid );
     }
 
     return m_structGrid.p();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RigFemPart::setInvertIJKInStructGrid( bool invert )
+{
+    m_invertIJKInStructGrid = invert;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPart.h
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPart.h
@@ -95,6 +95,7 @@ public:
     cvf::Vec3f faceNormal( int elementIndex, int faceIndex ) const;
 
     const RigFemPartGrid*   getOrCreateStructGrid() const;
+    void                    setInvertIJKInStructGrid( bool invert );
     const std::vector<int>& elementIdxToId() const;
 
     void        setName( std::string name );
@@ -111,6 +112,7 @@ private:
     int         m_elementPartId;
     std::string m_name;
     bool        m_enabled;
+    bool        m_invertIJKInStructGrid;
 
     std::vector<int>            m_elementId;
     std::vector<RigElementType> m_elementTypes;

--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartGrid.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartGrid.cpp
@@ -43,16 +43,16 @@ RigFemPartGrid::~RigFemPartGrid()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigFemPartGrid::setFemPart( const RigFemPart* femPart )
+void RigFemPartGrid::setFemPart( const RigFemPart* femPart, bool invertIJK )
 {
     m_femPart = femPart;
-    generateStructGridData();
+    generateStructGridData( invertIJK );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RigFemPartGrid::generateStructGridData()
+void RigFemPartGrid::generateStructGridData( bool invertIJK )
 {
     //[X] 1. Calculate neighbors for each element
     //[X]    record the ones with 3 or fewer neighbors as possible grid corners
@@ -178,6 +178,19 @@ void RigFemPartGrid::generateStructGridData()
     }
 
     m_elmIdxPrIJK.resize( m_elementIJKCounts[0], m_elementIJKCounts[1], m_elementIJKCounts[2] );
+
+    if ( invertIJK )
+    {
+        size_t iCount = m_elementIJKCounts[0];
+        size_t jCount = m_elementIJKCounts[1];
+        size_t kCount = m_elementIJKCounts[2];
+        for ( auto& ijk : m_ijkPrElement )
+        {
+            if ( ijk[0] >= 0 ) ijk[0] = static_cast<int>( iCount ) - 1 - ijk[0];
+            if ( ijk[1] >= 0 ) ijk[1] = static_cast<int>( jCount ) - 1 - ijk[1];
+            if ( ijk[2] >= 0 ) ijk[2] = static_cast<int>( kCount ) - 1 - ijk[2];
+        }
+    }
 
     for ( int elmIdx = 0; elmIdx < m_femPart->elementCount(); ++elmIdx )
     {

--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartGrid.h
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartGrid.h
@@ -31,7 +31,7 @@ public:
     RigFemPartGrid();
     ~RigFemPartGrid() override;
 
-    void setFemPart( const RigFemPart* femPart );
+    void setFemPart( const RigFemPart* femPart, bool invertIJK = false );
 
     size_t cellCountI() const override;
     size_t cellCountJ() const override;
@@ -47,7 +47,7 @@ public:
     cvf::Vec3d                              cellCentroid( size_t cellIndex ) const override;
 
 private:
-    void generateStructGridData();
+    void generateStructGridData( bool invertIJK );
     int  findElmIdxForIJK000();
     int  perpendicularFaceInDirection( cvf::Vec3f direction, int perpFaceIdx, int elmIdx );
 

--- a/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechDataModel/RigFemPartResultsCollection.cpp
@@ -576,9 +576,10 @@ std::map<std::string, std::vector<std::string>> RigFemPartResultsCollection::sca
             fieldCompNames[RigFemAddressDefines::porBar()];
             if ( fieldCompNames.contains( "VOIDR" ) ) fieldCompNames["PORO-PERM"].push_back( "PHI0" );
 
+            if ( fieldCompNames.contains( "U" ) ) fieldCompNames["U"].push_back( "U_LENGTH" );
+
             if ( m_readerInterface->populateDerivedResultNames() )
             {
-                if ( fieldCompNames.contains( "U" ) ) fieldCompNames["U"].push_back( "U_LENGTH" );
                 fieldCompNames[FIELD_NAME_COMPACTION];
             }
         }

--- a/ApplicationLibCode/GeoMech/GeoMechFileInterface/RifVtkReader.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechFileInterface/RifVtkReader.cpp
@@ -191,6 +191,10 @@ bool RifVtkReader::readFemParts( RigFemPartCollection* femParts )
             femPart->addElementSet( setName, elementSet );
         }
 
+        // VTK coordinates are negated to match ResInsight internal convention (z positive downward),
+        // which flips the IJK directions. Invert all so IJK=0 is at the correct corner.
+        femPart->setInvertIJKInStructGrid( true );
+
         femPart->setElementPartId( femParts->partCount() );
         femParts->addFemPart( femPart );
 

--- a/ApplicationLibCode/GeoMech/GeoMechFileInterface/RifVtkReader.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechFileInterface/RifVtkReader.cpp
@@ -376,6 +376,8 @@ std::map<std::string, std::vector<std::string>> RifVtkReader::scalarNodeFieldAnd
         retVal[entry.first] = {};
     }
 
+    retVal["U"] = { "U1", "U2", "U3" };
+
     return retVal;
 }
 
@@ -466,6 +468,28 @@ void RifVtkReader::readNodeField( const std::string&                fieldName,
                                   int                               frameIndex,
                                   std::vector<std::vector<float>*>* resultValues )
 {
+    CVF_ASSERT( resultValues );
+
+    if ( fieldName == "U" )
+    {
+        std::vector<cvf::Vec3f> disp;
+        readDisplacements( partIndex, stepIndex, frameIndex, &disp );
+        if ( disp.empty() ) return;
+
+        size_t n = disp.size();
+
+        for ( int comp = 0; comp < 3 && comp < static_cast<int>( resultValues->size() ); comp++ )
+        {
+            if ( ( *resultValues )[comp] == nullptr ) continue;
+            ( *resultValues )[comp]->resize( n );
+            for ( size_t i = 0; i < n; i++ )
+            {
+                ( *( *resultValues )[comp] )[i] = disp[i][comp];
+            }
+        }
+        return;
+    }
+
     readField( RigFemResultPosEnum::RIG_NODAL, fieldName, partIndex, stepIndex, resultValues );
 }
 

--- a/ApplicationLibCode/GeoMech/GeoMechVisualization/RivFemPartGeometryGenerator.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechVisualization/RivFemPartGeometryGenerator.cpp
@@ -248,16 +248,26 @@ void RivFemPartGeometryGenerator::setElementVisibility( const cvf::UByteArray* c
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-cvf::ref<cvf::DrawableGeo> RivFemPartGeometryGenerator::createMeshDrawableFromSingleElement( const RigFemPart* part,
-                                                                                             size_t            elmIdx,
-                                                                                             const cvf::Vec3d& displayModelOffset )
+cvf::ref<cvf::DrawableGeo> RivFemPartGeometryGenerator::createMeshDrawableFromSingleElement( const RigFemPart*              part,
+                                                                                             size_t                         elmIdx,
+                                                                                             const cvf::Vec3d&              displayModelOffset,
+                                                                                             const std::vector<cvf::Vec3f>& displacements,
+                                                                                             double                         displacementScaleFactor )
 {
     cvf::ref<cvf::Vec3fArray> quadVertices;
 
     {
         std::vector<Vec3f> vertices;
 
-        const std::vector<cvf::Vec3f>& nodeCoordinates = part->nodes().coordinates;
+        const std::vector<cvf::Vec3f>& nodeCoordinates  = part->nodes().coordinates;
+        bool                           useDisplacements = !displacements.empty() && displacements.size() == nodeCoordinates.size();
+
+        auto nodePosition = [&]( int nodeIdx ) -> cvf::Vec3d
+        {
+            cvf::Vec3d pos = cvf::Vec3d( nodeCoordinates[nodeIdx] );
+            if ( useDisplacements ) pos += cvf::Vec3d( displacements[nodeIdx] ) * displacementScaleFactor;
+            return pos;
+        };
 
         RigElementType eType     = part->elementType( elmIdx );
         int            faceCount = RigFemTypes::elementFaceCount( eType );
@@ -270,14 +280,10 @@ cvf::ref<cvf::DrawableGeo> RivFemPartGeometryGenerator::createMeshDrawableFromSi
             const int* localElmNodeIndicesForFace = RigFemTypes::localElmNodeIndicesForFace( eType, lfIdx, &faceNodeCount );
             if ( faceNodeCount == 4 )
             {
-                vertices.push_back(
-                    cvf::Vec3f( cvf::Vec3d( nodeCoordinates[elmNodeIndices[localElmNodeIndicesForFace[0]]] ) - displayModelOffset ) );
-                vertices.push_back(
-                    cvf::Vec3f( cvf::Vec3d( nodeCoordinates[elmNodeIndices[localElmNodeIndicesForFace[1]]] ) - displayModelOffset ) );
-                vertices.push_back(
-                    cvf::Vec3f( cvf::Vec3d( nodeCoordinates[elmNodeIndices[localElmNodeIndicesForFace[2]]] ) - displayModelOffset ) );
-                vertices.push_back(
-                    cvf::Vec3f( cvf::Vec3d( nodeCoordinates[elmNodeIndices[localElmNodeIndicesForFace[3]]] ) - displayModelOffset ) );
+                vertices.push_back( cvf::Vec3f( nodePosition( elmNodeIndices[localElmNodeIndicesForFace[0]] ) - displayModelOffset ) );
+                vertices.push_back( cvf::Vec3f( nodePosition( elmNodeIndices[localElmNodeIndicesForFace[1]] ) - displayModelOffset ) );
+                vertices.push_back( cvf::Vec3f( nodePosition( elmNodeIndices[localElmNodeIndicesForFace[2]] ) - displayModelOffset ) );
+                vertices.push_back( cvf::Vec3f( nodePosition( elmNodeIndices[localElmNodeIndicesForFace[3]] ) - displayModelOffset ) );
             }
             else
             {

--- a/ApplicationLibCode/GeoMech/GeoMechVisualization/RivFemPartGeometryGenerator.cpp
+++ b/ApplicationLibCode/GeoMech/GeoMechVisualization/RivFemPartGeometryGenerator.cpp
@@ -248,11 +248,11 @@ void RivFemPartGeometryGenerator::setElementVisibility( const cvf::UByteArray* c
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-cvf::ref<cvf::DrawableGeo> RivFemPartGeometryGenerator::createMeshDrawableFromSingleElement( const RigFemPart*              part,
-                                                                                             size_t                         elmIdx,
-                                                                                             const cvf::Vec3d&              displayModelOffset,
+cvf::ref<cvf::DrawableGeo> RivFemPartGeometryGenerator::createMeshDrawableFromSingleElement( const RigFemPart* part,
+                                                                                             size_t            elmIdx,
+                                                                                             const cvf::Vec3d& displayModelOffset,
                                                                                              const std::vector<cvf::Vec3f>& displacements,
-                                                                                             double                         displacementScaleFactor )
+                                                                                             double displacementScaleFactor )
 {
     cvf::ref<cvf::Vec3fArray> quadVertices;
 

--- a/ApplicationLibCode/GeoMech/GeoMechVisualization/RivFemPartGeometryGenerator.h
+++ b/ApplicationLibCode/GeoMech/GeoMechVisualization/RivFemPartGeometryGenerator.h
@@ -91,12 +91,11 @@ public:
 
     RivFemPartTriangleToElmMapper* triangleToElementMapper() { return m_triangleMapper.p(); }
 
-    static cvf::ref<cvf::DrawableGeo>
-        createMeshDrawableFromSingleElement( const RigFemPart*              part,
-                                             size_t                         elementIndex,
-                                             const cvf::Vec3d&              displayModelOffset,
-                                             const std::vector<cvf::Vec3f>& displacements          = {},
-                                             double                         displacementScaleFactor = 1.0 );
+    static cvf::ref<cvf::DrawableGeo> createMeshDrawableFromSingleElement( const RigFemPart*              part,
+                                                                           size_t                         elementIndex,
+                                                                           const cvf::Vec3d&              displayModelOffset,
+                                                                           const std::vector<cvf::Vec3f>& displacements           = {},
+                                                                           double                         displacementScaleFactor = 1.0 );
 
 private:
     void computeArrays( const std::vector<cvf::Vec3f>& nodeCoordinates );

--- a/ApplicationLibCode/GeoMech/GeoMechVisualization/RivFemPartGeometryGenerator.h
+++ b/ApplicationLibCode/GeoMech/GeoMechVisualization/RivFemPartGeometryGenerator.h
@@ -92,7 +92,11 @@ public:
     RivFemPartTriangleToElmMapper* triangleToElementMapper() { return m_triangleMapper.p(); }
 
     static cvf::ref<cvf::DrawableGeo>
-        createMeshDrawableFromSingleElement( const RigFemPart* grid, size_t elementIndex, const cvf::Vec3d& displayModelOffset );
+        createMeshDrawableFromSingleElement( const RigFemPart*              part,
+                                             size_t                         elementIndex,
+                                             const cvf::Vec3d&              displayModelOffset,
+                                             const std::vector<cvf::Vec3f>& displacements          = {},
+                                             double                         displacementScaleFactor = 1.0 );
 
 private:
     void computeArrays( const std::vector<cvf::Vec3f>& nodeCoordinates );

--- a/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.cpp
@@ -248,7 +248,11 @@ cvf::ref<cvf::DrawableGeo> RivSingleCellPartGenerator::createMeshDrawable()
         RigFemPart* femPart = m_geoMechCase->geoMechData()->femParts()->part( m_gridIndex );
         CVF_ASSERT( femPart );
 
-        return RivFemPartGeometryGenerator::createMeshDrawableFromSingleElement( femPart, m_cellIndex, m_displayModelOffset, m_displacements, m_displacementScaleFactor );
+        return RivFemPartGeometryGenerator::createMeshDrawableFromSingleElement( femPart,
+                                                                                 m_cellIndex,
+                                                                                 m_displayModelOffset,
+                                                                                 m_displacements,
+                                                                                 m_displacementScaleFactor );
     }
 
     return nullptr;

--- a/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.cpp
+++ b/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.cpp
@@ -83,6 +83,15 @@ void RivSingleCellPartGenerator::setShowLgrMeshLines( bool enable )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RivSingleCellPartGenerator::setDisplacementData( double scaleFactor, const std::vector<cvf::Vec3f>& displacements )
+{
+    m_displacementScaleFactor = scaleFactor;
+    m_displacements           = displacements;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 cvf::ref<cvf::Part> RivSingleCellPartGenerator::createPart( const cvf::Color3f color )
 {
     cvf::ref<cvf::Part> part = new cvf::Part;
@@ -239,7 +248,7 @@ cvf::ref<cvf::DrawableGeo> RivSingleCellPartGenerator::createMeshDrawable()
         RigFemPart* femPart = m_geoMechCase->geoMechData()->femParts()->part( m_gridIndex );
         CVF_ASSERT( femPart );
 
-        return RivFemPartGeometryGenerator::createMeshDrawableFromSingleElement( femPart, m_cellIndex, m_displayModelOffset );
+        return RivFemPartGeometryGenerator::createMeshDrawableFromSingleElement( femPart, m_cellIndex, m_displayModelOffset, m_displacements, m_displacementScaleFactor );
     }
 
     return nullptr;

--- a/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.h
+++ b/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.h
@@ -20,6 +20,9 @@
 #pragma once
 
 #include "cvfDrawableGeo.h"
+#include "cvfVector3.h"
+
+#include <vector>
 
 namespace cvf
 {
@@ -41,6 +44,7 @@ public:
     RivSingleCellPartGenerator( RimGeoMechCase* rimGeoMechCase, size_t gridIndex, size_t cellIndex, const cvf::Vec3d& displayModelOffset );
 
     void setShowLgrMeshLines( bool enable );
+    void setDisplacementData( double scaleFactor, const std::vector<cvf::Vec3f>& displacements );
 
     cvf::ref<cvf::Part>               createPart( const cvf::Color3f color );
     static cvf::ref<cvf::DrawableGeo> createMeshLinesOfParentGridCells( RigGridBase const*   grid,
@@ -58,4 +62,6 @@ private:
     size_t              m_cellIndex;
     cvf::Vec3d          m_displayModelOffset;
     bool                m_showLgrMeshLines{ false };
+    double              m_displacementScaleFactor{ 1.0 };
+    std::vector<cvf::Vec3f> m_displacements;
 };

--- a/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.h
+++ b/ApplicationLibCode/ModelVisualization/RivSingleCellPartGenerator.h
@@ -56,12 +56,12 @@ private:
     cvf::ref<cvf::DrawableGeo> createMeshDrawableFromLgrGridCells();
 
 private:
-    RigEclipseCaseData* m_rigCaseData;
-    RimGeoMechCase*     m_geoMechCase;
-    size_t              m_gridIndex;
-    size_t              m_cellIndex;
-    cvf::Vec3d          m_displayModelOffset;
-    bool                m_showLgrMeshLines{ false };
-    double              m_displacementScaleFactor{ 1.0 };
+    RigEclipseCaseData*     m_rigCaseData;
+    RimGeoMechCase*         m_geoMechCase;
+    size_t                  m_gridIndex;
+    size_t                  m_cellIndex;
+    cvf::Vec3d              m_displayModelOffset;
+    bool                    m_showLgrMeshLines{ false };
+    double                  m_displacementScaleFactor{ 1.0 };
     std::vector<cvf::Vec3f> m_displacements;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimGridView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimGridView.cpp
@@ -22,7 +22,9 @@
 #include "RimCellFilterCollection.h"
 #include "RimEclipseCase.h"
 #include "RimEclipseResultDefinition.h"
+#include "RimGeoMechPartCollection.h"
 #include "RimGeoMechResultDefinition.h"
+#include "RimGeoMechView.h"
 #include "RimGridCollection.h"
 #include "RimIntersection.h"
 #include "RimIntersectionCollection.h"
@@ -367,6 +369,17 @@ void RimGridView::onCreatePartCollectionFromSelection( cvf::Collection<cvf::Part
                                                     geomSelItem->m_gridIndex,
                                                     geomSelItem->m_cellIndex,
                                                     ownerCase()->displayModelOffset() );
+
+                auto geoMechView = dynamic_cast<RimGeoMechView*>( this );
+                if ( geoMechView )
+                {
+                    const RimGeoMechPartCollection* partsColl = geoMechView->partsCollection();
+                    if ( partsColl && partsColl->isDisplacementsUsed() )
+                    {
+                        partGen.setDisplacementData( partsColl->currentDisplacementScaleFactor(),
+                                                     partsColl->displacements( static_cast<int>( geomSelItem->m_gridIndex ) ) );
+                    }
+                }
 
                 cvf::ref<cvf::Part> part = partGen.createPart( geomSelItem->m_color );
                 part->setTransform( scaleTransform() );

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimRegularSurface.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimRegularSurface.cpp
@@ -418,6 +418,19 @@ std::vector<float> RimRegularSurface::getProperty( const QString& key ) const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+std::vector<QString> RimRegularSurface::propertyNames() const
+{
+    std::vector<QString> names;
+    for ( const auto& [key, value] : m_properties )
+    {
+        names.push_back( key );
+    }
+    return names;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 int RimRegularSurface::nx() const
 {
     return m_nx;

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimRegularSurface.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimRegularSurface.h
@@ -42,7 +42,8 @@ public:
     void setProperty( const QString& key, const std::vector<float>& values );
     void setPropertyAsDepth( const QString& key );
 
-    std::vector<float> getProperty( const QString& key ) const;
+    std::vector<float>   getProperty( const QString& key ) const;
+    std::vector<QString> propertyNames() const;
 
     int    nx() const;
     int    ny() const;

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcRegularSurface.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcRegularSurface.cpp
@@ -22,6 +22,7 @@
 
 #include "RimRegularSurface.h"
 #include "RimSurfaceCollection.h"
+#include "RimcDataContainerString.h"
 
 #include "RifSurfaceExporter.h"
 
@@ -137,4 +138,37 @@ std::expected<caf::PdmObjectHandle*, QString> RimcRegularSurface_setPropertyAsDe
     surface->updateConnectedEditors();
 
     return nullptr;
+}
+
+CAF_PDM_OBJECT_METHOD_SOURCE_INIT( RimRegularSurface, RimcRegularSurface_propertyNames, "PropertyNames" );
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimcRegularSurface_propertyNames::RimcRegularSurface_propertyNames( caf::PdmObjectHandle* self )
+    : PdmObjectMethod( self, PdmObjectMethod::NullPointerType::NULL_IS_INVALID, PdmObjectMethod::ResultType::PERSISTENT_FALSE )
+{
+    CAF_PDM_InitObject( "Property Names", "", "", "Property Names." );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::expected<caf::PdmObjectHandle*, QString> RimcRegularSurface_propertyNames::execute()
+{
+    RimRegularSurface* surface = self<RimRegularSurface>();
+    if ( !surface ) return std::unexpected( "No surface found" );
+
+    auto dataObject            = new RimcDataContainerString();
+    dataObject->m_stringValues = surface->propertyNames();
+
+    return dataObject;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RimcRegularSurface_propertyNames::classKeywordReturnedType() const
+{
+    return RimcDataContainerString::classKeywordStatic();
 }

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcRegularSurface.h
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcRegularSurface.h
@@ -75,3 +75,17 @@ public:
 private:
     caf::PdmField<QString> m_name;
 };
+
+//==================================================================================================
+///
+//==================================================================================================
+class RimcRegularSurface_propertyNames : public caf::PdmObjectMethod
+{
+    CAF_PDM_HEADER_INIT;
+
+public:
+    RimcRegularSurface_propertyNames( caf::PdmObjectHandle* self );
+
+    std::expected<caf::PdmObjectHandle*, QString> execute() override;
+    QString                                       classKeywordReturnedType() const override;
+};

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigPadModel.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigPadModel.cpp
@@ -788,10 +788,12 @@ void extendEQUIL( Opm::DeckKeyword& equil )
     equil.addRecord( std::move( record ) );
 }
 
+} // namespace
+
 //--------------------------------------------------------------------------------------------------
 /// Extend RSVD/RVVD/RTEMPVD/PBVD/PDVD tables (padmodel lines 832-867)
 //--------------------------------------------------------------------------------------------------
-void extendDepthTable( const RigModelPaddingSettings& settings, Opm::DeckKeyword& propertyVD )
+void RigPadModel::extendDepthTable( const RigModelPaddingSettings& settings, Opm::DeckKeyword& propertyVD )
 {
     assert( !propertyVD.empty() );
 
@@ -804,16 +806,25 @@ void extendDepthTable( const RigModelPaddingSettings& settings, Opm::DeckKeyword
 
         const auto& values = table.getItem( 0 ).getData<double>();
 
-        i.front().push_back( settings.topUpper() );
-        i.front().push_back( values[0 + 1] );
+        // Need at least one depth-property pair for safe indexing
+        if ( values.size() < 2 ) continue;
+
+        if ( settings.topUpper() < values.front() )
+        {
+            i.front().push_back( settings.topUpper() );
+            i.front().push_back( values[0 + 1] );
+        }
 
         for ( const auto& value : values )
         {
             i.front().push_back( value );
         }
 
-        i.front().push_back( settings.bottomLower() );
-        i.front().push_back( values.back() );
+        if ( settings.bottomLower() > values[values.size() - 2] )
+        {
+            i.front().push_back( settings.bottomLower() );
+            i.front().push_back( values.back() );
+        }
 
         newPropertyVD.addRecord( Opm::DeckRecord{ std::move( i ) } );
     }
@@ -823,8 +834,11 @@ void extendDepthTable( const RigModelPaddingSettings& settings, Opm::DeckKeyword
         newPropertyVD.addRecord( std::move( first ) );
     }
 
-    propertyVD = newPropertyVD;
+    propertyVD = std::move( newPropertyVD );
 }
+
+namespace
+{
 
 //--------------------------------------------------------------------------------------------------
 /// Extend EQUIL + depth tables in SOLUTION section (padmodel lines 869-886)
@@ -852,7 +866,7 @@ void extendSolution( const RigModelPaddingSettings& settings, Opm::FileDeck& fil
         else if ( keyword.name() == "RSVD" || keyword.name() == "RVVD" || keyword.name() == "RTEMPVD" || keyword.name() == "PBVD" ||
                   keyword.name() == "PDVD" )
         {
-            extendDepthTable( settings, const_cast<Opm::DeckKeyword&>( keyword ) );
+            RigPadModel::extendDepthTable( settings, const_cast<Opm::DeckKeyword&>( keyword ) );
         }
     }
 }

--- a/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigPadModel.h
+++ b/ApplicationLibCode/ReservoirDataModel/SimulationFile/RigPadModel.h
@@ -27,6 +27,7 @@
 namespace Opm
 {
 class Deck;
+class DeckKeyword;
 class FileDeck;
 } // namespace Opm
 
@@ -58,4 +59,6 @@ public:
                                                     int                        nzLower,
                                                     double                     upperDefault,
                                                     double                     lowerDefault );
+
+    static void extendDepthTable( const RigModelPaddingSettings& settings, Opm::DeckKeyword& propertyVD );
 };

--- a/ApplicationLibCode/UnitTests/RigPadModel-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigPadModel-Test.cpp
@@ -18,9 +18,11 @@
 
 #include "gtest/gtest.h"
 
+#include "RigModelPaddingSettings.h"
 #include "RigPadModel.h"
 
 #include "opm/input/eclipse/Deck/Deck.hpp"
+#include "opm/input/eclipse/Deck/DeckKeyword.hpp"
 #include "opm/input/eclipse/Parser/Parser.hpp"
 
 #include <algorithm>
@@ -308,4 +310,197 @@ SCHEDULE
 
     // Unknown keyword should return 0.0
     EXPECT_DOUBLE_EQ( 0.0, RigPadModel::getPropsDefaultValue( deck, "UNKNOWN_KEYWORD" ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+// Helper: parse a minimal deck with RSVD and return a mutable copy of the keyword
+//--------------------------------------------------------------------------------------------------
+static Opm::DeckKeyword createRsvdKeyword( const std::string& rsvdData )
+{
+    std::string deckString = R"(
+EQLDIMS
+  1 /
+SOLUTION
+RSVD
+)" + rsvdData;
+
+    auto deck = Opm::Parser{}.parseString( deckString );
+    return deck["RSVD"][0];
+}
+
+//--------------------------------------------------------------------------------------------------
+// Helper: extract depth values (every other element starting at index 0) from RSVD record
+//--------------------------------------------------------------------------------------------------
+static std::vector<double> getDepths( const Opm::DeckKeyword& kw, size_t recordIndex = 0 )
+{
+    const auto&         values = kw.getRecord( recordIndex ).getItem( 0 ).getData<double>();
+    std::vector<double> depths;
+    for ( size_t i = 0; i < values.size(); i += 2 )
+    {
+        depths.push_back( values[i] );
+    }
+    return depths;
+}
+
+//--------------------------------------------------------------------------------------------------
+// Helper: verify strict monotonicity of depth values in an RSVD record
+//--------------------------------------------------------------------------------------------------
+static void verifyMonotonicDepths( const Opm::DeckKeyword& kw, size_t recordIndex = 0 )
+{
+    auto depths = getDepths( kw, recordIndex );
+    for ( size_t i = 1; i < depths.size(); ++i )
+    {
+        EXPECT_LT( depths[i - 1], depths[i] ) << "Depth values must be strictly monotonic at index " << i;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// extendDepthTable: both top and bottom rows are added when table doesn't cover padding range
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendDepthTable_BothExtended )
+{
+    // RSVD table: depths 2000, 2500, 3000 with Rs values 120, 110, 100
+    auto rsvd = createRsvdKeyword( "  2000.0  120.0\n  2500.0  110.0\n  3000.0  100.0 /\n" );
+
+    RigModelPaddingSettings settings;
+    settings.setTopUpper( 1500.0 );
+    settings.setBottomLower( 3500.0 );
+
+    RigPadModel::extendDepthTable( settings, rsvd );
+
+    // The function duplicates the first record for the padding equilibrium region
+    ASSERT_EQ( 2u, rsvd.size() );
+
+    const auto& values = rsvd.getRecord( 0 ).getItem( 0 ).getData<double>();
+
+    // 5 depth-property pairs: prepended + 3 original + appended
+    ASSERT_EQ( 10u, values.size() );
+
+    // Prepended row: depth=1500, property copied from first entry (120)
+    EXPECT_DOUBLE_EQ( 1500.0, values[0] );
+    EXPECT_DOUBLE_EQ( 120.0, values[1] );
+
+    // Original data preserved
+    EXPECT_DOUBLE_EQ( 2000.0, values[2] );
+    EXPECT_DOUBLE_EQ( 120.0, values[3] );
+    EXPECT_DOUBLE_EQ( 2500.0, values[4] );
+    EXPECT_DOUBLE_EQ( 110.0, values[5] );
+    EXPECT_DOUBLE_EQ( 3000.0, values[6] );
+    EXPECT_DOUBLE_EQ( 100.0, values[7] );
+
+    // Appended row: depth=3500, property copied from last entry (100)
+    EXPECT_DOUBLE_EQ( 3500.0, values[8] );
+    EXPECT_DOUBLE_EQ( 100.0, values[9] );
+
+    verifyMonotonicDepths( rsvd );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// extendDepthTable: table already covers top, only bottom row added
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendDepthTable_TopAlreadyCovered )
+{
+    auto rsvd = createRsvdKeyword( "  2000.0  120.0\n  2500.0  110.0\n  3000.0  100.0 /\n" );
+
+    RigModelPaddingSettings settings;
+    settings.setTopUpper( 2500.0 ); // >= first depth (2000), so no top row
+    settings.setBottomLower( 3500.0 );
+
+    RigPadModel::extendDepthTable( settings, rsvd );
+
+    const auto& values = rsvd.getRecord( 0 ).getItem( 0 ).getData<double>();
+
+    // 4 depth-property pairs: 3 original + 1 appended
+    ASSERT_EQ( 8u, values.size() );
+
+    // No prepended row - starts with original data
+    EXPECT_DOUBLE_EQ( 2000.0, values[0] );
+    EXPECT_DOUBLE_EQ( 120.0, values[1] );
+
+    // Appended row
+    EXPECT_DOUBLE_EQ( 3500.0, values[6] );
+    EXPECT_DOUBLE_EQ( 100.0, values[7] );
+
+    verifyMonotonicDepths( rsvd );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// extendDepthTable: table already covers bottom, only top row added
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendDepthTable_BottomAlreadyCovered )
+{
+    auto rsvd = createRsvdKeyword( "  2000.0  120.0\n  2500.0  110.0\n  3000.0  100.0 /\n" );
+
+    RigModelPaddingSettings settings;
+    settings.setTopUpper( 1500.0 );
+    settings.setBottomLower( 2800.0 ); // < last depth (3000), so no bottom row
+
+    RigPadModel::extendDepthTable( settings, rsvd );
+
+    const auto& values = rsvd.getRecord( 0 ).getItem( 0 ).getData<double>();
+
+    // 4 depth-property pairs: 1 prepended + 3 original
+    ASSERT_EQ( 8u, values.size() );
+
+    // Prepended row
+    EXPECT_DOUBLE_EQ( 1500.0, values[0] );
+    EXPECT_DOUBLE_EQ( 120.0, values[1] );
+
+    // No appended row - ends with original data
+    EXPECT_DOUBLE_EQ( 3000.0, values[6] );
+    EXPECT_DOUBLE_EQ( 100.0, values[7] );
+
+    verifyMonotonicDepths( rsvd );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// extendDepthTable: table already covers both top and bottom, no rows added
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendDepthTable_BothAlreadyCovered )
+{
+    auto rsvd = createRsvdKeyword( "  2000.0  120.0\n  2500.0  110.0\n  3000.0  100.0 /\n" );
+
+    RigModelPaddingSettings settings;
+    settings.setTopUpper( 2200.0 ); // > first depth (2000)
+    settings.setBottomLower( 2800.0 ); // < last depth (3000)
+
+    RigPadModel::extendDepthTable( settings, rsvd );
+
+    const auto& values = rsvd.getRecord( 0 ).getItem( 0 ).getData<double>();
+
+    // Unchanged: 3 original depth-property pairs
+    ASSERT_EQ( 6u, values.size() );
+
+    EXPECT_DOUBLE_EQ( 2000.0, values[0] );
+    EXPECT_DOUBLE_EQ( 120.0, values[1] );
+    EXPECT_DOUBLE_EQ( 2500.0, values[2] );
+    EXPECT_DOUBLE_EQ( 110.0, values[3] );
+    EXPECT_DOUBLE_EQ( 3000.0, values[4] );
+    EXPECT_DOUBLE_EQ( 100.0, values[5] );
+
+    verifyMonotonicDepths( rsvd );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// extendDepthTable: exact boundary match - strict inequalities prevent duplicate depths
+//--------------------------------------------------------------------------------------------------
+TEST( RigPadModel, ExtendDepthTable_ExactBoundaryMatch )
+{
+    auto rsvd = createRsvdKeyword( "  2000.0  120.0\n  2500.0  110.0\n  3000.0  100.0 /\n" );
+
+    RigModelPaddingSettings settings;
+    settings.setTopUpper( 2000.0 ); // == first depth, strict < means no prepend
+    settings.setBottomLower( 3000.0 ); // == last depth, strict > means no append
+
+    RigPadModel::extendDepthTable( settings, rsvd );
+
+    const auto& values = rsvd.getRecord( 0 ).getItem( 0 ).getData<double>();
+
+    // Unchanged: 3 original depth-property pairs, no duplicates
+    ASSERT_EQ( 6u, values.size() );
+
+    EXPECT_DOUBLE_EQ( 2000.0, values[0] );
+    EXPECT_DOUBLE_EQ( 3000.0, values[4] );
+
+    verifyMonotonicDepths( rsvd );
 }

--- a/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
+++ b/Fwk/AppFwk/cafPdmScripting/cafPdmScripting_UnitTests/cafPdmFieldSerializationTest.cpp
@@ -157,10 +157,7 @@ TEST( PdmFieldSerialization, ValueList )
     caf::PdmScriptIOMessages messages;
     bool                     stringsAreQuoted = true;
 
-    caf::PdmFieldScriptingCapabilityIOHandler<std::vector<float>>::readFromField( floatValues,
-                                                                                  stream,
-                                                                                  &messages,
-                                                                                  stringsAreQuoted );
+    caf::PdmFieldScriptingCapabilityIOHandler<std::vector<float>>::readFromField( floatValues, stream, stringsAreQuoted );
 
     const QString expected = "[1.5, 0.0001, 1.77e+10]";
     EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
@@ -234,7 +231,6 @@ TEST( PdmFieldSerialization, OptionalValues )
 
         caf::PdmFieldScriptingCapabilityIOHandler<std::optional<QString>>::readFromField( optionalString,
                                                                                           stream,
-                                                                                          &messages,
                                                                                           stringsAreQuoted );
 
         const QString expected = "";
@@ -261,7 +257,6 @@ TEST( PdmFieldSerialization, OptionalValues )
 
         caf::PdmFieldScriptingCapabilityIOHandler<std::optional<QString>>::readFromField( optionalString,
                                                                                           stream,
-                                                                                          &messages,
                                                                                           stringsAreQuoted );
 
         const QString expected = "\"Test string with spaces\"";
@@ -286,7 +281,7 @@ TEST( PdmFieldSerialization, OptionalValues )
 
         caf::PdmScriptIOMessages messages;
 
-        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<float>>::readFromField( optionalString, stream, &messages );
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<float>>::readFromField( optionalString, stream );
 
         const QString expected = "23.45";
         EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
@@ -308,7 +303,7 @@ TEST( PdmFieldSerialization, OptionalValues )
 
         caf::PdmScriptIOMessages messages;
 
-        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<double>>::readFromField( optionalString, stream, &messages );
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<double>>::readFromField( optionalString, stream );
 
         const QString expected = "2.345000000000000e+01";
         EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
@@ -327,7 +322,7 @@ TEST( PdmFieldSerialization, OptionalValues )
         QString                  text;
         QTextStream              stream( &text );
         caf::PdmScriptIOMessages messages;
-        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<bool>>::readFromField( optionalString, stream, &messages );
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<bool>>::readFromField( optionalString, stream );
 
         const QString expected = "true";
         EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
@@ -345,7 +340,7 @@ TEST( PdmFieldSerialization, OptionalValues )
         QString                  text;
         QTextStream              stream( &text );
         caf::PdmScriptIOMessages messages;
-        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<int>>::readFromField( optionalString, stream, &messages );
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<int>>::readFromField( optionalString, stream );
 
         const QString expected = "2345";
         EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );
@@ -362,7 +357,7 @@ TEST( PdmFieldSerialization, OptionalValues )
         QString                  text;
         QTextStream              stream( &text );
         caf::PdmScriptIOMessages messages;
-        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<int>>::readFromField( optionalInt, stream, &messages );
+        caf::PdmFieldScriptingCapabilityIOHandler<std::optional<int>>::readFromField( optionalInt, stream );
 
         const QString expected = "";
         EXPECT_STREQ( expected.toStdString().c_str(), text.toStdString().c_str() );

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmCore_UnitTests/cafAppEnumTest.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmCore_UnitTests/cafAppEnumTest.cpp
@@ -90,11 +90,11 @@ TEST( AppEnumTest, EnumSubsetNoCollision )
     auto retrievedSubset2 = caf::AppEnum<TestEnumType>::enumSubset( &obj2.m_enumField );
 
     // Verify that the subsets are correct and independent
-    ASSERT_EQ( 2, retrievedSubset1.size() );
+    ASSERT_EQ( 2u, retrievedSubset1.size() );
     EXPECT_EQ( TestEnumType::VALUE_A, retrievedSubset1[0] );
     EXPECT_EQ( TestEnumType::VALUE_B, retrievedSubset1[1] );
 
-    ASSERT_EQ( 3, retrievedSubset2.size() );
+    ASSERT_EQ( 3u, retrievedSubset2.size() );
     EXPECT_EQ( TestEnumType::VALUE_C, retrievedSubset2[0] );
     EXPECT_EQ( TestEnumType::VALUE_D, retrievedSubset2[1] );
     EXPECT_EQ( TestEnumType::VALUE_E, retrievedSubset2[2] );
@@ -116,8 +116,8 @@ TEST( AppEnumTest, EnumSubsetSameClass )
     auto retrievedSubset1 = caf::AppEnum<TestEnumType>::enumSubset( &obj1a.m_enumField );
     auto retrievedSubset2 = caf::AppEnum<TestEnumType>::enumSubset( &obj1b.m_enumField );
 
-    ASSERT_EQ( 2, retrievedSubset1.size() );
-    ASSERT_EQ( 2, retrievedSubset2.size() );
+    ASSERT_EQ( 2u, retrievedSubset1.size() );
+    ASSERT_EQ( 2u, retrievedSubset2.size() );
     EXPECT_EQ( TestEnumType::VALUE_A, retrievedSubset1[0] );
     EXPECT_EQ( TestEnumType::VALUE_C, retrievedSubset1[1] );
     EXPECT_EQ( TestEnumType::VALUE_A, retrievedSubset2[0] );

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmCore_UnitTests/cafPdmLoggingTest.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmCore/cafPdmCore_UnitTests/cafPdmLoggingTest.cpp
@@ -156,7 +156,7 @@ TEST_F( PdmLoggingTest, DuplicateRegistration )
 
     // Should still be registered only once
     caf::PdmLogging::error( "Test message" );
-    EXPECT_EQ( 1, m_testLogger1->errorCount() );
+    EXPECT_EQ( 1u, m_testLogger1->errorCount() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -187,10 +187,10 @@ TEST_F( PdmLoggingTest, BasicMessageLogging )
     caf::PdmLogging::debug( "Debug message" );
 
     // Verify messages were captured
-    EXPECT_EQ( 1, m_testLogger1->errorCount() );
-    EXPECT_EQ( 1, m_testLogger1->warningCount() );
-    EXPECT_EQ( 1, m_testLogger1->infoCount() );
-    EXPECT_EQ( 1, m_testLogger1->debugCount() );
+    EXPECT_EQ( 1u, m_testLogger1->errorCount() );
+    EXPECT_EQ( 1u, m_testLogger1->warningCount() );
+    EXPECT_EQ( 1u, m_testLogger1->infoCount() );
+    EXPECT_EQ( 1u, m_testLogger1->debugCount() );
 
     EXPECT_EQ( "Error message", m_testLogger1->errorMessages()[0] );
     EXPECT_EQ( "Warning message", m_testLogger1->warningMessages()[0] );
@@ -212,10 +212,10 @@ TEST_F( PdmLoggingTest, LogLevelFiltering )
     caf::PdmLogging::debug( "Debug message" );
 
     // Should receive error, warning, info but not debug
-    EXPECT_EQ( 1, m_testLogger2->errorCount() );
-    EXPECT_EQ( 1, m_testLogger2->warningCount() );
-    EXPECT_EQ( 1, m_testLogger2->infoCount() );
-    EXPECT_EQ( 0, m_testLogger2->debugCount() );
+    EXPECT_EQ( 1u, m_testLogger2->errorCount() );
+    EXPECT_EQ( 1u, m_testLogger2->warningCount() );
+    EXPECT_EQ( 1u, m_testLogger2->infoCount() );
+    EXPECT_EQ( 0u, m_testLogger2->debugCount() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -234,19 +234,19 @@ TEST_F( PdmLoggingTest, MultipleLoggers )
     caf::PdmLogging::debug( "Debug message" );
 
     // Error message should reach all loggers
-    EXPECT_EQ( 1, m_testLogger1->errorCount() );
-    EXPECT_EQ( 1, m_testLogger2->errorCount() );
-    EXPECT_EQ( 1, m_testLogger3->errorCount() );
+    EXPECT_EQ( 1u, m_testLogger1->errorCount() );
+    EXPECT_EQ( 1u, m_testLogger2->errorCount() );
+    EXPECT_EQ( 1u, m_testLogger3->errorCount() );
 
     // Warning should reach debug and info loggers, but not error-only logger
-    EXPECT_EQ( 1, m_testLogger1->warningCount() );
-    EXPECT_EQ( 1, m_testLogger2->warningCount() );
-    EXPECT_EQ( 0, m_testLogger3->warningCount() );
+    EXPECT_EQ( 1u, m_testLogger1->warningCount() );
+    EXPECT_EQ( 1u, m_testLogger2->warningCount() );
+    EXPECT_EQ( 0u, m_testLogger3->warningCount() );
 
     // Debug should only reach debug logger
-    EXPECT_EQ( 1, m_testLogger1->debugCount() );
-    EXPECT_EQ( 0, m_testLogger2->debugCount() );
-    EXPECT_EQ( 0, m_testLogger3->debugCount() );
+    EXPECT_EQ( 1u, m_testLogger1->debugCount() );
+    EXPECT_EQ( 0u, m_testLogger2->debugCount() );
+    EXPECT_EQ( 0u, m_testLogger3->debugCount() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -265,8 +265,8 @@ TEST_F( PdmLoggingTest, ClearAllLoggers )
 
     // Logging should not reach any logger now
     caf::PdmLogging::error( "Error message" );
-    EXPECT_EQ( 0, m_testLogger1->errorCount() );
-    EXPECT_EQ( 0, m_testLogger2->errorCount() );
+    EXPECT_EQ( 0u, m_testLogger1->errorCount() );
+    EXPECT_EQ( 0u, m_testLogger2->errorCount() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -282,10 +282,10 @@ TEST_F( PdmLoggingTest, LoggingMacros )
     CAF_PDM_LOG_INFO( "Macro info" );
     CAF_PDM_LOG_DEBUG( "Macro debug" );
 
-    EXPECT_EQ( 1, m_testLogger1->errorCount() );
-    EXPECT_EQ( 1, m_testLogger1->warningCount() );
-    EXPECT_EQ( 1, m_testLogger1->infoCount() );
-    EXPECT_EQ( 1, m_testLogger1->debugCount() );
+    EXPECT_EQ( 1u, m_testLogger1->errorCount() );
+    EXPECT_EQ( 1u, m_testLogger1->warningCount() );
+    EXPECT_EQ( 1u, m_testLogger1->infoCount() );
+    EXPECT_EQ( 1u, m_testLogger1->debugCount() );
 
     EXPECT_EQ( "Macro error", m_testLogger1->errorMessages()[0] );
     EXPECT_EQ( "Macro warning", m_testLogger1->warningMessages()[0] );
@@ -305,7 +305,7 @@ TEST_F( PdmLoggingTest, ConditionalLoggingMacros )
     CAF_PDM_LOG_DEBUG_IF( "Conditional debug" );
 
     // No messages should be logged since no loggers registered
-    EXPECT_EQ( 0, m_testLogger1->errorCount() );
+    EXPECT_EQ( 0u, m_testLogger1->errorCount() );
 
     // Register logger and test again
     caf::PdmLogging::registerLogger( m_testLogger1 );
@@ -316,10 +316,10 @@ TEST_F( PdmLoggingTest, ConditionalLoggingMacros )
     CAF_PDM_LOG_DEBUG_IF( "Conditional debug" );
 
     // Now messages should be logged
-    EXPECT_EQ( 1, m_testLogger1->errorCount() );
-    EXPECT_EQ( 1, m_testLogger1->warningCount() );
-    EXPECT_EQ( 1, m_testLogger1->infoCount() );
-    EXPECT_EQ( 1, m_testLogger1->debugCount() );
+    EXPECT_EQ( 1u, m_testLogger1->errorCount() );
+    EXPECT_EQ( 1u, m_testLogger1->warningCount() );
+    EXPECT_EQ( 1u, m_testLogger1->infoCount() );
+    EXPECT_EQ( 1u, m_testLogger1->debugCount() );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -338,6 +338,6 @@ TEST_F( PdmLoggingTest, ThreadSafety )
         caf::PdmLogging::unregisterLogger( m_testLogger2 );
     }
 
-    EXPECT_EQ( 100, m_testLogger1->errorCount() );
+    EXPECT_EQ( 100u, m_testLogger1->errorCount() );
     EXPECT_TRUE( caf::PdmLogging::hasLoggers() );
 }

--- a/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/cafPdmBasicTest.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafProjectDataModel_UnitTests/cafPdmBasicTest.cpp
@@ -620,8 +620,8 @@ TEST( BaseTest, ReadWrite )
     {
         QFile f1( fileName );
         QFile f2( fileNameCopy );
-        f1.open( QIODevice::ReadOnly | QIODevice::Text );
-        f2.open( QIODevice::ReadOnly | QIODevice::Text );
+        EXPECT_TRUE( f1.open( QIODevice::ReadOnly | QIODevice::Text ) );
+        EXPECT_TRUE( f2.open( QIODevice::ReadOnly | QIODevice::Text ) );
         QByteArray ba1   = f1.readAll();
         QByteArray ba2   = f2.readAll();
         bool       equal = ba1 == ba2;
@@ -702,7 +702,7 @@ TEST( BaseTest, ReadWrite )
         // Write the edited document
 
         QFile f3( "PdmTestFilWithError.xml" );
-        f3.open( QIODevice::WriteOnly | QIODevice::Text );
+        EXPECT_TRUE( f3.open( QIODevice::WriteOnly | QIODevice::Text ) );
         f3.write( ba1 );
         f3.close();
 

--- a/GrpcInterface/Python/rips/PythonExamples/surfaces_and_visualization/create_regular_surface.py
+++ b/GrpcInterface/Python/rips/PythonExamples/surfaces_and_visualization/create_regular_surface.py
@@ -83,5 +83,9 @@ if resinsight is not None:
             f"Retrieved {len(wave_values)} wave property values, min={min(wave_values):.2f}, max={max(wave_values):.2f}"
         )
 
+        # List available properties
+        props = s.available_properties()
+        print(f"Available properties: {props}")
+
         # Use the wave as depth for the surface
         s.set_property_as_depth("wave")

--- a/GrpcInterface/Python/rips/surface.py
+++ b/GrpcInterface/Python/rips/surface.py
@@ -26,6 +26,17 @@ def set_property(self: RegularSurface, name: str, values: List[float]) -> None:
 
 
 @add_method(RegularSurface)
+def available_properties(self: RegularSurface) -> List[str]:
+    """Gets the list of available property names on a regular surface.
+
+    Returns:
+        List[str]: Names of all properties set on this surface.
+    """
+    result = self.property_names()
+    return result.values
+
+
+@add_method(RegularSurface)
 def get_property(self: RegularSurface, name: str) -> List[float]:
     """Gets a property from a regular surface.
 

--- a/GrpcInterface/Python/rips/tests/test_surfaces.py
+++ b/GrpcInterface/Python/rips/tests/test_surfaces.py
@@ -106,6 +106,35 @@ def test_get_property(rips_instance, initialize_test):
         s.get_property("non_existent_property")
 
 
+def test_available_properties(rips_instance, initialize_test):
+    case_path = dataroot.PATH + "/Case_with_10_timesteps/Real0/BRUGGE_0000.EGRID"
+    c = rips_instance.project.load_case(path=case_path)
+    assert len(c.grids()) == 1
+
+    surface_collection = rips_instance.project.descendants(rips.SurfaceCollection)[0]
+
+    nx = 5
+    ny = 4
+    s = surface_collection.new_regular_surface(nx=nx, ny=ny)
+
+    # Empty property list initially
+    props = s.available_properties()
+    assert props == []
+
+    # Property names after setting one property
+    s.set_property("prop_a", [float(i) for i in range(nx * ny)])
+    props = s.available_properties()
+    assert "prop_a" in props
+    assert len(props) == 1
+
+    # Property names persist after setting multiple properties
+    s.set_property("prop_b", [float(i) for i in range(nx * ny)])
+    props = s.available_properties()
+    assert len(props) == 2
+    assert "prop_a" in props
+    assert "prop_b" in props
+
+
 def test_create_regular_surface_invalid_values(rips_instance, initialize_test):
     case_path = dataroot.PATH + "/Case_with_10_timesteps/Real0/BRUGGE_0000.EGRID"
     c = rips_instance.project.load_case(path=case_path)

--- a/docs/fractureGridResultsForUnitSystem.md
+++ b/docs/fractureGridResultsForUnitSystem.md
@@ -1,0 +1,148 @@
+# `fractureGridResultsForUnitSystem` — How It Is Used
+
+## Overview
+
+`fractureGridResultsForUnitSystem` is a pure virtual method declared in `RimMeshFractureTemplate` and implemented by both `RimStimPlanFractureTemplate` and `RimThermalFractureTemplate`. It returns per-cell result values from the fracture grid, converting them to the unit system of the fracture template (metric or field).
+
+## Declaration
+
+`RimMeshFractureTemplate.h:85`
+
+```cpp
+virtual std::vector<double> fractureGridResultsForUnitSystem(
+    const QString&                resultName,
+    const QString&                unitName,
+    size_t                        timeStepIndex,
+    RiaDefines::EclipseUnitSystem requiredUnitSystem ) const = 0;
+```
+
+| Parameter | Description |
+|---|---|
+| `resultName` | Name of the fracture property (e.g. width, conductivity) |
+| `unitName` | Unit string as stored in the fracture definition file (e.g. `"m"`, `"ft"`, `"/m"`) |
+| `timeStepIndex` | Index into the fracture time step data |
+| `requiredUnitSystem` | Target unit system (currently always passed as `fractureTemplateUnit()`) |
+
+**Return value:** one `double` per fracture grid cell, converted to the template's unit system.
+
+---
+
+## Implementation: `RimStimPlanFractureTemplate`
+
+`RimStimPlanFractureTemplate.cpp:287`
+
+```cpp
+std::vector<double> RimStimPlanFractureTemplate::fractureGridResultsForUnitSystem(
+    const QString& resultName, const QString& unitName,
+    size_t timeStepIndex, RiaDefines::EclipseUnitSystem requiredUnitSystem ) const
+{
+    auto resultValues = m_stimPlanFractureDefinitionData->fractureGridResults(
+        resultName, unitName, m_activeTimeStepIndex );
+
+    if ( fractureTemplateUnit() == UNITS_METRIC )
+        for ( auto& v : resultValues )
+            v = RiaEclipseUnitTools::convertToMeter( v, unitName );
+    else if ( fractureTemplateUnit() == UNITS_FIELD )
+        for ( auto& v : resultValues )
+            v = RiaEclipseUnitTools::convertToFeet( v, unitName );
+
+    return resultValues;
+}
+```
+
+1. Fetches raw cell values from `RigStimPlanFractureDefinition::fractureGridResults`.
+2. Converts each value using `RiaEclipseUnitTools::convertToMeter` or `convertToFeet` based on the template's unit system.
+3. The `requiredUnitSystem` parameter is accepted but the actual conversion uses `fractureTemplateUnit()` — the two are expected to match at all call sites.
+
+`RimThermalFractureTemplate` follows the same pattern, but sources data from `RigThermalFractureDefinition` instead.
+
+---
+
+## Call Sites in `RimMeshFractureTemplate`
+
+All call sites are in `RimMeshFractureTemplate.cpp`. The method is never called from outside the template hierarchy.
+
+### 1. `wellFractureIntersectionData` — along-well-path orientation
+
+`RimMeshFractureTemplate.cpp:239–247`
+
+Width and conductivity values are fetched for every fracture grid cell, then a length-weighted mean is computed over the cells intersected by the well path:
+
+```cpp
+auto nameUnit = widthParameterNameAndUnit();
+widthResultValues = fractureGridResultsForUnitSystem(
+    nameUnit.first, nameUnit.second, m_activeTimeStepIndex, fractureTemplateUnit() );
+
+auto nameUnit2 = conductivityParameterNameAndUnit();
+conductivityResultValues = fractureGridResultsForUnitSystem(
+    nameUnit2.first, nameUnit2.second, m_activeTimeStepIndex, fractureTemplateUnit() );
+```
+
+The intersection lengths come from `RigWellPathStimplanIntersector`. The weighted means are used to populate `WellFractureIntersectionData::m_width`, `m_conductivity`, and `m_permeability`.
+
+### 2. `wellFractureIntersectionData` — transverse/default orientation
+
+`RimMeshFractureTemplate.cpp:335`
+
+Only width is needed here (conductivity is read directly from the `RigFractureCell`). The value at the well-center cell index is extracted:
+
+```cpp
+auto resultValues = fractureGridResultsForUnitSystem(
+    nameUnit.first, nameUnit.second, m_activeTimeStepIndex, fractureTemplateUnit() );
+
+if ( wellCellIndex < resultValues.size() )
+    widthInRequiredUnit = resultValues[wellCellIndex];
+```
+
+Width and permeability are then set on the intersection data struct.
+
+### 3. `widthResultValues`
+
+`RimMeshFractureTemplate.cpp:437`
+
+A thin wrapper that fetches the full width array for the active time step:
+
+```cpp
+std::vector<double> RimMeshFractureTemplate::widthResultValues() const
+{
+    auto nameUnit = widthParameterNameAndUnit();
+    return fractureGridResultsForUnitSystem(
+        nameUnit.first, nameUnit.second, m_activeTimeStepIndex, fractureTemplateUnit() );
+}
+```
+
+This is used by callers that need the complete per-cell width grid (e.g. for visualization).
+
+---
+
+## Data Flow
+
+```
+Fracture definition file (.xml / thermal)
+        |
+        v
+RigStimPlanFractureDefinition::fractureGridResults()   (raw values, native file units)
+        |
+        v
+RimStimPlanFractureTemplate::fractureGridResultsForUnitSystem()   (unit-converted)
+        |
+        v
+RimMeshFractureTemplate::wellFractureIntersectionData()
+    ├── along-well-path: length-weighted mean → WellFractureIntersectionData
+    └── transverse:      single cell lookup   → WellFractureIntersectionData
+        |
+        v
+RimMeshFractureTemplate::widthResultValues()   (full grid, for visualization)
+```
+
+---
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `ApplicationLibCode/ProjectDataModel/Completions/RimMeshFractureTemplate.h` | Pure virtual declaration |
+| `ApplicationLibCode/ProjectDataModel/Completions/RimMeshFractureTemplate.cpp` | All call sites |
+| `ApplicationLibCode/ProjectDataModel/Completions/RimStimPlanFractureTemplate.cpp` | StimPlan implementation |
+| `ApplicationLibCode/ProjectDataModel/Completions/RimThermalFractureTemplate.cpp` | Thermal implementation |
+| `ApplicationLibCode/Application/Tools/RiaEclipseUnitTools.h` | Unit conversion helpers |


### PR DESCRIPTION
Closes #873

## Summary

- Add displacement field `U` (components `U1`/`U2`/`U3`) in `RifVtkReader`, read from VTK point data
- Negate z-component of displacements to match ResInsight internal convention (z positive downward)
- Invert IJK indices in `RigFemPartGrid` to compensate for coordinate negation flipping the grid orientation; the `invertIJK` flag is passed as a parameter rather than stored as a member variable
- Apply displacements to cell selection wireframe via `RivSingleCellPartGenerator` and `RivFemPartGeometryGenerator`