### PR TITLE
#13806 Python: Add option to create discrete grid property

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.cpp
@@ -1299,6 +1299,20 @@ void RigCaseCellResultsData::createResultEntry( const RigEclipseResultAddress& r
 }
 
 //--------------------------------------------------------------------------------------------------
+/// Update the data type of an existing result entry. Equality/ordering on RigEclipseResultAddress
+/// ignores dataType, so overwriting a property with a different dataType does not update the
+/// persisted metadata unless we explicitly patch it here.
+//--------------------------------------------------------------------------------------------------
+bool RigCaseCellResultsData::updateResultDataType( const RigEclipseResultAddress& resultAddress, RiaDefines::ResultDataType dataType )
+{
+    size_t scalarResultIndex = findScalarResultIndexFromAddress( resultAddress );
+    if ( scalarResultIndex == cvf::UNDEFINED_SIZE_T ) return false;
+
+    m_resultInfos[scalarResultIndex].m_resultAddress.setDataType( dataType );
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 size_t RigCaseCellResultsData::findOrLoadKnownScalarResult( const RigEclipseResultAddress& resVarAddrOrg )

--- a/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigCaseCellResultsData.h
@@ -140,6 +140,7 @@ public:
     bool hasResultEntry( const RigEclipseResultAddress& resultAddress ) const;
     bool isResultLoaded( const RigEclipseResultAddress& resultAddress ) const;
     void createResultEntry( const RigEclipseResultAddress& resultAddress, bool needsToBeStored );
+    bool updateResultDataType( const RigEclipseResultAddress& resultAddress, RiaDefines::ResultDataType dataType );
     void createPlaceholderResultEntries();
     void computeDepthRelatedResults();
     void computeCellVolumes();

--- a/GrpcInterface/GrpcProtos/Properties.proto
+++ b/GrpcInterface/GrpcProtos/Properties.proto
@@ -30,6 +30,11 @@ enum PropertyType {
   UNDEFINED = 999;
 }
 
+enum PropertyDataType {
+  FLOAT = 0;
+  INTEGER = 1;
+}
+
 message AvailablePropertiesRequest {
   CaseRequest case_request = 1;
   PropertyType property_type = 2;
@@ -45,6 +50,7 @@ message PropertyRequest {
   int32 time_step = 4;
   int32 grid_index = 5;
   PorosityModelType porosity_model = 6;
+  PropertyDataType data_type = 7;
 }
 
 message TimeStep { int32 index = 1; }

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_active_cell_property.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_active_cell_property.py
@@ -1,0 +1,24 @@
+######################################################################
+# This script creates a discrete (integer) property for all active
+# cells in the first case in the project.
+#
+# The script is intended to be used for TEST10K_FLT_LGR_NNC.EGRID.
+#
+# Passing data_type="INTEGER" flags the property as discrete regardless
+# of the property name (previously this required the name to end with
+# "NUM").
+######################################################################
+import rips
+
+resinsight = rips.Instance.find()
+
+case = resinsight.project.case(case_id=0)
+
+# Derive a discrete region id from a continuous property.
+poro = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
+region_ids = [int(value * 100) % 4 for value in poro]
+
+print("Applying discrete values to active cells")
+case.set_active_cell_property(
+    region_ids, "GENERATED", "MY_REGION", 0, data_type="INTEGER"
+)

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_active_cell_property.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_active_cell_property.py
@@ -2,8 +2,6 @@
 # This script creates a discrete (integer) property for all active
 # cells in the first case in the project.
 #
-# The script is intended to be used for TEST10K_FLT_LGR_NNC.EGRID.
-#
 # Passing data_type="INTEGER" flags the property as discrete regardless
 # of the property name (previously this required the name to end with
 # "NUM").

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_grid_property.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_grid_property.py
@@ -24,6 +24,4 @@ for i in range(0, grid_cell_count):
     values.append(i % 4)
 
 print("Applying discrete values to main grid")
-case.set_grid_property(
-    values, "STATIC_NATIVE", "MY_REGION", 0, data_type="INTEGER"
-)
+case.set_grid_property(values, "STATIC_NATIVE", "MY_REGION", 0, data_type="INTEGER")

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_grid_property.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_grid_property.py
@@ -2,8 +2,6 @@
 # This script creates a discrete (integer) grid property for all grid
 # cells in the first case in the project.
 #
-# The script is intended to be used for TEST10K_FLT_LGR_NNC.EGRID.
-#
 # A discrete property is visualized with a category legend, in contrast
 # to the continuous legend used for floating point properties. Passing
 # data_type="INTEGER" flags the property as discrete regardless of the

--- a/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_grid_property.py
+++ b/GrpcInterface/Python/rips/PythonExamples/case_and_grid_operations/set_discrete_grid_property.py
@@ -1,0 +1,29 @@
+######################################################################
+# This script creates a discrete (integer) grid property for all grid
+# cells in the first case in the project.
+#
+# The script is intended to be used for TEST10K_FLT_LGR_NNC.EGRID.
+#
+# A discrete property is visualized with a category legend, in contrast
+# to the continuous legend used for floating point properties. Passing
+# data_type="INTEGER" flags the property as discrete regardless of the
+# property name (previously this required the name to end with "NUM").
+######################################################################
+import rips
+
+resinsight = rips.Instance.find()
+
+case = resinsight.project.case(case_id=0)
+grid = case.grid()
+grid_cell_count = grid.cell_count()
+print("total cell count : " + str(grid_cell_count))
+
+# Assign a simple region id based on IJK index.
+values = []
+for i in range(0, grid_cell_count):
+    values.append(i % 4)
+
+print("Applying discrete values to main grid")
+case.set_grid_property(
+    values, "STATIC_NATIVE", "MY_REGION", 0, data_type="INTEGER"
+)

--- a/GrpcInterface/Python/rips/case.py
+++ b/GrpcInterface/Python/rips/case.py
@@ -830,6 +830,7 @@ def set_active_cell_property_async(
     property_name,
     time_step,
     porosity_model: str = "MATRIX_MODEL",
+    data_type: str = "FLOAT",
 ):
     """Set cell property for all active cells Async. Takes an iterator to the input values. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -839,15 +840,18 @@ def set_active_cell_property_async(
         property_name(str): name of an Eclipse property
         time_step(int): the time step for which to get the property for
         porosity_model(str): string enum
+        data_type(str): property data type ("FLOAT" or "INTEGER"). Use "INTEGER" to create a discrete/category property.
     """
     property_type_enum = Properties_pb2.PropertyType.Value(property_type)
     porosity_model_enum = Case_pb2.PorosityModelType.Value(porosity_model)
+    data_type_enum = Properties_pb2.PropertyDataType.Value(data_type)
     request = Properties_pb2.PropertyRequest(
         case_request=self.__request(),
         property_type=property_type_enum,
         property_name=property_name,
         time_step=time_step,
         porosity_model=porosity_model_enum,
+        data_type=data_type_enum,
     )
 
     request_iterator = self.__generate_property_input_iterator(values_iterator, request)
@@ -862,6 +866,7 @@ def set_active_cell_property(
     property_name,
     time_step,
     porosity_model: str = "MATRIX_MODEL",
+    data_type: str = "FLOAT",
 ):
     """Set a cell property for all active cells. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -871,15 +876,18 @@ def set_active_cell_property(
         property_name(str): name of an Eclipse property
         time_step(int): the time step for which to get the property for
         porosity_model(str): string enum
+        data_type(str): property data type ("FLOAT" or "INTEGER"). Use "INTEGER" to create a discrete/category property.
     """
     property_type_enum = Properties_pb2.PropertyType.Value(property_type)
     porosity_model_enum = Case_pb2.PorosityModelType.Value(porosity_model)
+    data_type_enum = Properties_pb2.PropertyDataType.Value(data_type)
     request = Properties_pb2.PropertyRequest(
         case_request=self.__request(),
         property_type=property_type_enum,
         property_name=property_name,
         time_step=time_step,
         porosity_model=porosity_model_enum,
+        data_type=data_type_enum,
     )
     request_iterator = self.__generate_property_input_chunks(values, request)
     reply = self.__properties_stub.SetActiveCellProperty(request_iterator)
@@ -896,6 +904,7 @@ def set_grid_property(
     time_step,
     grid_index=0,
     porosity_model: str = "MATRIX_MODEL",
+    data_type: str = "FLOAT",
 ):
     """Set a cell property for all grid cells. For argument details, see :ref:`Result Definition <result-definition-label>`
 
@@ -906,9 +915,11 @@ def set_grid_property(
         time_step(int): the time step for which to get the property for
         grid_index(int): index to the grid we're setting values for
         porosity_model(str): string enum
+        data_type(str): property data type ("FLOAT" or "INTEGER"). Use "INTEGER" to create a discrete/category property.
     """
     property_type_enum = Properties_pb2.PropertyType.Value(property_type)
     porosity_model_enum = Case_pb2.PorosityModelType.Value(porosity_model)
+    data_type_enum = Properties_pb2.PropertyDataType.Value(data_type)
     request = Properties_pb2.PropertyRequest(
         case_request=self.__request(),
         property_type=property_type_enum,
@@ -916,6 +927,7 @@ def set_grid_property(
         time_step=time_step,
         grid_index=grid_index,
         porosity_model=porosity_model_enum,
+        data_type=data_type_enum,
     )
     request_iterator = self.__generate_property_input_chunks(values, request)
     reply = self.__properties_stub.SetGridProperty(request_iterator)

--- a/GrpcInterface/Python/rips/tests/test_properties.py
+++ b/GrpcInterface/Python/rips/tests/test_properties.py
@@ -98,7 +98,7 @@ def test_10k_PoroPermX(rips_instance, initialize_test):
     checkResults(poro, permx, poroPermX)
 
 
-def test_10k_set_integer_property(rips_instance, initialize_test):
+def test_10k_set_integer_active_cell_property(rips_instance, initialize_test):
     casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(path=casePath)
 
@@ -108,10 +108,28 @@ def test_10k_set_integer_property(rips_instance, initialize_test):
     # A name that does not end with "NUM" - only the data_type flag should
     # cause this to be treated as a discrete/category property.
     case.set_active_cell_property(
-        integer_values, "GENERATED", "MY_DISCRETE", 0, data_type="INTEGER"
+        integer_values, "GENERATED", "MY_DISCRETE_ACTIVE", 0, data_type="INTEGER"
     )
 
-    round_trip = case.active_cell_property("GENERATED", "MY_DISCRETE", 0)
+    round_trip = case.active_cell_property("GENERATED", "MY_DISCRETE_ACTIVE", 0)
+    assert len(round_trip) == len(integer_values)
+    for expected, actual in zip(integer_values, round_trip):
+        assert expected == int(actual)
+
+
+def test_10k_set_integer_grid_property(rips_instance, initialize_test):
+    casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
+    case = rips_instance.project.load_case(path=casePath)
+
+    grid = case.grid()
+    grid_cell_count = grid.cell_count()
+    integer_values = [i % 4 for i in range(grid_cell_count)]
+
+    case.set_grid_property(
+        integer_values, "GENERATED", "MY_DISCRETE_GRID", 0, data_type="INTEGER"
+    )
+
+    round_trip = case.grid_property("GENERATED", "MY_DISCRETE_GRID", 0)
     assert len(round_trip) == len(integer_values)
     for expected, actual in zip(integer_values, round_trip):
         assert expected == int(actual)

--- a/GrpcInterface/Python/rips/tests/test_properties.py
+++ b/GrpcInterface/Python/rips/tests/test_properties.py
@@ -98,6 +98,25 @@ def test_10k_PoroPermX(rips_instance, initialize_test):
     checkResults(poro, permx, poroPermX)
 
 
+def test_10k_set_integer_property(rips_instance, initialize_test):
+    casePath = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
+    case = rips_instance.project.load_case(path=casePath)
+
+    results = case.active_cell_property("STATIC_NATIVE", "PORO", 0)
+    integer_values = [int(v * 100) for v in results]
+
+    # A name that does not end with "NUM" - only the data_type flag should
+    # cause this to be treated as a discrete/category property.
+    case.set_active_cell_property(
+        integer_values, "GENERATED", "MY_DISCRETE", 0, data_type="INTEGER"
+    )
+
+    round_trip = case.active_cell_property("GENERATED", "MY_DISCRETE", 0)
+    assert len(round_trip) == len(integer_values)
+    for expected, actual in zip(integer_values, round_trip):
+        assert expected == int(actual)
+
+
 def test_exportPropertyInView(rips_instance, initialize_test):
     case_path = dataroot.PATH + "/TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
     case = rips_instance.project.load_case(case_path)

--- a/GrpcInterface/RiaGrpcPropertiesService.cpp
+++ b/GrpcInterface/RiaGrpcPropertiesService.cpp
@@ -104,6 +104,11 @@ public:
 
             m_resultAddress = RigEclipseResultAddress( resultType, QString::fromStdString( request->property_name() ) );
 
+            auto dataType = ( request->data_type() == rips::PropertyDataType::INTEGER )
+                                ? RiaDefines::ResultDataType::INTEGER
+                                : RiaDefines::ResultDataType::FLOAT;
+            m_resultAddress.setDataType( dataType );
+
             if ( resultData->ensureKnownResultLoaded( m_resultAddress ) )
             {
                 if ( timeStep < resultData->timeStepCount( m_resultAddress ) )

--- a/GrpcInterface/RiaGrpcPropertiesService.cpp
+++ b/GrpcInterface/RiaGrpcPropertiesService.cpp
@@ -113,6 +113,9 @@ public:
             {
                 if ( timeStep < resultData->timeStepCount( m_resultAddress ) )
                 {
+                    // Equality on RigEclipseResultAddress ignores dataType, so an existing entry
+                    // keeps its original dataType. Patch it when overwriting from the client.
+                    if ( m_clientStreamer ) resultData->updateResultDataType( m_resultAddress, dataType );
                     initResultAccess( caseData, request->grid_index(), m_porosityModel, timeStep, m_resultAddress );
                     return grpc::Status::OK;
                 }


### PR DESCRIPTION
## Summary
- Adds a `PropertyDataType` enum (`FLOAT`, `INTEGER`) and a `data_type` field on `PropertyRequest` in `Properties.proto`.
- `RiaGrpcPropertiesService` now stamps the `RigEclipseResultAddress` with `ResultDataType::INTEGER` when requested, which is how `hasCategoryResult()` already detects discrete properties — so a property no longer has to end with `NUM` to be treated as a category.
- Python API: `set_active_cell_property`, its async variant, and `set_grid_property` accept an optional `data_type="FLOAT"` / `"INTEGER"` kwarg. Values on the wire remain doubles, which round-trip exactly for integer category codes.
- Adds `test_10k_set_integer_property` and a `set_discrete_grid_property.py` example.

Refs OPM/ResInsight#13806. The issue also mentions setting legend text for each discrete value — that is a separate view/legend-config concern and intentionally left for a follow-up.