### PR TITLE
#13958 OSDU well path import: recover absolute UTM and target unit system

### DIFF
--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
@@ -82,9 +82,9 @@ double linearCrsUnitToMeters( const QString& persistableReferenceCrs )
     if ( wkt.isEmpty() ) return 1.0;
     if ( !wkt.startsWith( "PROJCS", Qt::CaseInsensitive ) ) return 1.0;
 
-    QRegularExpression      re( "UNIT\\[\"[^\"]+\"\\s*,\\s*([0-9.eE+\\-]+)\\]" );
-    auto                    matches = re.globalMatch( wkt );
-    double                  factor  = 1.0;
+    QRegularExpression re( "UNIT\\[\"[^\"]+\"\\s*,\\s*([0-9.eE+\\-]+)\\]" );
+    auto               matches = re.globalMatch( wkt );
+    double             factor  = 1.0;
     while ( matches.hasNext() )
     {
         QRegularExpressionMatch m  = matches.next();
@@ -456,9 +456,7 @@ void RiaOsduConnector::parseWellboresByFieldId( QNetworkReply* reply, const QStr
                         if ( !unitRecognized && !unitId.isEmpty() )
                         {
                             RiaLogging::warning(
-                                QString( "Unrecognized datum elevation unit '%1' for well bore '%2'; assuming meters." )
-                                    .arg( unitId )
-                                    .arg( name ) );
+                                QString( "Unrecognized datum elevation unit '%1' for well bore '%2'; assuming meters." ).arg( unitId ).arg( name ) );
                         }
                         datumElevation = verticalMeasurement * factor;
                     }
@@ -544,12 +542,10 @@ void RiaOsduConnector::parseWellTrajectory( QNetworkReply* reply, const QString&
                 double unitToMeters   = unitOfMeasureToMeters( mdUnitId, &unitRecognized );
                 if ( !unitRecognized && !mdUnitId.isEmpty() )
                 {
-                    RiaLogging::warning(
-                        QString( "Unrecognized MD unit '%1' for trajectory %2; assuming meters." ).arg( mdUnitId ).arg( id ) );
+                    RiaLogging::warning( QString( "Unrecognized MD unit '%1' for trajectory %2; assuming meters." ).arg( mdUnitId ).arg( id ) );
                 }
 
-                m_wellboreTrajectories[wellboreId].push_back(
-                    OsduWellboreTrajectory{ id, kind, wellboreId, existenceKind, crs, unitToMeters } );
+                m_wellboreTrajectories[wellboreId].push_back( OsduWellboreTrajectory{ id, kind, wellboreId, existenceKind, crs, unitToMeters } );
             }
         }
 
@@ -898,17 +894,17 @@ RiaOsduConnector::WellSurfaceLocation RiaOsduConnector::requestWellSurfaceLocati
 
     if ( reply->error() == QNetworkReply::NoError )
     {
-        QByteArray    body = reply->readAll();
-        QJsonDocument doc  = QJsonDocument::fromJson( body );
-        QJsonObject   data = doc.object()["data"].toObject();
+        QByteArray    body            = reply->readAll();
+        QJsonDocument doc             = QJsonDocument::fromJson( body );
+        QJsonObject   data            = doc.object()["data"].toObject();
         QJsonObject   spatialLocation = data["SpatialLocation"].toObject();
         QJsonObject   ingested        = spatialLocation["AsIngestedCoordinates"].toObject();
 
         if ( !ingested.isEmpty() )
         {
-            location.crs              = ingested["persistableReferenceCrs"].toString();
-            const double crsToMeters  = linearCrsUnitToMeters( location.crs );
-            QJsonArray   features     = ingested["features"].toArray();
+            location.crs             = ingested["persistableReferenceCrs"].toString();
+            const double crsToMeters = linearCrsUnitToMeters( location.crs );
+            QJsonArray   features    = ingested["features"].toArray();
             if ( !features.isEmpty() )
             {
                 QJsonArray coordinates = features[0].toObject()["geometry"].toObject()["coordinates"].toArray();

--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
@@ -449,7 +449,42 @@ void RiaOsduConnector::parseWellTrajectory( QNetworkReply* reply, const QString&
                     crs = ingested["persistableReferenceCrs"].toString();
                 }
 
-                m_wellboreTrajectories[wellboreId].push_back( OsduWellboreTrajectory{ id, kind, wellboreId, existenceKind, crs } );
+                // The trajectory parquet's MD/TVD/X/Y columns share a single length unit advertised on each
+                // AvailableTrajectoryStationProperties entry. Use the MD column's unit as the canonical one and
+                // derive a multiplier into meters, which downstream code uses to align with surface origin and
+                // datum elevation (always meters).
+                double     unitToMeters = 1.0;
+                QString    mdUnitId;
+                QJsonArray availableProps = dataObj["AvailableTrajectoryStationProperties"].toArray();
+                for ( const QJsonValue& propValue : availableProps )
+                {
+                    QJsonObject propObj = propValue.toObject();
+                    if ( propObj["Name"].toString() == "MD" )
+                    {
+                        mdUnitId = propObj["StationPropertyUnitID"].toString();
+                        break;
+                    }
+                }
+                // OSDU unit-of-measure ids look like "data:reference-data--UnitOfMeasure:ft:" — the symbol is
+                // between the last two colons.
+                QString unitSymbol;
+                if ( mdUnitId.endsWith( ':' ) )
+                {
+                    int lastColon       = mdUnitId.lastIndexOf( ':', mdUnitId.length() - 2 );
+                    if ( lastColon >= 0 ) unitSymbol = mdUnitId.mid( lastColon + 1, mdUnitId.length() - lastColon - 2 );
+                }
+                if ( unitSymbol.compare( "ft", Qt::CaseInsensitive ) == 0 )
+                {
+                    unitToMeters = 0.3048;
+                }
+                else if ( unitSymbol.compare( "m", Qt::CaseInsensitive ) != 0 && !unitSymbol.isEmpty() )
+                {
+                    RiaLogging::warning(
+                        QString( "Unrecognized MD unit '%1' for trajectory %2; assuming meters." ).arg( unitSymbol ).arg( id ) );
+                }
+
+                m_wellboreTrajectories[wellboreId].push_back(
+                    OsduWellboreTrajectory{ id, kind, wellboreId, existenceKind, crs, unitToMeters } );
             }
         }
 

--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
@@ -523,10 +523,14 @@ void RiaOsduConnector::parseWellTrajectory( QNetworkReply* reply, const QString&
                     crs = ingested["persistableReferenceCrs"].toString();
                 }
 
-                // The trajectory parquet's MD/TVD/X/Y columns share a single length unit advertised on each
-                // AvailableTrajectoryStationProperties entry. Use the MD column's unit as the canonical one and
-                // derive a multiplier into meters, which downstream code uses to align with surface origin and
-                // datum elevation (always meters).
+                // The MD entry in AvailableTrajectoryStationProperties advertises a length unit that the parquet
+                // values are stored in. Treat it as the canonical length unit for the geometric columns
+                // (MD/TVD/X/Y) and use it to derive a multiplier into meters, so downstream code can combine the
+                // trajectory with surface origin and datum elevation (which are stored as meters).
+                //
+                // Note: in real-world OSDU records the X/Y entries sometimes advertise a different unit than
+                // MD/TVD (e.g. "dega" while the values are clearly meters/feet). Trusting MD's unit and applying
+                // it uniformly to all four columns gives the right result for those datasets too.
                 QString    mdUnitId;
                 QJsonArray availableProps = dataObj["AvailableTrajectoryStationProperties"].toArray();
                 for ( const QJsonValue& propValue : availableProps )

--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
@@ -79,6 +79,7 @@ void RiaOsduConnector::clearCachedData()
     m_wellLogs.clear();
     m_parquetData.clear();
     m_parquetErrors.clear();
+    m_wellSurfaceLocations.clear();
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -393,36 +394,9 @@ void RiaOsduConnector::parseWellboresByFieldId( QNetworkReply* reply, const QStr
                     datumElevation = 0.0;
                 }
 
-                // Extract surface location from SpatialLocation. The well trajectory parquet stores X/Y as offsets
-                // relative to this surface point, so it is needed to recover absolute UTM coordinates.
-                double      surfaceEasting  = 0.0;
-                double      surfaceNorthing = 0.0;
-                QString     crs;
-                QJsonObject spatialLocation = resultObj["data"].toObject()["SpatialLocation"].toObject();
-                QJsonObject ingested        = spatialLocation["AsIngestedCoordinates"].toObject();
-                if ( !ingested.isEmpty() )
-                {
-                    crs = ingested["persistableReferenceCrs"].toString();
-
-                    QJsonArray features = ingested["features"].toArray();
-                    if ( !features.isEmpty() )
-                    {
-                        QJsonArray coordinates = features[0].toObject()["geometry"].toObject()["coordinates"].toArray();
-                        if ( coordinates.size() >= 2 )
-                        {
-                            surfaceEasting  = coordinates[0].toDouble();
-                            surfaceNorthing = coordinates[1].toDouble();
-                        }
-                    }
-                }
-
-                if ( surfaceEasting == 0.0 && surfaceNorthing == 0.0 )
-                {
-                    RiaLogging::warning( QString( "Missing surface location for well bore '%1'. Id: %2" ).arg( name ).arg( id ) );
-                }
-
-                m_wellbores[fieldId].push_back(
-                    OsduWellbore{ id, kind, name, wellId, fieldId, datumElevation, surfaceEasting, surfaceNorthing, crs } );
+                // Wellbore records typically do not carry SpatialLocation; the surface point lives on the parent
+                // Well record. Surface easting/northing/crs are populated separately via requestWellSurfaceLocationBlocking.
+                m_wellbores[fieldId].push_back( OsduWellbore{ id, kind, name, wellId, fieldId, datumElevation } );
             }
         }
 
@@ -786,4 +760,82 @@ void RiaOsduConnector::cancelRequestForId( const QString& id )
             it->second->abort();
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaOsduConnector::WellSurfaceLocation RiaOsduConnector::requestWellSurfaceLocationBlocking( const QString& wellId )
+{
+    if ( wellId.isEmpty() ) return {};
+
+    // OSDU stores record references with a trailing colon (e.g. "data:master-data--Well:abcd:"). The storage
+    // API expects the id without it.
+    QString recordId = wellId;
+    while ( recordId.endsWith( ':' ) )
+        recordId.chop( 1 );
+
+    {
+        QMutexLocker lock( &m_mutex );
+        auto         it = m_wellSurfaceLocations.find( recordId );
+        if ( it != m_wellSurfaceLocations.end() ) return it->second;
+    }
+
+    QString token = requestTokenBlocking();
+    QString url   = m_server + "/api/storage/v2/records/" + recordId;
+
+    QNetworkRequest networkRequest;
+    networkRequest.setUrl( QUrl( url ) );
+    addStandardHeader( networkRequest, token, m_dataPartitionId, RiaCloudDefines::contentTypeJson() );
+
+    QNetworkReply* reply = m_networkAccessManager->get( networkRequest );
+
+    QEventLoop loop;
+    connect( reply, &QNetworkReply::finished, &loop, &QEventLoop::quit );
+    loop.exec();
+
+    WellSurfaceLocation location;
+
+    if ( reply->error() == QNetworkReply::NoError )
+    {
+        QByteArray    body = reply->readAll();
+        QJsonDocument doc  = QJsonDocument::fromJson( body );
+        QJsonObject   data = doc.object()["data"].toObject();
+        QJsonObject   spatialLocation = data["SpatialLocation"].toObject();
+        QJsonObject   ingested        = spatialLocation["AsIngestedCoordinates"].toObject();
+
+        if ( !ingested.isEmpty() )
+        {
+            location.crs        = ingested["persistableReferenceCrs"].toString();
+            QJsonArray features = ingested["features"].toArray();
+            if ( !features.isEmpty() )
+            {
+                QJsonArray coordinates = features[0].toObject()["geometry"].toObject()["coordinates"].toArray();
+                if ( coordinates.size() >= 2 )
+                {
+                    location.easting  = coordinates[0].toDouble();
+                    location.northing = coordinates[1].toDouble();
+                    location.isValid  = true;
+                }
+            }
+        }
+
+        if ( !location.isValid )
+        {
+            RiaLogging::warning( QString( "No SpatialLocation found on Well record '%1'." ).arg( recordId ) );
+        }
+    }
+    else
+    {
+        RiaLogging::error( QString( "Failed to download Well record '%1': %2" ).arg( recordId ).arg( reply->errorString() ) );
+    }
+
+    reply->deleteLater();
+
+    {
+        QMutexLocker lock( &m_mutex );
+        m_wellSurfaceLocations[recordId] = location;
+    }
+
+    return location;
 }

--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
@@ -25,10 +25,76 @@
 #include <QJsonObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QRegularExpression>
 
 #include <limits>
 
 #include "cafAssert.h"
+
+namespace
+{
+//--------------------------------------------------------------------------------------------------
+/// Parse an OSDU UnitOfMeasure reference id (e.g. "data:reference-data--UnitOfMeasure:ft:") and return
+/// the multiplier that converts the value into meters. Returns 1.0 (and sets recognized=false) when the
+/// id is empty or the symbol is unknown, so callers can log a single warning at the call site.
+//--------------------------------------------------------------------------------------------------
+double unitOfMeasureToMeters( const QString& unitId, bool* recognized = nullptr )
+{
+    if ( recognized ) *recognized = false;
+
+    QString symbol;
+    if ( unitId.endsWith( ':' ) )
+    {
+        int lastColon = unitId.lastIndexOf( ':', unitId.length() - 2 );
+        if ( lastColon >= 0 ) symbol = unitId.mid( lastColon + 1, unitId.length() - lastColon - 2 );
+    }
+    if ( symbol.isEmpty() ) return 1.0;
+
+    if ( symbol.compare( "m", Qt::CaseInsensitive ) == 0 )
+    {
+        if ( recognized ) *recognized = true;
+        return 1.0;
+    }
+    if ( symbol.compare( "ft", Qt::CaseInsensitive ) == 0 )
+    {
+        if ( recognized ) *recognized = true;
+        return 0.3048;
+    }
+    return 1.0;
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Extract the linear unit factor (-> meters) from a persistableReferenceCrs JSON string by scanning
+/// the embedded WKT. The PROJCS WKT places the projection's linear UNIT after the nested angular GEOGCS
+/// UNIT, so the last `UNIT["name", factor]` token is the linear one. Falls back to 1.0 on any parse
+/// failure or for non-projected CRSs.
+//--------------------------------------------------------------------------------------------------
+double linearCrsUnitToMeters( const QString& persistableReferenceCrs )
+{
+    if ( persistableReferenceCrs.isEmpty() ) return 1.0;
+
+    QJsonDocument doc = QJsonDocument::fromJson( persistableReferenceCrs.toUtf8() );
+    if ( !doc.isObject() ) return 1.0;
+
+    QJsonObject obj = doc.object();
+    QString     wkt = obj["wkt"].toString();
+    if ( wkt.isEmpty() ) wkt = obj["lateBoundCRS"].toObject()["wkt"].toString();
+    if ( wkt.isEmpty() ) return 1.0;
+    if ( !wkt.startsWith( "PROJCS", Qt::CaseInsensitive ) ) return 1.0;
+
+    QRegularExpression      re( "UNIT\\[\"[^\"]+\"\\s*,\\s*([0-9.eE+\\-]+)\\]" );
+    auto                    matches = re.globalMatch( wkt );
+    double                  factor  = 1.0;
+    while ( matches.hasNext() )
+    {
+        QRegularExpressionMatch m  = matches.next();
+        bool                    ok = false;
+        double                  v  = m.captured( 1 ).toDouble( &ok );
+        if ( ok ) factor = v;
+    }
+    return factor;
+}
+} // namespace
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -383,8 +449,18 @@ void RiaOsduConnector::parseWellboresByFieldId( QNetworkReply* reply, const QStr
                     QString verticalMeasurementId = vma["VerticalMeasurementID"].toString();
                     if ( verticalMeasurementId == defaultVerticalMeasurementId )
                     {
-                        double verticalMeasurement = vma["VerticalMeasurement"].toDouble( 0.0 );
-                        datumElevation             = verticalMeasurement;
+                        double  verticalMeasurement = vma["VerticalMeasurement"].toDouble( 0.0 );
+                        QString unitId              = vma["VerticalMeasurementUnitOfMeasureID"].toString();
+                        bool    unitRecognized      = false;
+                        double  factor              = unitOfMeasureToMeters( unitId, &unitRecognized );
+                        if ( !unitRecognized && !unitId.isEmpty() )
+                        {
+                            RiaLogging::warning(
+                                QString( "Unrecognized datum elevation unit '%1' for well bore '%2'; assuming meters." )
+                                    .arg( unitId )
+                                    .arg( name ) );
+                        }
+                        datumElevation = verticalMeasurement * factor;
                     }
                 }
 
@@ -453,7 +529,6 @@ void RiaOsduConnector::parseWellTrajectory( QNetworkReply* reply, const QString&
                 // AvailableTrajectoryStationProperties entry. Use the MD column's unit as the canonical one and
                 // derive a multiplier into meters, which downstream code uses to align with surface origin and
                 // datum elevation (always meters).
-                double     unitToMeters = 1.0;
                 QString    mdUnitId;
                 QJsonArray availableProps = dataObj["AvailableTrajectoryStationProperties"].toArray();
                 for ( const QJsonValue& propValue : availableProps )
@@ -465,22 +540,12 @@ void RiaOsduConnector::parseWellTrajectory( QNetworkReply* reply, const QString&
                         break;
                     }
                 }
-                // OSDU unit-of-measure ids look like "data:reference-data--UnitOfMeasure:ft:" — the symbol is
-                // between the last two colons.
-                QString unitSymbol;
-                if ( mdUnitId.endsWith( ':' ) )
-                {
-                    int lastColon       = mdUnitId.lastIndexOf( ':', mdUnitId.length() - 2 );
-                    if ( lastColon >= 0 ) unitSymbol = mdUnitId.mid( lastColon + 1, mdUnitId.length() - lastColon - 2 );
-                }
-                if ( unitSymbol.compare( "ft", Qt::CaseInsensitive ) == 0 )
-                {
-                    unitToMeters = 0.3048;
-                }
-                else if ( unitSymbol.compare( "m", Qt::CaseInsensitive ) != 0 && !unitSymbol.isEmpty() )
+                bool   unitRecognized = false;
+                double unitToMeters   = unitOfMeasureToMeters( mdUnitId, &unitRecognized );
+                if ( !unitRecognized && !mdUnitId.isEmpty() )
                 {
                     RiaLogging::warning(
-                        QString( "Unrecognized MD unit '%1' for trajectory %2; assuming meters." ).arg( unitSymbol ).arg( id ) );
+                        QString( "Unrecognized MD unit '%1' for trajectory %2; assuming meters." ).arg( mdUnitId ).arg( id ) );
                 }
 
                 m_wellboreTrajectories[wellboreId].push_back(
@@ -841,15 +906,18 @@ RiaOsduConnector::WellSurfaceLocation RiaOsduConnector::requestWellSurfaceLocati
 
         if ( !ingested.isEmpty() )
         {
-            location.crs        = ingested["persistableReferenceCrs"].toString();
-            QJsonArray features = ingested["features"].toArray();
+            location.crs              = ingested["persistableReferenceCrs"].toString();
+            const double crsToMeters  = linearCrsUnitToMeters( location.crs );
+            QJsonArray   features     = ingested["features"].toArray();
             if ( !features.isEmpty() )
             {
                 QJsonArray coordinates = features[0].toObject()["geometry"].toObject()["coordinates"].toArray();
                 if ( coordinates.size() >= 2 )
                 {
-                    location.easting  = coordinates[0].toDouble();
-                    location.northing = coordinates[1].toDouble();
+                    // CRS WKT may declare a non-meter linear unit (e.g. US survey foot for state-plane CRSs).
+                    // Convert here so downstream code can rely on the surface origin always being meters.
+                    location.easting  = coordinates[0].toDouble() * crsToMeters;
+                    location.northing = coordinates[1].toDouble() * crsToMeters;
                     location.isValid  = true;
                 }
             }

--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.cpp
@@ -393,7 +393,36 @@ void RiaOsduConnector::parseWellboresByFieldId( QNetworkReply* reply, const QStr
                     datumElevation = 0.0;
                 }
 
-                m_wellbores[fieldId].push_back( OsduWellbore{ id, kind, name, wellId, fieldId, datumElevation } );
+                // Extract surface location from SpatialLocation. The well trajectory parquet stores X/Y as offsets
+                // relative to this surface point, so it is needed to recover absolute UTM coordinates.
+                double      surfaceEasting  = 0.0;
+                double      surfaceNorthing = 0.0;
+                QString     crs;
+                QJsonObject spatialLocation = resultObj["data"].toObject()["SpatialLocation"].toObject();
+                QJsonObject ingested        = spatialLocation["AsIngestedCoordinates"].toObject();
+                if ( !ingested.isEmpty() )
+                {
+                    crs = ingested["persistableReferenceCrs"].toString();
+
+                    QJsonArray features = ingested["features"].toArray();
+                    if ( !features.isEmpty() )
+                    {
+                        QJsonArray coordinates = features[0].toObject()["geometry"].toObject()["coordinates"].toArray();
+                        if ( coordinates.size() >= 2 )
+                        {
+                            surfaceEasting  = coordinates[0].toDouble();
+                            surfaceNorthing = coordinates[1].toDouble();
+                        }
+                    }
+                }
+
+                if ( surfaceEasting == 0.0 && surfaceNorthing == 0.0 )
+                {
+                    RiaLogging::warning( QString( "Missing surface location for well bore '%1'. Id: %2" ).arg( name ).arg( id ) );
+                }
+
+                m_wellbores[fieldId].push_back(
+                    OsduWellbore{ id, kind, name, wellId, fieldId, datumElevation, surfaceEasting, surfaceNorthing, crs } );
             }
         }
 
@@ -430,6 +459,7 @@ void RiaOsduConnector::parseWellTrajectory( QNetworkReply* reply, const QString&
                 QString id   = resultObj["id"].toString();
                 QString kind = resultObj["kind"].toString();
                 QString existenceKind;
+                QString crs;
 
                 // Safely extract existenceKind from nested data object
                 QJsonObject dataObj = resultObj["data"].toObject();
@@ -438,7 +468,14 @@ void RiaOsduConnector::parseWellTrajectory( QNetworkReply* reply, const QString&
                     existenceKind = dataObj["ExistenceKind"].toString();
                 }
 
-                m_wellboreTrajectories[wellboreId].push_back( OsduWellboreTrajectory{ id, kind, wellboreId, existenceKind } );
+                QJsonObject spatialLocation = dataObj["SpatialLocation"].toObject();
+                QJsonObject ingested        = spatialLocation["AsIngestedCoordinates"].toObject();
+                if ( !ingested.isEmpty() )
+                {
+                    crs = ingested["persistableReferenceCrs"].toString();
+                }
+
+                m_wellboreTrajectories[wellboreId].push_back( OsduWellboreTrajectory{ id, kind, wellboreId, existenceKind, crs } );
             }
         }
 

--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.h
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.h
@@ -55,6 +55,7 @@ struct OsduWellboreTrajectory
     QString wellboreId;
     QString existenceKind;
     QString crs;
+    double  unitToMeters = 1.0;
 };
 
 struct OsduWellLogChannel

--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.h
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.h
@@ -43,6 +43,9 @@ struct OsduWellbore
     QString wellId;
     QString fieldId;
     double  datumElevation;
+    double  surfaceEasting  = 0.0;
+    double  surfaceNorthing = 0.0;
+    QString crs;
 };
 
 struct OsduWellboreTrajectory
@@ -51,6 +54,7 @@ struct OsduWellboreTrajectory
     QString kind;
     QString wellboreId;
     QString existenceKind;
+    QString crs;
 };
 
 struct OsduWellLogChannel

--- a/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.h
+++ b/ApplicationLibCode/Application/Tools/Cloud/RiaOsduConnector.h
@@ -110,6 +110,15 @@ public:
     std::pair<QByteArray, QString> requestWellLogParquetDataByIdBlocking( const QString& wellLogId );
     std::pair<QByteArray, QString> requestWellboreTrajectoryParquetDataByIdBlocking( const QString& wellboreTrajectoryId );
 
+    struct WellSurfaceLocation
+    {
+        double  easting  = 0.0;
+        double  northing = 0.0;
+        QString crs;
+        bool    isValid = false;
+    };
+    WellSurfaceLocation requestWellSurfaceLocationBlocking( const QString& wellId );
+
     std::optional<OsduWellbore> wellboreById( const QString& wellboreId ) const;
 
     void cancelRequestForId( const QString& id );
@@ -178,4 +187,5 @@ private:
     std::map<QString, QByteArray>                          m_parquetData;
     std::map<QString, QString>                             m_parquetErrors;
     std::map<QString, QPointer<QNetworkReply>>             m_replies;
+    std::map<QString, WellSurfaceLocation>                 m_wellSurfaceLocations;
 };

--- a/ApplicationLibCode/Commands/OsduCommands/RicWellPathsImportOsduFeature.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RicWellPathsImportOsduFeature.cpp
@@ -96,6 +96,7 @@ void RicWellPathsImportOsduFeature::onActionTriggered( bool isChecked )
             wellPath->setSurfaceEastingFromOsdu( w.surfaceEasting );
             wellPath->setSurfaceNorthingFromOsdu( w.surfaceNorthing );
             wellPath->setCrsFromOsdu( w.crs );
+            wellPath->setUnitToMetersFromOsdu( w.unitToMeters );
             wellPath->setWellPathColor( RiaColorTables::wellPathsPaletteColors().cycledColor3f( colorIndex++ ) );
 
             newWells.push_back( wellPath );

--- a/ApplicationLibCode/Commands/OsduCommands/RicWellPathsImportOsduFeature.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RicWellPathsImportOsduFeature.cpp
@@ -93,6 +93,9 @@ void RicWellPathsImportOsduFeature::onActionTriggered( bool isChecked )
             wellPath->setWellboreTrajectoryId( w.wellboreTrajectoryId );
             wellPath->setExistenceKind( w.existenceKind );
             wellPath->setDatumElevationFromOsdu( w.datumElevation );
+            wellPath->setSurfaceEastingFromOsdu( w.surfaceEasting );
+            wellPath->setSurfaceNorthingFromOsdu( w.surfaceNorthing );
+            wellPath->setCrsFromOsdu( w.crs );
             wellPath->setWellPathColor( RiaColorTables::wellPathsPaletteColors().cycledColor3f( colorIndex++ ) );
 
             newWells.push_back( wellPath );

--- a/ApplicationLibCode/Commands/OsduCommands/RicWellPathsImportOsduFeature.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RicWellPathsImportOsduFeature.cpp
@@ -97,6 +97,7 @@ void RicWellPathsImportOsduFeature::onActionTriggered( bool isChecked )
             wellPath->setSurfaceNorthingFromOsdu( w.surfaceNorthing );
             wellPath->setCrsFromOsdu( w.crs );
             wellPath->setUnitToMetersFromOsdu( w.unitToMeters );
+            wellPath->setTargetUnitToMeters( w.targetUnitToMeters );
             wellPath->setWellPathColor( RiaColorTables::wellPathsPaletteColors().cycledColor3f( colorIndex++ ) );
 
             newWells.push_back( wellPath );

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
@@ -722,7 +722,8 @@ void WellSummaryPage::updateSummaryDisplay()
                                         .datumElevation       = wellbore.value().datumElevation,
                                         .surfaceEasting       = location.easting,
                                         .surfaceNorthing      = location.northing,
-                                        .crs                  = location.crs } );
+                                        .crs                  = location.crs,
+                                        .unitToMeters         = w.unitToMeters } );
                     includedCount++;
                 }
             }

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
@@ -749,9 +749,9 @@ void WellSummaryPage::updateSummaryDisplay()
             {
                 if ( shouldIncludeTrajectory( w.existenceKind ) )
                 {
-                    QString wellboreTrajectoryId = w.id;
-                    auto         location           = m_osduConnector->requestWellSurfaceLocationBlocking( wellbore.value().wellId );
-                    const double targetUnitToMeters = m_targetUnitComboBox->currentData().toDouble();
+                    QString      wellboreTrajectoryId = w.id;
+                    auto         location             = m_osduConnector->requestWellSurfaceLocationBlocking( wellbore.value().wellId );
+                    const double targetUnitToMeters   = m_targetUnitComboBox->currentData().toDouble();
                     wiz->addWellInfo( { .name                 = wellbore.value().name,
                                         .wellId               = wellbore.value().wellId,
                                         .wellboreId           = w.wellboreId,

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
@@ -18,7 +18,13 @@
 
 #include "RiuWellImportWizard.h"
 
+#include "RiaDefines.h"
 #include "RiaStringListSerializer.h"
+
+#include "RigEclipseCaseData.h"
+
+#include "RimEclipseCase.h"
+#include "RimProject.h"
 
 #include <QAbstractTableModel>
 #include <QObject>
@@ -597,12 +603,31 @@ WellSummaryPage::WellSummaryPage( RiaOsduConnector* osduConnector, QWidget* pare
     layout->addLayout( existenceFilterLayout );
 
     // Target unit system: the OSDU trajectory parquet is converted to this unit before storing the well path.
+    // Default to the unit system of the first grid case in the project so the imported well path matches the
+    // case's coordinate frame; fall back to Meters when no Eclipse case is loaded.
     QHBoxLayout* unitLayout = new QHBoxLayout;
     unitLayout->addWidget( new QLabel( "Target unit system:", this ) );
     m_targetUnitComboBox = new QComboBox( this );
     m_targetUnitComboBox->addItem( "Meters", 1.0 );
     m_targetUnitComboBox->addItem( "Feet", 0.3048 );
-    m_targetUnitComboBox->setCurrentIndex( 0 );
+
+    int defaultUnitIndex = 0;
+    if ( auto* project = RimProject::current() )
+    {
+        for ( RimCase* gridCase : project->allGridCases() )
+        {
+            auto* eclipseCase = dynamic_cast<RimEclipseCase*>( gridCase );
+            if ( eclipseCase && eclipseCase->eclipseCaseData() )
+            {
+                if ( eclipseCase->eclipseCaseData()->unitsType() == RiaDefines::EclipseUnitSystem::UNITS_FIELD )
+                {
+                    defaultUnitIndex = 1;
+                }
+                break;
+            }
+        }
+    }
+    m_targetUnitComboBox->setCurrentIndex( defaultUnitIndex );
     unitLayout->addWidget( m_targetUnitComboBox );
     unitLayout->addStretch();
     layout->addLayout( unitLayout );

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
@@ -713,15 +713,16 @@ void WellSummaryPage::updateSummaryDisplay()
                 if ( shouldIncludeTrajectory( w.existenceKind ) )
                 {
                     QString wellboreTrajectoryId = w.id;
+                    auto location = m_osduConnector->requestWellSurfaceLocationBlocking( wellbore.value().wellId );
                     wiz->addWellInfo( { .name                 = wellbore.value().name,
                                         .wellId               = wellbore.value().wellId,
                                         .wellboreId           = w.wellboreId,
                                         .wellboreTrajectoryId = wellboreTrajectoryId,
                                         .existenceKind        = w.existenceKind,
                                         .datumElevation       = wellbore.value().datumElevation,
-                                        .surfaceEasting       = wellbore.value().surfaceEasting,
-                                        .surfaceNorthing      = wellbore.value().surfaceNorthing,
-                                        .crs                  = wellbore.value().crs } );
+                                        .surfaceEasting       = location.easting,
+                                        .surfaceNorthing      = location.northing,
+                                        .crs                  = location.crs } );
                     includedCount++;
                 }
             }

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
@@ -596,6 +596,17 @@ WellSummaryPage::WellSummaryPage( RiaOsduConnector* osduConnector, QWidget* pare
 
     layout->addLayout( existenceFilterLayout );
 
+    // Target unit system: the OSDU trajectory parquet is converted to this unit before storing the well path.
+    QHBoxLayout* unitLayout = new QHBoxLayout;
+    unitLayout->addWidget( new QLabel( "Target unit system:", this ) );
+    m_targetUnitComboBox = new QComboBox( this );
+    m_targetUnitComboBox->addItem( "Meters", 1.0 );
+    m_targetUnitComboBox->addItem( "Feet", 0.3048 );
+    m_targetUnitComboBox->setCurrentIndex( 0 );
+    unitLayout->addWidget( m_targetUnitComboBox );
+    unitLayout->addStretch();
+    layout->addLayout( unitLayout );
+
     m_textEdit = new QTextEdit( this );
     m_textEdit->setReadOnly( true );
     layout->addWidget( m_textEdit );
@@ -608,6 +619,7 @@ WellSummaryPage::WellSummaryPage( RiaOsduConnector* osduConnector, QWidget* pare
 
     connect( m_showAllRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onFilterChanged() ) );
     connect( m_showActualRadioButton, SIGNAL( toggled( bool ) ), this, SLOT( onFilterChanged() ) );
+    connect( m_targetUnitComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( onFilterChanged() ) );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -713,7 +725,8 @@ void WellSummaryPage::updateSummaryDisplay()
                 if ( shouldIncludeTrajectory( w.existenceKind ) )
                 {
                     QString wellboreTrajectoryId = w.id;
-                    auto location = m_osduConnector->requestWellSurfaceLocationBlocking( wellbore.value().wellId );
+                    auto         location           = m_osduConnector->requestWellSurfaceLocationBlocking( wellbore.value().wellId );
+                    const double targetUnitToMeters = m_targetUnitComboBox->currentData().toDouble();
                     wiz->addWellInfo( { .name                 = wellbore.value().name,
                                         .wellId               = wellbore.value().wellId,
                                         .wellboreId           = w.wellboreId,
@@ -723,7 +736,8 @@ void WellSummaryPage::updateSummaryDisplay()
                                         .surfaceEasting       = location.easting,
                                         .surfaceNorthing      = location.northing,
                                         .crs                  = location.crs,
-                                        .unitToMeters         = w.unitToMeters } );
+                                        .unitToMeters         = w.unitToMeters,
+                                        .targetUnitToMeters   = targetUnitToMeters } );
                     includedCount++;
                 }
             }

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.cpp
@@ -718,7 +718,10 @@ void WellSummaryPage::updateSummaryDisplay()
                                         .wellboreId           = w.wellboreId,
                                         .wellboreTrajectoryId = wellboreTrajectoryId,
                                         .existenceKind        = w.existenceKind,
-                                        .datumElevation       = wellbore.value().datumElevation } );
+                                        .datumElevation       = wellbore.value().datumElevation,
+                                        .surfaceEasting       = wellbore.value().surfaceEasting,
+                                        .surfaceNorthing      = wellbore.value().surfaceNorthing,
+                                        .crs                  = wellbore.value().crs } );
                     includedCount++;
                 }
             }

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.h
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.h
@@ -388,6 +388,7 @@ public:
         double  surfaceEasting;
         double  surfaceNorthing;
         QString crs;
+        double  unitToMeters;
     };
 
     RiuWellImportWizard( RiaOsduConnector* osduConnector, QWidget* parent = nullptr );

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.h
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.h
@@ -364,6 +364,7 @@ private:
     QTextEdit*                                             m_textEdit;
     QRadioButton*                                          m_showAllRadioButton;
     QRadioButton*                                          m_showActualRadioButton;
+    QComboBox*                                             m_targetUnitComboBox;
     std::set<QString>                                      m_pendingWellboreIds;
     std::map<QString, std::vector<OsduWellboreTrajectory>> m_wellboreTrajectories;
     mutable QMutex                                         m_mutex;
@@ -389,6 +390,7 @@ public:
         double  surfaceNorthing;
         QString crs;
         double  unitToMeters;
+        double  targetUnitToMeters;
     };
 
     RiuWellImportWizard( RiaOsduConnector* osduConnector, QWidget* parent = nullptr );

--- a/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.h
+++ b/ApplicationLibCode/Commands/OsduCommands/RiuWellImportWizard.h
@@ -385,6 +385,9 @@ public:
         QString wellboreTrajectoryId;
         QString existenceKind;
         double  datumElevation;
+        double  surfaceEasting;
+        double  surfaceNorthing;
+        QString crs;
     };
 
     RiuWellImportWizard( RiaOsduConnector* osduConnector, QWidget* parent = nullptr );

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
@@ -109,7 +109,8 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::parseCsv( const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathData( const QByteArray& content, double datumElevation )
+std::pair<cvf::ref<RigWellPath>, QString>
+    RifOsduWellPathReader::readWellPathData( const QByteArray& content, double datumElevation, double surfaceEasting, double surfaceNorthing )
 {
     arrow::MemoryPool* pool = arrow::default_memory_pool();
 
@@ -169,7 +170,9 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathDat
 
         for ( size_t i = 0; i < firstSize; i++ )
         {
-            cvf::Vec3d point( readValues[X][i], readValues[Y][i], -readValues[TVD][i] + datumElevation );
+            // Trajectory parquet stores X/Y as offsets relative to the wellbore surface point. Add the surface
+            // location (from the OSDU wellbore SpatialLocation) to recover absolute UTM coordinates.
+            cvf::Vec3d point( readValues[X][i] + surfaceEasting, readValues[Y][i] + surfaceNorthing, -readValues[TVD][i] + datumElevation );
             double     md = readValues[MD][i];
 
             wellPathPoints.push_back( point );

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
@@ -113,7 +113,8 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathDat
                                                                                     double            datumElevation,
                                                                                     double            surfaceEasting,
                                                                                     double            surfaceNorthing,
-                                                                                    double            unitToMeters )
+                                                                                    double            unitToMeters,
+                                                                                    double            targetUnitToMeters )
 {
     arrow::MemoryPool* pool = arrow::default_memory_pool();
 
@@ -171,18 +172,19 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathDat
         std::vector<cvf::Vec3d> wellPathPoints;
         std::vector<double>     measuredDepths;
 
+        // Convert OSDU values to meters (the surface origin and datum elevation are already meters), then scale
+        // the result into the user-selected target unit system.
+        const double targetScale = ( targetUnitToMeters != 0.0 ) ? 1.0 / targetUnitToMeters : 1.0;
+
         for ( size_t i = 0; i < firstSize; i++ )
         {
-            // Trajectory parquet stores X/Y as offsets relative to the well surface point, and MD/TVD/X/Y in
-            // whatever length unit the trajectory advertises (typically ft or m). Convert to meters and add the
-            // surface origin (always meters) to recover absolute UTM coordinates.
-            const double x   = readValues[X][i] * unitToMeters;
-            const double y   = readValues[Y][i] * unitToMeters;
-            const double tvd = readValues[TVD][i] * unitToMeters;
-            const double md  = readValues[MD][i] * unitToMeters;
+            const double xMeters   = readValues[X][i] * unitToMeters + surfaceEasting;
+            const double yMeters   = readValues[Y][i] * unitToMeters + surfaceNorthing;
+            const double zMeters   = -readValues[TVD][i] * unitToMeters + datumElevation;
+            const double mdMeters  = readValues[MD][i] * unitToMeters;
 
-            wellPathPoints.push_back( cvf::Vec3d( x + surfaceEasting, y + surfaceNorthing, -tvd + datumElevation ) );
-            measuredDepths.push_back( md );
+            wellPathPoints.push_back( cvf::Vec3d( xMeters * targetScale, yMeters * targetScale, zMeters * targetScale ) );
+            measuredDepths.push_back( mdMeters * targetScale );
         }
 
         auto wellPath = cvf::make_ref<RigWellPath>( wellPathPoints, measuredDepths );

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
@@ -109,8 +109,11 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::parseCsv( const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-std::pair<cvf::ref<RigWellPath>, QString>
-    RifOsduWellPathReader::readWellPathData( const QByteArray& content, double datumElevation, double surfaceEasting, double surfaceNorthing )
+std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathData( const QByteArray& content,
+                                                                                    double            datumElevation,
+                                                                                    double            surfaceEasting,
+                                                                                    double            surfaceNorthing,
+                                                                                    double            unitToMeters )
 {
     arrow::MemoryPool* pool = arrow::default_memory_pool();
 
@@ -170,12 +173,15 @@ std::pair<cvf::ref<RigWellPath>, QString>
 
         for ( size_t i = 0; i < firstSize; i++ )
         {
-            // Trajectory parquet stores X/Y as offsets relative to the wellbore surface point. Add the surface
-            // location (from the OSDU wellbore SpatialLocation) to recover absolute UTM coordinates.
-            cvf::Vec3d point( readValues[X][i] + surfaceEasting, readValues[Y][i] + surfaceNorthing, -readValues[TVD][i] + datumElevation );
-            double     md = readValues[MD][i];
+            // Trajectory parquet stores X/Y as offsets relative to the well surface point, and MD/TVD/X/Y in
+            // whatever length unit the trajectory advertises (typically ft or m). Convert to meters and add the
+            // surface origin (always meters) to recover absolute UTM coordinates.
+            const double x   = readValues[X][i] * unitToMeters;
+            const double y   = readValues[Y][i] * unitToMeters;
+            const double tvd = readValues[TVD][i] * unitToMeters;
+            const double md  = readValues[MD][i] * unitToMeters;
 
-            wellPathPoints.push_back( point );
+            wellPathPoints.push_back( cvf::Vec3d( x + surfaceEasting, y + surfaceNorthing, -tvd + datumElevation ) );
             measuredDepths.push_back( md );
         }
 

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
@@ -110,11 +110,11 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::parseCsv( const
 ///
 //--------------------------------------------------------------------------------------------------
 std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathData( const QByteArray& content,
-                                                                                    double            datumElevation,
-                                                                                    double            surfaceEasting,
-                                                                                    double            surfaceNorthing,
-                                                                                    double            unitToMeters,
-                                                                                    double            targetUnitToMeters )
+                                                                                   double            datumElevation,
+                                                                                   double            surfaceEasting,
+                                                                                   double            surfaceNorthing,
+                                                                                   double            unitToMeters,
+                                                                                   double            targetUnitToMeters )
 {
     arrow::MemoryPool* pool = arrow::default_memory_pool();
 
@@ -178,10 +178,10 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathDat
 
         for ( size_t i = 0; i < firstSize; i++ )
         {
-            const double xMeters   = readValues[X][i] * unitToMeters + surfaceEasting;
-            const double yMeters   = readValues[Y][i] * unitToMeters + surfaceNorthing;
-            const double zMeters   = -readValues[TVD][i] * unitToMeters + datumElevation;
-            const double mdMeters  = readValues[MD][i] * unitToMeters;
+            const double xMeters  = readValues[X][i] * unitToMeters + surfaceEasting;
+            const double yMeters  = readValues[Y][i] * unitToMeters + surfaceNorthing;
+            const double zMeters  = -readValues[TVD][i] * unitToMeters + datumElevation;
+            const double mdMeters = readValues[MD][i] * unitToMeters;
 
             wellPathPoints.push_back( cvf::Vec3d( xMeters * targetScale, yMeters * targetScale, zMeters * targetScale ) );
             measuredDepths.push_back( mdMeters * targetScale );

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.cpp
@@ -172,15 +172,18 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathDat
         std::vector<cvf::Vec3d> wellPathPoints;
         std::vector<double>     measuredDepths;
 
-        // Convert OSDU values to meters (the surface origin and datum elevation are already meters), then scale
-        // the result into the user-selected target unit system.
+        // Convert OSDU values to meters (the surface origin is already meters), then scale into the user-
+        // selected target unit system. The trajectory's TVD column is referenced to its vertical CRS
+        // (typically EPSG:5715 / MSL Depth, positive = down), so Z = -TVD without adding the wellbore
+        // datum elevation — that would otherwise shift the imported well path above the simulation well
+        // path by the RKB elevation. The datum is still stored on RigWellPath as metadata for plots.
         const double targetScale = ( targetUnitToMeters != 0.0 ) ? 1.0 / targetUnitToMeters : 1.0;
 
         for ( size_t i = 0; i < firstSize; i++ )
         {
             const double xMeters  = readValues[X][i] * unitToMeters + surfaceEasting;
             const double yMeters  = readValues[Y][i] * unitToMeters + surfaceNorthing;
-            const double zMeters  = -readValues[TVD][i] * unitToMeters + datumElevation;
+            const double zMeters  = -readValues[TVD][i] * unitToMeters;
             const double mdMeters = readValues[MD][i] * unitToMeters;
 
             wellPathPoints.push_back( cvf::Vec3d( xMeters * targetScale, yMeters * targetScale, zMeters * targetScale ) );
@@ -188,7 +191,7 @@ std::pair<cvf::ref<RigWellPath>, QString> RifOsduWellPathReader::readWellPathDat
         }
 
         auto wellPath = cvf::make_ref<RigWellPath>( wellPathPoints, measuredDepths );
-        wellPath->setDatumElevation( datumElevation );
+        wellPath->setDatumElevation( datumElevation * targetScale );
         return { wellPath, "" };
     }
 

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.h
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.h
@@ -34,8 +34,8 @@ public:
     static std::pair<cvf::ref<RigWellPath>, QString> parseCsv( const QString& content );
     static std::pair<cvf::ref<RigWellPath>, QString> readWellPathData( const QByteArray& content,
                                                                        double            datumElevation,
-                                                                       double            surfaceEasting    = 0.0,
-                                                                       double            surfaceNorthing   = 0.0,
-                                                                       double            unitToMeters      = 1.0,
+                                                                       double            surfaceEasting     = 0.0,
+                                                                       double            surfaceNorthing    = 0.0,
+                                                                       double            unitToMeters       = 1.0,
                                                                        double            targetUnitToMeters = 1.0 );
 };

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.h
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.h
@@ -32,6 +32,9 @@ class RifOsduWellPathReader
 {
 public:
     static std::pair<cvf::ref<RigWellPath>, QString> parseCsv( const QString& content );
-    static std::pair<cvf::ref<RigWellPath>, QString>
-        readWellPathData( const QByteArray& content, double datumElevation, double surfaceEasting = 0.0, double surfaceNorthing = 0.0 );
+    static std::pair<cvf::ref<RigWellPath>, QString> readWellPathData( const QByteArray& content,
+                                                                       double            datumElevation,
+                                                                       double            surfaceEasting  = 0.0,
+                                                                       double            surfaceNorthing = 0.0,
+                                                                       double            unitToMeters    = 1.0 );
 };

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.h
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.h
@@ -32,5 +32,6 @@ class RifOsduWellPathReader
 {
 public:
     static std::pair<cvf::ref<RigWellPath>, QString> parseCsv( const QString& content );
-    static std::pair<cvf::ref<RigWellPath>, QString> readWellPathData( const QByteArray& content, double datumElevation );
+    static std::pair<cvf::ref<RigWellPath>, QString>
+        readWellPathData( const QByteArray& content, double datumElevation, double surfaceEasting = 0.0, double surfaceNorthing = 0.0 );
 };

--- a/ApplicationLibCode/FileInterface/RifOsduWellPathReader.h
+++ b/ApplicationLibCode/FileInterface/RifOsduWellPathReader.h
@@ -34,7 +34,8 @@ public:
     static std::pair<cvf::ref<RigWellPath>, QString> parseCsv( const QString& content );
     static std::pair<cvf::ref<RigWellPath>, QString> readWellPathData( const QByteArray& content,
                                                                        double            datumElevation,
-                                                                       double            surfaceEasting  = 0.0,
-                                                                       double            surfaceNorthing = 0.0,
-                                                                       double            unitToMeters    = 1.0 );
+                                                                       double            surfaceEasting    = 0.0,
+                                                                       double            surfaceNorthing   = 0.0,
+                                                                       double            unitToMeters      = 1.0,
+                                                                       double            targetUnitToMeters = 1.0 );
 };

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.cpp
@@ -38,6 +38,9 @@ RimOsduWellPath::RimOsduWellPath()
 
     CAF_PDM_InitField( &m_unitToMetersFromOsdu, "UnitToMetersFromOsdu", 1.0, "Unit-to-meters Factor From OSDU" );
     m_unitToMetersFromOsdu.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitField( &m_targetUnitToMeters, "TargetUnitToMeters", 1.0, "Target Unit-to-meters Factor" );
+    m_targetUnitToMeters.uiCapability()->setUiReadOnly( true );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -178,6 +181,22 @@ double RimOsduWellPath::unitToMetersFromOsdu() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimOsduWellPath::setTargetUnitToMeters( double targetUnitToMeters )
+{
+    m_targetUnitToMeters = targetUnitToMeters;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimOsduWellPath::targetUnitToMeters() const
+{
+    return m_targetUnitToMeters;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimOsduWellPath::setExistenceKind( const QString& existenceKind )
 {
     m_existenceKind = existenceKind;
@@ -206,6 +225,7 @@ void RimOsduWellPath::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering
     osduGroup->add( &m_surfaceNorthingFromOsdu );
     osduGroup->add( &m_crsFromOsdu );
     osduGroup->add( &m_unitToMetersFromOsdu );
+    osduGroup->add( &m_targetUnitToMeters );
 
     RimWellPath::defineUiOrdering( uiConfigName, uiOrdering );
 }

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.cpp
@@ -35,6 +35,9 @@ RimOsduWellPath::RimOsduWellPath()
 
     CAF_PDM_InitFieldNoDefault( &m_crsFromOsdu, "CrsFromOsdu", "CRS From OSDU" );
     m_crsFromOsdu.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitField( &m_unitToMetersFromOsdu, "UnitToMetersFromOsdu", 1.0, "Unit-to-meters Factor From OSDU" );
+    m_unitToMetersFromOsdu.uiCapability()->setUiReadOnly( true );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -159,6 +162,22 @@ QString RimOsduWellPath::crsFromOsdu() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimOsduWellPath::setUnitToMetersFromOsdu( double unitToMeters )
+{
+    m_unitToMetersFromOsdu = unitToMeters;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimOsduWellPath::unitToMetersFromOsdu() const
+{
+    return m_unitToMetersFromOsdu;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimOsduWellPath::setExistenceKind( const QString& existenceKind )
 {
     m_existenceKind = existenceKind;
@@ -186,6 +205,7 @@ void RimOsduWellPath::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering
     osduGroup->add( &m_surfaceEastingFromOsdu );
     osduGroup->add( &m_surfaceNorthingFromOsdu );
     osduGroup->add( &m_crsFromOsdu );
+    osduGroup->add( &m_unitToMetersFromOsdu );
 
     RimWellPath::defineUiOrdering( uiConfigName, uiOrdering );
 }

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.cpp
@@ -26,6 +26,15 @@ RimOsduWellPath::RimOsduWellPath()
 
     CAF_PDM_InitField( &m_datumElevationFromOsdu, "DatumElevationFromOsdu", 0.0, "Datum Elevation From OSDU" );
     m_datumElevationFromOsdu.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitField( &m_surfaceEastingFromOsdu, "SurfaceEastingFromOsdu", 0.0, "Surface Easting From OSDU" );
+    m_surfaceEastingFromOsdu.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitField( &m_surfaceNorthingFromOsdu, "SurfaceNorthingFromOsdu", 0.0, "Surface Northing From OSDU" );
+    m_surfaceNorthingFromOsdu.uiCapability()->setUiReadOnly( true );
+
+    CAF_PDM_InitFieldNoDefault( &m_crsFromOsdu, "CrsFromOsdu", "CRS From OSDU" );
+    m_crsFromOsdu.uiCapability()->setUiReadOnly( true );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -102,6 +111,54 @@ double RimOsduWellPath::datumElevationFromOsdu() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimOsduWellPath::setSurfaceEastingFromOsdu( double surfaceEasting )
+{
+    m_surfaceEastingFromOsdu = surfaceEasting;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimOsduWellPath::surfaceEastingFromOsdu() const
+{
+    return m_surfaceEastingFromOsdu;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimOsduWellPath::setSurfaceNorthingFromOsdu( double surfaceNorthing )
+{
+    m_surfaceNorthingFromOsdu = surfaceNorthing;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+double RimOsduWellPath::surfaceNorthingFromOsdu() const
+{
+    return m_surfaceNorthingFromOsdu;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimOsduWellPath::setCrsFromOsdu( const QString& crs )
+{
+    m_crsFromOsdu = crs;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RimOsduWellPath::crsFromOsdu() const
+{
+    return m_crsFromOsdu;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimOsduWellPath::setExistenceKind( const QString& existenceKind )
 {
     m_existenceKind = existenceKind;
@@ -126,6 +183,9 @@ void RimOsduWellPath::defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering
     osduGroup->add( &m_wellboreTrajectoryId );
     osduGroup->add( &m_existenceKind );
     osduGroup->add( &m_datumElevationFromOsdu );
+    osduGroup->add( &m_surfaceEastingFromOsdu );
+    osduGroup->add( &m_surfaceNorthingFromOsdu );
+    osduGroup->add( &m_crsFromOsdu );
 
     RimWellPath::defineUiOrdering( uiConfigName, uiOrdering );
 }

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.h
@@ -51,6 +51,9 @@ public:
     void   setUnitToMetersFromOsdu( double unitToMeters );
     double unitToMetersFromOsdu() const;
 
+    void   setTargetUnitToMeters( double targetUnitToMeters );
+    double targetUnitToMeters() const;
+
     void    setExistenceKind( const QString& existenceKind );
     QString existenceKind() const;
 
@@ -67,4 +70,5 @@ private:
     caf::PdmField<double>  m_surfaceNorthingFromOsdu;
     caf::PdmField<QString> m_crsFromOsdu;
     caf::PdmField<double>  m_unitToMetersFromOsdu;
+    caf::PdmField<double>  m_targetUnitToMeters;
 };

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.h
@@ -48,6 +48,9 @@ public:
     void    setCrsFromOsdu( const QString& crs );
     QString crsFromOsdu() const;
 
+    void   setUnitToMetersFromOsdu( double unitToMeters );
+    double unitToMetersFromOsdu() const;
+
     void    setExistenceKind( const QString& existenceKind );
     QString existenceKind() const;
 
@@ -63,4 +66,5 @@ private:
     caf::PdmField<double>  m_surfaceEastingFromOsdu;
     caf::PdmField<double>  m_surfaceNorthingFromOsdu;
     caf::PdmField<QString> m_crsFromOsdu;
+    caf::PdmField<double>  m_unitToMetersFromOsdu;
 };

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.h
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPath.h
@@ -39,6 +39,15 @@ public:
     void   setDatumElevationFromOsdu( double datumElevationFromOsdu );
     double datumElevationFromOsdu() const;
 
+    void   setSurfaceEastingFromOsdu( double surfaceEasting );
+    double surfaceEastingFromOsdu() const;
+
+    void   setSurfaceNorthingFromOsdu( double surfaceNorthing );
+    double surfaceNorthingFromOsdu() const;
+
+    void    setCrsFromOsdu( const QString& crs );
+    QString crsFromOsdu() const;
+
     void    setExistenceKind( const QString& existenceKind );
     QString existenceKind() const;
 
@@ -51,4 +60,7 @@ private:
     caf::PdmField<QString> m_wellboreTrajectoryId;
     caf::PdmField<QString> m_existenceKind;
     caf::PdmField<double>  m_datumElevationFromOsdu;
+    caf::PdmField<double>  m_surfaceEastingFromOsdu;
+    caf::PdmField<double>  m_surfaceNorthingFromOsdu;
+    caf::PdmField<QString> m_crsFromOsdu;
 };

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPathDataLoader.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPathDataLoader.cpp
@@ -115,7 +115,8 @@ void RimOsduWellPathDataLoader::parquetDownloadComplete( const QByteArray& conte
                                                                                               oWPath->datumElevationFromOsdu(),
                                                                                               oWPath->surfaceEastingFromOsdu(),
                                                                                               oWPath->surfaceNorthingFromOsdu(),
-                                                                                              oWPath->unitToMetersFromOsdu() );
+                                                                                              oWPath->unitToMetersFromOsdu(),
+                                                                                              oWPath->targetUnitToMeters() );
             if ( wellPathGeometry.notNull() )
             {
                 oWPath->setWellPathGeometry( wellPathGeometry.p() );

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPathDataLoader.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPathDataLoader.cpp
@@ -114,7 +114,8 @@ void RimOsduWellPathDataLoader::parquetDownloadComplete( const QByteArray& conte
             auto [wellPathGeometry, errorMessage] = RifOsduWellPathReader::readWellPathData( contents,
                                                                                               oWPath->datumElevationFromOsdu(),
                                                                                               oWPath->surfaceEastingFromOsdu(),
-                                                                                              oWPath->surfaceNorthingFromOsdu() );
+                                                                                              oWPath->surfaceNorthingFromOsdu(),
+                                                                                              oWPath->unitToMetersFromOsdu() );
             if ( wellPathGeometry.notNull() )
             {
                 oWPath->setWellPathGeometry( wellPathGeometry.p() );

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPathDataLoader.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPathDataLoader.cpp
@@ -111,7 +111,10 @@ void RimOsduWellPathDataLoader::parquetDownloadComplete( const QByteArray& conte
         if ( !contents.isEmpty() )
         {
             auto oWPath                           = m_wellPaths[id];
-            auto [wellPathGeometry, errorMessage] = RifOsduWellPathReader::readWellPathData( contents, oWPath->datumElevationFromOsdu() );
+            auto [wellPathGeometry, errorMessage] = RifOsduWellPathReader::readWellPathData( contents,
+                                                                                              oWPath->datumElevationFromOsdu(),
+                                                                                              oWPath->surfaceEastingFromOsdu(),
+                                                                                              oWPath->surfaceNorthingFromOsdu() );
             if ( wellPathGeometry.notNull() )
             {
                 oWPath->setWellPathGeometry( wellPathGeometry.p() );

--- a/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPathDataLoader.cpp
+++ b/ApplicationLibCode/ProjectDataModel/WellPath/RimOsduWellPathDataLoader.cpp
@@ -112,11 +112,11 @@ void RimOsduWellPathDataLoader::parquetDownloadComplete( const QByteArray& conte
         {
             auto oWPath                           = m_wellPaths[id];
             auto [wellPathGeometry, errorMessage] = RifOsduWellPathReader::readWellPathData( contents,
-                                                                                              oWPath->datumElevationFromOsdu(),
-                                                                                              oWPath->surfaceEastingFromOsdu(),
-                                                                                              oWPath->surfaceNorthingFromOsdu(),
-                                                                                              oWPath->unitToMetersFromOsdu(),
-                                                                                              oWPath->targetUnitToMeters() );
+                                                                                             oWPath->datumElevationFromOsdu(),
+                                                                                             oWPath->surfaceEastingFromOsdu(),
+                                                                                             oWPath->surfaceNorthingFromOsdu(),
+                                                                                             oWPath->unitToMetersFromOsdu(),
+                                                                                             oWPath->targetUnitToMeters() );
             if ( wellPathGeometry.notNull() )
             {
                 oWPath->setWellPathGeometry( wellPathGeometry.p() );

--- a/scripts/tools/extract_osdu_wellpath.py
+++ b/scripts/tools/extract_osdu_wellpath.py
@@ -99,6 +99,8 @@ def main() -> int:
     parser.add_argument("--wellbore-id", required=True)
     parser.add_argument("--trajectory-id", required=True)
     parser.add_argument("--rows", type=int, default=5, help="Rows to print from head and tail of the parquet.")
+    parser.add_argument("--full", action="store_true",
+                        help="Print the full data block of each record, not just SpatialLocation.")
     args = parser.parse_args()
 
     config = load_json(args.config_file)
@@ -122,16 +124,47 @@ def main() -> int:
 
     print(f"=== Wellbore: {args.wellbore_id} ===")
     wellbore = fetch_storage_record(server, partition, token, args.wellbore_id)
-    spatial = wellbore.get("data", {}).get("SpatialLocation", {}) or {}
-    print(json.dumps(spatial, indent=2))
-    easting, northing, crs = extract_surface_origin(spatial)
-    print(f"Surface origin: easting={easting} northing={northing} crs={crs!r}")
+    wellbore_data = wellbore.get("data", {}) or {}
+    if args.full:
+        print(json.dumps(wellbore_data, indent=2))
+    else:
+        print(f"data keys: {sorted(wellbore_data.keys())}")
+        spatial = wellbore_data.get("SpatialLocation", {}) or {}
+        print("SpatialLocation:")
+        print(json.dumps(spatial, indent=2))
+    easting, northing, crs = extract_surface_origin(wellbore_data.get("SpatialLocation", {}) or {})
+    print(f"Wellbore surface origin: easting={easting} northing={northing} crs={crs!r}")
+
+    # Wellbores often have no SpatialLocation; the surface point lives on the parent Well.
+    well_id = (wellbore_data.get("WellID") or "").rstrip(":")
+    if well_id and (easting is None or northing is None):
+        print()
+        print(f"=== Well: {well_id} ===")
+        well = fetch_storage_record(server, partition, token, well_id)
+        well_data = well.get("data", {}) or {}
+        if args.full:
+            print(json.dumps(well_data, indent=2))
+        else:
+            print(f"data keys: {sorted(well_data.keys())}")
+            well_spatial = well_data.get("SpatialLocation", {}) or {}
+            print("SpatialLocation:")
+            print(json.dumps(well_spatial, indent=2))
+        well_easting, well_northing, well_crs = extract_surface_origin(well_data.get("SpatialLocation", {}) or {})
+        print(f"Well surface origin: easting={well_easting} northing={well_northing} crs={well_crs!r}")
+        if well_easting is not None and well_northing is not None:
+            easting, northing, crs = well_easting, well_northing, well_crs
 
     print()
     print(f"=== Trajectory: {args.trajectory_id} ===")
     trajectory = fetch_storage_record(server, partition, token, args.trajectory_id)
-    traj_spatial = trajectory.get("data", {}).get("SpatialLocation", {}) or {}
-    print(json.dumps(traj_spatial, indent=2))
+    traj_data = trajectory.get("data", {}) or {}
+    if args.full:
+        print(json.dumps(traj_data, indent=2))
+    else:
+        print(f"data keys: {sorted(traj_data.keys())}")
+        traj_spatial = traj_data.get("SpatialLocation", {}) or {}
+        print("SpatialLocation:")
+        print(json.dumps(traj_spatial, indent=2))
 
     print()
     print("=== Trajectory parquet ===")

--- a/scripts/tools/extract_osdu_wellpath.py
+++ b/scripts/tools/extract_osdu_wellpath.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""
+Standalone OSDU well trajectory inspector.
+
+Fetches a wellbore record and a wellbore-trajectory record from OSDU, dumps
+the SpatialLocation block from each, downloads the trajectory parquet and
+prints the absolute UTM coordinates after applying the wellbore surface
+origin.
+
+This is independent of ResInsight. Use it to validate what ResInsight's
+OSDU importer should produce.
+
+By default, configuration is read from ResInsight's local files:
+    ~/.resinsight/osdu_config.json   server, dataPartitionId, ...
+    ~/.resinsight/osdu_token.json    token (bearer access token)
+
+CLI flags override the values from those files. You can also use
+--config-file / --token-file to point at alternate locations, or set
+OSDU_SERVER / OSDU_PARTITION / OSDU_TOKEN as env-var overrides.
+
+Requirements:
+    pip install requests pandas pyarrow
+
+Example (uses ~/.resinsight/osdu_*.json automatically):
+    python extract_osdu_wellpath.py \\
+        --wellbore-id "opendes:master-data--Wellbore:abcd" \\
+        --trajectory-id "opendes:work-product-component--WellboreTrajectory:efgh"
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional, Tuple
+
+import requests
+
+
+DEFAULT_CONFIG_FILE = Path.home() / ".resinsight" / "osdu_config.json"
+DEFAULT_TOKEN_FILE = Path.home() / ".resinsight" / "osdu_token.json"
+
+
+def _headers(partition: str, token: str, accept: str) -> dict:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Data-Partition-Id": partition,
+        "Accept": accept,
+    }
+
+
+def load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"Warning: {path} is not valid JSON ({exc}); ignoring.", file=sys.stderr)
+        return {}
+
+
+def fetch_storage_record(server: str, partition: str, token: str, record_id: str) -> dict:
+    url = f"{server.rstrip('/')}/api/storage/v2/records/{record_id}"
+    resp = requests.get(url, headers=_headers(partition, token, "application/json"), timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_trajectory_parquet(server: str, partition: str, token: str, trajectory_id: str) -> bytes:
+    url = f"{server.rstrip('/')}/api/os-wellbore-ddms/ddms/v3/wellboretrajectories/{trajectory_id}/data"
+    resp = requests.get(url, headers=_headers(partition, token, "application/x-parquet"), timeout=120)
+    resp.raise_for_status()
+    return resp.content
+
+
+def extract_surface_origin(spatial_location: dict) -> Tuple[Optional[float], Optional[float], str]:
+    ingested = spatial_location.get("AsIngestedCoordinates", {}) or {}
+    crs = ingested.get("persistableReferenceCrs", "")
+    features = ingested.get("features", []) or []
+    if features:
+        coords = features[0].get("geometry", {}).get("coordinates", [])
+        if len(coords) >= 2:
+            return float(coords[0]), float(coords[1]), crs
+    return None, None, crs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inspect an OSDU wellbore trajectory.")
+    parser.add_argument("--config-file", type=Path, default=DEFAULT_CONFIG_FILE,
+                        help=f"OSDU config json (default: {DEFAULT_CONFIG_FILE})")
+    parser.add_argument("--token-file", type=Path, default=DEFAULT_TOKEN_FILE,
+                        help=f"OSDU token json (default: {DEFAULT_TOKEN_FILE})")
+    parser.add_argument("--server", default=os.environ.get("OSDU_SERVER"))
+    parser.add_argument("--partition", default=os.environ.get("OSDU_PARTITION"))
+    parser.add_argument("--token", default=os.environ.get("OSDU_TOKEN"))
+    parser.add_argument("--wellbore-id", required=True)
+    parser.add_argument("--trajectory-id", required=True)
+    parser.add_argument("--rows", type=int, default=5, help="Rows to print from head and tail of the parquet.")
+    args = parser.parse_args()
+
+    config = load_json(args.config_file)
+    token_data = load_json(args.token_file)
+
+    server = args.server or config.get("server")
+    partition = args.partition or config.get("dataPartitionId")
+    token = args.token or token_data.get("token")
+
+    missing = [n for n, v in [("server", server), ("partition", partition), ("token", token)] if not v]
+    if missing:
+        parser.error(
+            f"Missing required configuration: {', '.join(missing)}.\n"
+            f"Looked in: config={args.config_file}, token={args.token_file}.\n"
+            "Provide via CLI flag, env var, or update those files."
+        )
+
+    print(f"Server   : {server}")
+    print(f"Partition: {partition}")
+    print()
+
+    print(f"=== Wellbore: {args.wellbore_id} ===")
+    wellbore = fetch_storage_record(server, partition, token, args.wellbore_id)
+    spatial = wellbore.get("data", {}).get("SpatialLocation", {}) or {}
+    print(json.dumps(spatial, indent=2))
+    easting, northing, crs = extract_surface_origin(spatial)
+    print(f"Surface origin: easting={easting} northing={northing} crs={crs!r}")
+
+    print()
+    print(f"=== Trajectory: {args.trajectory_id} ===")
+    trajectory = fetch_storage_record(server, partition, token, args.trajectory_id)
+    traj_spatial = trajectory.get("data", {}).get("SpatialLocation", {}) or {}
+    print(json.dumps(traj_spatial, indent=2))
+
+    print()
+    print("=== Trajectory parquet ===")
+    parquet_bytes = fetch_trajectory_parquet(server, partition, token, args.trajectory_id)
+    print(f"Downloaded {len(parquet_bytes)} bytes")
+
+    try:
+        import pandas as pd
+        import pyarrow.parquet as pq
+    except ImportError:
+        print("pandas / pyarrow not installed; skipping parquet inspection.", file=sys.stderr)
+        return 0
+
+    table = pq.read_table(io.BytesIO(parquet_bytes))
+    df = table.to_pandas()
+    print(f"Columns: {list(df.columns)}")
+    print(f"Rows:    {len(df)}")
+
+    cols = [c for c in ("MD", "TVD", "X", "Y") if c in df.columns]
+    if cols:
+        print()
+        print("Head:")
+        print(df[cols].head(args.rows).to_string(index=False))
+        print()
+        print("Tail:")
+        print(df[cols].tail(args.rows).to_string(index=False))
+
+    if easting is not None and northing is not None and {"X", "Y"}.issubset(df.columns):
+        print()
+        print("Absolute UTM after applying surface origin (E + X, N + Y):")
+        first, last = df.iloc[0], df.iloc[-1]
+        print(f"  first: E={first['X'] + easting:.3f}, N={first['Y'] + northing:.3f}")
+        print(f"  last : E={last['X']  + easting:.3f}, N={last['Y']  + northing:.3f}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Fetches the parent **Well** record (via `Wellbore.WellID`) and uses its `SpatialLocation.AsIngestedCoordinates` as the surface origin, since the Wellbore record itself does not carry a `SpatialLocation`. Trajectory parquet `X`/`Y` (offsets relative to that origin) are added back to recover absolute UTM coordinates — fixes wells landing at `(0, 0)`.
- Detects the trajectory's advertised length unit from `AvailableTrajectoryStationProperties.MD.StationPropertyUnitID` (typically `ft` or `m`) and converts `MD/TVD/X/Y` to meters before combining with the meter-frame surface origin and datum elevation.
- Adds a **Target unit system** combobox (`Meters` / `Feet`) on the well import wizard's summary page; the resulting `RigWellPath` is scaled into the chosen unit at read time.
- Adds `scripts/tools/extract_osdu_wellpath.py`, a standalone Python tool to fetch wellbore + well + trajectory records and inspect surface origin / parquet contents independently of ResInsight (uses `~/.resinsight/osdu_config.json` and `osdu_token.json` automatically).

Issue: https://github.com/OPM/ResInsight/issues/13958

## Test plan
- [ ] Import a known wellbore from OSDU and confirm the well surfaces at the correct absolute UTM (e.g. `(457121.86, 7322122.99)` for the test wellbore on Equinor's swe partition).
- [ ] Toggle Target unit system between Meters and Feet on the wizard summary page and confirm imported well path coordinates and MD scale accordingly.
- [ ] Verify a wellbore with no parent Well or no `SpatialLocation` still imports without crashing (will fall back to origin `0, 0` with a warning in the log).
- [ ] Run `python scripts/tools/extract_osdu_wellpath.py --wellbore-id ... --trajectory-id ...` and confirm the printed absolute UTM matches what ResInsight imports.