### PR TITLE
#14003 Faults: Use NNCs to extend fault face detection

### DIFF
--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
@@ -549,8 +549,8 @@ void RigMainGrid::addFaultFacesFromNNCs( const RigActiveCellInfo* activeCellInfo
 
     for ( size_t nncIdx = 0; nncIdx < nncs.size(); ++nncIdx )
     {
-        const RigConnection&               conn = nncs[nncIdx];
-        StructGridInterface::FaceType      face = conn.face();
+        const RigConnection&          conn = nncs[nncIdx];
+        StructGridInterface::FaceType face = conn.face();
         if ( face == StructGridInterface::NO_FACE ) continue;
 
         const size_t c1 = conn.c1GlobIdx();

--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.cpp
@@ -518,6 +518,64 @@ void RigMainGrid::calculateFaults( const RigActiveCellInfo* activeCellInfo )
                               unNamedFaultFacesInactive,
                               m_faultsPrCellAcc.p() );
     }
+
+    // Augment fault detection with NNCs from the file. NNCs can mark faulted face pairs that the
+    // pure geometric (sharedFaceVertices) check above misses, in particular K-faces and
+    // pinch-out/LGR-related connections. Only NNCs with a resolved face direction that are not
+    // already associated with a fault face are added.
+    addFaultFacesFromNNCs( activeCellInfo, unNamedFault, unNamedFaultIdx, unNamedFaultWithInactive, unNamedFaultWithInactiveIdx );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RigMainGrid::addFaultFacesFromNNCs( const RigActiveCellInfo* activeCellInfo,
+                                         RigFault*                unNamedFault,
+                                         int                      unNamedFaultIdx,
+                                         RigFault*                unNamedFaultWithInactive,
+                                         int                      unNamedFaultWithInactiveIdx )
+{
+    if ( m_nncData.isNull() || m_faultsPrCellAcc.isNull() || activeCellInfo == nullptr ) return;
+
+    // NNCs read from file have no face direction until buildPolygonsForEclipseConnections runs.
+    // Trigger it here so we can use the face direction during fault detection.
+    m_nncData->buildPolygonsForEclipseConnections();
+
+    const RigConnectionContainer& nncs       = m_nncData->availableConnections();
+    const size_t                  cellsCount = totalCellCount();
+
+    std::vector<RigFault::FaultFace>& unNamedFaultFaces         = unNamedFault->faultFaces();
+    std::vector<RigFault::FaultFace>& unNamedFaultFacesInactive = unNamedFaultWithInactive->faultFaces();
+
+    for ( size_t nncIdx = 0; nncIdx < nncs.size(); ++nncIdx )
+    {
+        const RigConnection&               conn = nncs[nncIdx];
+        StructGridInterface::FaceType      face = conn.face();
+        if ( face == StructGridInterface::NO_FACE ) continue;
+
+        const size_t c1 = conn.c1GlobIdx();
+        const size_t c2 = conn.c2GlobIdx();
+        if ( c1 >= cellsCount || c2 >= cellsCount ) continue;
+
+        if ( m_faultsPrCellAcc->faultIdx( c1, face ) != RigFaultsPrCellAccumulator::NO_FAULT ) continue;
+
+        const bool isC1Active = activeCellInfo->isActive( ReservoirCellIndex( c1 ) );
+        const bool isC2Active = activeCellInfo->isActive( ReservoirCellIndex( c2 ) );
+        const int  faultIdx   = ( isC1Active && isC2Active ) ? unNamedFaultIdx : unNamedFaultWithInactiveIdx;
+
+        m_faultsPrCellAcc->setFaultIdx( c1, face, faultIdx );
+        m_faultsPrCellAcc->setFaultIdx( c2, StructGridInterface::oppositeFace( face ), faultIdx );
+
+        RigFault::FaultFace ff( c1, face, c2 );
+        if ( isC1Active && isC2Active )
+        {
+            unNamedFaultFaces.push_back( ff );
+        }
+        else
+        {
+            unNamedFaultFacesInactive.push_back( ff );
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -637,6 +695,23 @@ void RigMainGrid::distributeNNCsToFaults()
 {
     if ( m_faultsPrCellAcc.isNull() ) return;
 
+    // Resolve the unnamed fault indices once, so any NNC with a resolved face direction that is
+    // not already covered by an existing fault can be added to them. This catches NNCs synthesized
+    // by computeAdditionalNncs that ran after RigMainGrid::calculateFaults.
+    int unNamedFaultIdx             = RigFaultsPrCellAccumulator::NO_FAULT;
+    int unNamedFaultWithInactiveIdx = RigFaultsPrCellAccumulator::NO_FAULT;
+    for ( size_t i = 0; i < m_faults.size(); ++i )
+    {
+        if ( m_faults[i]->name() == RiaResultNames::undefinedGridFaultName() )
+        {
+            unNamedFaultIdx = static_cast<int>( i );
+        }
+        else if ( m_faults[i]->name() == RiaResultNames::undefinedGridFaultWithInactiveName() )
+        {
+            unNamedFaultWithInactiveIdx = static_cast<int>( i );
+        }
+    }
+
     const RigConnectionContainer& nncs = nncData()->allConnections();
     for ( size_t nncIdx = 0; nncIdx < nncs.size(); ++nncIdx )
     {
@@ -651,16 +726,40 @@ void RigMainGrid::distributeNNCsToFaults()
             fIdx2 = m_faultsPrCellAcc->faultIdx( conn.c2GlobIdx(), StructGridInterface::oppositeFace( conn.face() ) );
         }
 
-        if ( fIdx1 < 0 && fIdx2 < 0 )
+        // If the NNC describes a face that is not covered by an existing fault on either side,
+        // synthesize a fault face on the appropriate unnamed fault. We also cover the asymmetric
+        // case where one side has a fault on the opposite direction but the other side does not
+        // (common at LGR boundaries, where the NNC asserts a fault face distinct from the
+        // geometric pair already detected).
+        if ( conn.face() != StructGridInterface::NO_FACE && ( fIdx1 < 0 || fIdx2 < 0 ) && unNamedFaultIdx >= 0 &&
+             unNamedFaultWithInactiveIdx >= 0 )
         {
-            cvf::String lgrString( "Same Grid" );
-            if ( cell( conn.c1GlobIdx() ).hostGrid() != cell( conn.c2GlobIdx() ).hostGrid() )
-            {
-                lgrString = "Different Grid";
-            }
+            const size_t c1 = conn.c1GlobIdx();
+            const size_t c2 = conn.c2GlobIdx();
 
-            // cvf::Trace::show("NNC: No Fault for NNC C1: " + cvf::String((int)conn.m_c1GlobIdx) + " C2: " +
-            // cvf::String((int)conn.m_c2GlobIdx) + " Grid: " + lgrString);
+            if ( !cell( c1 ).isInvalid() && !cell( c2 ).isInvalid() )
+            {
+                const bool sameHostGrid = cell( c1 ).hostGrid() == cell( c2 ).hostGrid();
+
+                // Connections that cross grids (LGR boundaries) are pushed to the
+                // "with inactive" fault, mirroring how the geometric pass treats them.
+                const int targetFaultIdx = sameHostGrid ? unNamedFaultIdx : unNamedFaultWithInactiveIdx;
+
+                // Only update the accumulator for sides that are not already assigned, so we do not
+                // overwrite an existing fault assignment with this one.
+                if ( fIdx1 < 0 )
+                {
+                    m_faultsPrCellAcc->setFaultIdx( c1, conn.face(), targetFaultIdx );
+                    fIdx1 = targetFaultIdx;
+                }
+                if ( fIdx2 < 0 )
+                {
+                    m_faultsPrCellAcc->setFaultIdx( c2, StructGridInterface::oppositeFace( conn.face() ), targetFaultIdx );
+                    fIdx2 = targetFaultIdx;
+                }
+
+                m_faults[targetFaultIdx]->faultFaces().push_back( RigFault::FaultFace( c1, conn.face(), c2 ) );
+            }
         }
 
         if ( fIdx1 >= 0 )

--- a/ApplicationLibCode/ReservoirDataModel/RigMainGrid.h
+++ b/ApplicationLibCode/ReservoirDataModel/RigMainGrid.h
@@ -139,6 +139,12 @@ private:
     bool hasFaultWithName( const QString& name ) const;
     void computeBoundingBox();
 
+    void addFaultFacesFromNNCs( const RigActiveCellInfo* activeCellInfo,
+                                RigFault*                unNamedFault,
+                                int                      unNamedFaultIdx,
+                                RigFault*                unNamedFaultWithInactive,
+                                int                      unNamedFaultWithInactiveIdx );
+
     static std::array<double, 6> defaultMapAxes();
 
     void doBuildCellSearchTree( std::string* aabbTreeInfo = nullptr ) const;

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RifEclipseInputFileTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifOpmFlowDeckFile-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifReaderEclipseOutput-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RigDrogonHistNestedFault-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifReaderEclipseSummary-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigActiveCellInfo-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigEclipseCaseDataTools-Test.cpp

--- a/ApplicationLibCode/UnitTests/RigDrogonHistNestedFault-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigDrogonHistNestedFault-Test.cpp
@@ -1,0 +1,117 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026-     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RigEclipseCaseData.h"
+#include "RigFault.h"
+#include "RigMainGrid.h"
+#include "RigNNCData.h"
+#include "RigNncConnection.h"
+#include "RimEclipseResultCase.h"
+
+#include "cvfCollection.h"
+#include "cvfStructGrid.h"
+
+#include <QDebug>
+#include <QFile>
+
+#include <memory>
+
+//--------------------------------------------------------------------------------------------------
+/// Import the DROGON_HIST_NESTED hybrid-grid case and verify that the in-product fault detection
+/// (which is augmented with NNC connections inside RigMainGrid::calculateFaults) maps every NNC
+/// connection with a resolved face direction to an existing fault face.
+///
+/// Test is DISABLED by default because it depends on a local model file that is not part of the
+/// shared TestModels directory. Enable manually via --gtest_filter when the file is available.
+//--------------------------------------------------------------------------------------------------
+TEST( RigDrogonHistNestedFaultTest, DISABLED_AddFaultFacesFromNNCs )
+{
+    const QString filePath( "f:/Models/equinor_azure/hybrid grid/DROGON_HIST_NESTED.EGRID" );
+    ASSERT_TRUE( QFile::exists( filePath ) ) << "Test model not found: " << filePath.toStdString();
+
+    std::unique_ptr<RimEclipseResultCase> resultCase( new RimEclipseResultCase );
+    resultCase->setGridFileName( filePath );
+    ASSERT_TRUE( resultCase->importGridAndResultMetaData( false ) );
+
+    RigEclipseCaseData* caseData = resultCase->eclipseCaseData();
+    ASSERT_TRUE( caseData != nullptr );
+
+    RigMainGrid* mainGrid = caseData->mainGrid();
+    ASSERT_TRUE( mainGrid != nullptr );
+
+    // Importing the case triggers fault detection. Verify that at least one fault face was
+    // detected across all faults (named or auto-generated). The auto-generated faults are also
+    // augmented with NNC-derived faces inside RigMainGrid::calculateFaults.
+    const size_t faultCount = mainGrid->faults().size();
+    EXPECT_GT( faultCount, 0u );
+
+    size_t totalFaultFaces = 0;
+    for ( size_t i = 0; i < faultCount; ++i )
+    {
+        const RigFault* fault = mainGrid->faults().at( i );
+        totalFaultFaces += fault->faultFaces().size();
+        qDebug() << "Fault" << static_cast<int>( i ) << ":" << fault->name() << "-"
+                 << static_cast<int>( fault->faultFaces().size() ) << "faces";
+    }
+    EXPECT_GT( totalFaultFaces, 0u );
+
+    // Make sure NNC data is computed and available
+    ASSERT_TRUE( resultCase->ensureNncDataIsComputed() );
+
+    RigNNCData* nncData = mainGrid->nncData();
+    ASSERT_TRUE( nncData != nullptr );
+
+    const RigConnectionContainer& nncs = nncData->allConnections();
+    qDebug() << "Total NNC connections:" << static_cast<int>( nncs.size() );
+
+    // Every NNC connection with a resolved face direction should now map to an existing fault
+    // face, because calculateFaults adds any missing NNC face to the unnamed fault collections.
+    size_t nncWithFace             = 0;
+    size_t nncWithoutFace          = 0;
+    size_t nncWithoutExistingFault = 0;
+    for ( size_t i = 0; i < nncs.size(); ++i )
+    {
+        const RigConnection& conn = nncs[i];
+        if ( conn.face() == cvf::StructGridInterface::NO_FACE )
+        {
+            ++nncWithoutFace;
+            continue;
+        }
+
+        ++nncWithFace;
+
+        const RigFault* existingFault = mainGrid->findFaultFromCellIndexAndCellFace( conn.c1GlobIdx(), conn.face() );
+        if ( !existingFault )
+        {
+            ++nncWithoutExistingFault;
+        }
+    }
+
+    qDebug() << "NNCs with resolved face direction:" << static_cast<int>( nncWithFace );
+    qDebug() << "NNCs without resolved face direction:" << static_cast<int>( nncWithoutFace );
+    qDebug() << "NNCs that did not map to an existing fault face:" << static_cast<int>( nncWithoutExistingFault );
+
+    EXPECT_GT( nncWithFace, 0u );
+
+    // calculateFaults covers eclipse-read NNCs; distributeNNCsToFaults covers NNCs synthesized
+    // later by computeAdditionalNncs. Together they should leave no NNC with a resolved face
+    // direction unmapped to a fault.
+    EXPECT_EQ( nncWithoutExistingFault, 0u );
+}

--- a/ApplicationLibCode/UnitTests/RigDrogonHistNestedFault-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RigDrogonHistNestedFault-Test.cpp
@@ -67,8 +67,8 @@ TEST( RigDrogonHistNestedFaultTest, DISABLED_AddFaultFacesFromNNCs )
     {
         const RigFault* fault = mainGrid->faults().at( i );
         totalFaultFaces += fault->faultFaces().size();
-        qDebug() << "Fault" << static_cast<int>( i ) << ":" << fault->name() << "-"
-                 << static_cast<int>( fault->faultFaces().size() ) << "faces";
+        qDebug() << "Fault" << static_cast<int>( i ) << ":" << fault->name() << "-" << static_cast<int>( fault->faultFaces().size() )
+                 << "faces";
     }
     EXPECT_GT( totalFaultFaces, 0u );
 


### PR DESCRIPTION
## Summary

- `RigMainGrid::calculateFaults` now augments geometric fault detection with eclipse-read NNCs that have a resolved face direction. It triggers `buildPolygonsForEclipseConnections` so faces are available at fault-detection time, then appends a fault face to the appropriate unnamed fault for every NNC face not already covered.
- `RigMainGrid::distributeNNCsToFaults` covers the rest: NNCs synthesized later by `computeAdditionalNncs`, and the asymmetric case where one side of the NNC face is already part of a fault but the other side is not (typical at LGR boundaries). Pre-existing fault assignments in the accumulator are preserved.
- Adds a DISABLED unit test (depends on a local model) that imports `DROGON_HIST_NESTED.EGRID` and verifies every NNC with a resolved face direction now maps to an existing fault face.

Related issue: https://github.com/OPM/ResInsight/issues/14003