### PR TITLE
Grid ensemble GUI cleanup: import/export menus, icons, well-target-mapping guard

### DIFF
--- a/ApplicationExeCode/Resources/ResInsight.qrc
+++ b/ApplicationExeCode/Resources/ResInsight.qrc
@@ -296,6 +296,8 @@
         <file>Cloud.svg</file>
         <file>CloudBlobs.svg</file>
         <file>arrow-swap.svg</file>
+        <file>export.svg</file>
+        <file>import.svg</file>
         <file>inspect.svg</file>
         <file>pin.svg</file>
 		<file>Play.svg</file>

--- a/ApplicationExeCode/Resources/export.svg
+++ b/ApplicationExeCode/Resources/export.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M8 1L4 5l.707.707L7 3.414V11h2V3.414l2.293 2.293L12 5 8 1zM2 13h12v2H2v-2z" style="fill: rgb(128, 128, 128);"/></svg>

--- a/ApplicationExeCode/Resources/import.svg
+++ b/ApplicationExeCode/Resources/import.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7 1v7.586L4.707 6.293 4 7l4 4 4-4-.707-.707L9 8.586V1H7zM2 13h12v2H2v-2z" style="fill: rgb(128, 128, 128);"/></svg>

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicCellFilterFeatureTools.h
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicCellFilterFeatureTools.h
@@ -22,9 +22,11 @@
 
 #include "Rim3dView.h"
 #include "RimCase.h"
+#include "RimCellFilter.h"
 #include "RimCellFilterCollection.h"
 #include "RimCombinedFilter.h"
 #include "RimDataFilterCollection.h"
+#include "RimEclipseView.h"
 #include "RimFilterInViewCollection.h"
 #include "RimGridView.h"
 
@@ -42,6 +44,26 @@
 namespace RicCellFilterFeatureTools
 {
 //--------------------------------------------------------------------------------------------------
+/// After creating a new cell filter: select it in the tree, and refresh the per-view filter facade
+/// so the new entry appears immediately. The facade lives on RimEclipseView only, so the refresh
+/// is a no-op for filters created outside an eclipse view (e.g. case-level data filter collection).
+//--------------------------------------------------------------------------------------------------
+inline void selectAndRefreshFilterTree( RimCellFilter* filter )
+{
+    if ( !filter ) return;
+
+    Riu3DMainWindowTools::selectAsCurrentItem( filter );
+
+    if ( auto* eclipseView = filter->firstAncestorOrThisOfType<RimEclipseView>() )
+    {
+        if ( auto* facade = eclipseView->filterInViewCollection() )
+        {
+            facade->updateConnectedEditors();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 /// If a RimCombinedFilter is the current selection, create a new T inside it (configured via init)
 /// and select the result. Returns true when a combined filter was the selection — the caller should
 /// bail out of its own collection-targeted flow.
@@ -57,7 +79,7 @@ bool addNewFilterIfCombinedSelected( Init&& init )
     // need a Rim3dView ancestor here.
     RimCombinedFilter* target  = combined.front();
     T*                 created = target->addNewFilter<T>( std::forward<Init>( init ) );
-    if ( created ) Riu3DMainWindowTools::selectAsCurrentItem( created );
+    selectAndRefreshFilterTree( created );
     return true;
 }
 
@@ -100,7 +122,7 @@ bool addNewFilterToDataCollectionIfSelected( Init&& init )
     auto* created = new T();
     target->addFilter( created );
     std::forward<Init>( init )( created );
-    Riu3DMainWindowTools::selectAsCurrentItem( created );
+    selectAndRefreshFilterTree( created );
     return true;
 }
 } // namespace RicCellFilterFeatureTools

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewCellIndexFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewCellIndexFilterFeature.cpp
@@ -64,10 +64,7 @@ void RicNewCellIndexFilterFeature::onActionTriggered( bool isChecked )
     if ( RimCase* sourceCase = filtColl->firstAncestorOrThisOfTypeAsserted<Rim3dView>()->ownerCase() )
     {
         RimCellIndexFilter* lastCreatedOrUpdated = filtColl->addNewCellIndexFilter( sourceCase );
-        if ( lastCreatedOrUpdated )
-        {
-            Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-        }
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
     }
 }
 

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilter3dviewFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilter3dviewFeature.cpp
@@ -18,6 +18,8 @@
 
 #include "RicNewPolygonFilter3dviewFeature.h"
 
+#include "RicCellFilterFeatureTools.h"
+
 #include "Polygons/RimPolygonInView.h"
 
 #include "RiaApplication.h"
@@ -49,10 +51,7 @@ void RicNewPolygonFilter3dviewFeature::onActionTriggered( bool isChecked )
     RimCase* sourceCase = viewOrComparisonView->ownerCase();
 
     RimPolygonFilter* lastCreatedOrUpdated = filtColl->addNewPolygonFilter( sourceCase, nullptr );
-    if ( lastCreatedOrUpdated )
-    {
-        Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-    }
+    RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
@@ -100,7 +100,7 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
         {
             lastItem = addOne( polygon );
         }
-        if ( lastItem ) Riu3DMainWindowTools::selectAsCurrentItem( lastItem );
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastItem );
         return;
     }
 
@@ -117,7 +117,7 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
             configurePolygonFilter( f, polygon );
             lastItem = f;
         }
-        if ( lastItem ) Riu3DMainWindowTools::selectAsCurrentItem( lastItem );
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastItem );
         return;
     }
 
@@ -141,10 +141,7 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
         }
     }
 
-    if ( lastItem )
-    {
-        Riu3DMainWindowTools::selectAsCurrentItem( lastItem );
-    }
+    RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastItem );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSlice3dviewFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSlice3dviewFeature.cpp
@@ -18,6 +18,8 @@
 
 #include "RicNewRangeFilterSlice3dviewFeature.h"
 
+#include "RicCellFilterFeatureTools.h"
+
 #include "RiaApplication.h"
 
 #include "RigMainGrid.h"
@@ -101,7 +103,7 @@ void RicNewRangeFilterSlice3dviewFeature::onActionTriggered( bool isChecked )
     RimCellFilter* newFilter = filtColl->addNewCellRangeFilter( sourceCase, gridIndex, direction, sliceStart );
     if ( newFilter )
     {
-        Riu3DMainWindowTools::selectAsCurrentItem( newFilter );
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( newFilter );
         activeView->setSurfaceDrawstyle();
     }
 }

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSliceFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewRangeFilterSliceFeature.cpp
@@ -73,10 +73,7 @@ void RicNewRangeFilterSliceFeature::onActionTriggered( bool isChecked )
     {
         int            gridIndex            = 0;
         RimCellFilter* lastCreatedOrUpdated = filterCollection->addNewCellRangeFilter( sourceCase, gridIndex, m_sliceDirection );
-        if ( lastCreatedOrUpdated )
-        {
-            Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-        }
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
     }
 }
 

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedFilterFeature.cpp
@@ -51,10 +51,7 @@ void RicNewUserDefinedFilterFeature::onActionTriggered( bool isChecked )
     if ( sourceCase )
     {
         RimUserDefinedFilter* lastCreatedOrUpdated = filtColl->addNewUserDefinedFilter( sourceCase );
-        if ( lastCreatedOrUpdated )
-        {
-            Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-        }
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
     }
 }
 

--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedIndexFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewUserDefinedIndexFilterFeature.cpp
@@ -53,10 +53,7 @@ void RicNewUserDefinedIndexFilterFeature::onActionTriggered( bool isChecked )
     if ( sourceCase )
     {
         auto* lastCreatedOrUpdated = filtColl->addNewUserDefinedIndexFilter( sourceCase );
-        if ( lastCreatedOrUpdated )
-        {
-            Riu3DMainWindowTools::selectAsCurrentItem( lastCreatedOrUpdated );
-        }
+        RicCellFilterFeatureTools::selectAndRefreshFilterTree( lastCreatedOrUpdated );
     }
 }
 

--- a/ApplicationLibCode/Commands/EclipseCommands/RicEclipseCaseNewGroupFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicEclipseCaseNewGroupFeature.cpp
@@ -56,5 +56,6 @@ void RicEclipseCaseNewGroupFeature::onActionTriggered( bool isChecked )
 //--------------------------------------------------------------------------------------------------
 void RicEclipseCaseNewGroupFeature::setupActionLook( QAction* actionToSetup )
 {
+    actionToSetup->setIcon( QIcon( ":/CreateGridCaseGroup16x16.png" ) );
     actionToSetup->setText( "New Grid Case Group" );
 }

--- a/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicImportEclipseCaseFeature.cpp
@@ -252,5 +252,5 @@ QStringList RicImportEclipseCaseFeature::findPvdFilesToImport( const QStringList
 void RicImportEclipseCaseFeature::setupActionLook( QAction* actionToSetup )
 {
     actionToSetup->setIcon( QIcon( ":/Case.svg" ) );
-    actionToSetup->setText( "Import Eclipse Case" );
+    actionToSetup->setText( "Import Simulation Grid" );
 }

--- a/ApplicationLibCode/Commands/EclipseCommands/RicNewStatisticsCaseFeature.cpp
+++ b/ApplicationLibCode/Commands/EclipseCommands/RicNewStatisticsCaseFeature.cpp
@@ -64,6 +64,7 @@ void RicNewStatisticsCaseFeature::onActionTriggered( bool isChecked )
 void RicNewStatisticsCaseFeature::setupActionLook( QAction* actionToSetup )
 {
     actionToSetup->setText( "New Statistics Case" );
+    actionToSetup->setIcon( QIcon( ":/Histogram16x16.png" ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/OperationsUsingObjReferences/RicPasteCellFiltersFeature.cpp
+++ b/ApplicationLibCode/Commands/OperationsUsingObjReferences/RicPasteCellFiltersFeature.cpp
@@ -24,7 +24,10 @@
 #include "RimCase.h"
 #include "RimCellFilter.h"
 #include "RimCellFilterCollection.h"
+#include "RimEclipseView.h"
 #include "RimFilterInViewCollection.h"
+
+#include "Riu3DMainWindowTools.h"
 
 #include "cafPdmObjectGroup.h"
 #include "cafPdmPointer.h"
@@ -74,12 +77,23 @@ void RicPasteCellFiltersFeature::onActionTriggered( bool isChecked )
     caf::PdmObjectGroup objectGroup;
     RicPasteFeatureImpl::findObjectsFromClipboardRefs( &objectGroup );
 
+    RimCellFilter* lastPasted = nullptr;
     for ( auto obj : objectGroup.objects )
     {
         auto duplicatedObject = obj->copyObject<RimCellFilter>();
         if ( duplicatedObject )
         {
             cellFilterCollection->addFilterAndNotifyChanges( duplicatedObject, eclipseCase );
+            lastPasted = duplicatedObject;
+        }
+    }
+
+    if ( lastPasted )
+    {
+        Riu3DMainWindowTools::selectAsCurrentItem( lastPasted );
+        if ( auto* eclipseView = lastPasted->firstAncestorOrThisOfType<RimEclipseView>() )
+        {
+            if ( auto* facade = eclipseView->filterInViewCollection() ) facade->updateConnectedEditors();
         }
     }
 }

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleFeature.cpp
@@ -236,5 +236,5 @@ void RicImportGridAndSummaryEnsembleFeature::onActionTriggered( bool isChecked )
 void RicImportGridAndSummaryEnsembleFeature::setupActionLook( QAction* actionToSetup )
 {
     actionToSetup->setIcon( QIcon( ":/GridAndSummaryEnsemble.svg" ) );
-    actionToSetup->setText( "Grid and Summary Ensemble" );
+    actionToSetup->setText( "Import Grid and Summary Ensemble" );
 }

--- a/ApplicationLibCode/Commands/RicNewWellTargetMappingFeature.cpp
+++ b/ApplicationLibCode/Commands/RicNewWellTargetMappingFeature.cpp
@@ -34,6 +34,27 @@ CAF_CMD_SOURCE_INIT( RicNewWellTargetMappingFeature, "RicNewWellTargetMappingFea
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RicNewWellTargetMappingFeature::isCommandEnabled() const
+{
+    if ( auto gridEnsembles = caf::selectedObjectsByTypeStrict<RimReservoirGridEnsemble*>(); !gridEnsembles.empty() )
+    {
+        // Computation of well target mappings for individual grids is implemented in RimWellTargetMapping::generateEnsembleStatistics().
+        //
+        // If there is a future need to support well target mappings for ensembles with individual grids, the implementation in
+        // RimWellTargetMapping::generateEnsembleStatistics() will need to be updated, and this check can be removed.
+        //
+        // The main performance reason is the memory consumption of loading all grids in the ensemble into memory at the same time, which is
+        // currently needed in order to compute the well target mapping for ensembles with individual grids. For ensembles with shared grid,
+        // only the shared grid needs to be loaded, which is much more memory efficient.
+
+        return false;
+    }
+    return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RicNewWellTargetMappingFeature::onActionTriggered( bool isChecked )
 {
     if ( auto ensembles = caf::selectedObjectsByTypeStrict<RimEclipseCaseEnsemble*>(); !ensembles.empty() )

--- a/ApplicationLibCode/Commands/RicNewWellTargetMappingFeature.h
+++ b/ApplicationLibCode/Commands/RicNewWellTargetMappingFeature.h
@@ -28,6 +28,7 @@ class RicNewWellTargetMappingFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 private:
+    bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;
 };

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.cpp
@@ -127,7 +127,6 @@
 #include "RimSummaryAddress.h"
 #include "RimSummaryAddressCollection.h"
 #include "RimSummaryCase.h"
-#include "RimSummaryCaseMainCollection.h"
 #include "RimSummaryCurve.h"
 #include "RimSummaryCurveCollection.h"
 #include "RimSummaryMultiPlot.h"
@@ -758,19 +757,6 @@ caf::CmdFeatureMenuBuilder RimContextCommandBuilder::commandsFromSelection()
         else if ( dynamic_cast<RimEnsembleCurveFilterCollection*>( firstUiItem ) )
         {
             menuBuilder << "RicNewEnsembleCurveFilterFeature";
-        }
-        else if ( dynamic_cast<RimSummaryCaseMainCollection*>( firstUiItem ) )
-        {
-            menuBuilder << "RicImportSummaryCaseFeature";
-            menuBuilder << "RicImportRevealSummaryCaseFeature";
-            menuBuilder << "RicImportStimPlanSummaryCaseFeature";
-            menuBuilder << "RicImportSummaryCasesFeature";
-            menuBuilder << "RicImportSummaryGroupFeature";
-            menuBuilder << "RicImportEnsembleFeature";
-            menuBuilder << "RicNewDerivedEnsembleFeature";
-            menuBuilder << "RicNewDerivedSummaryFeature";
-            menuBuilder << "Separator";
-            menuBuilder << "RicShowSummaryCurveCalculatorFeature";
         }
         else if ( dynamic_cast<RimWellLogChannel*>( firstUiItem ) )
         {

--- a/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.h
+++ b/ApplicationLibCode/ProjectDataModel/RimContextCommandBuilder.h
@@ -49,7 +49,6 @@ private:
     static void                      createExecuteScriptForCasesFeatureMenu( caf::CmdFeatureMenuBuilder& menuBuilder );
 
     static void appendScriptItems( caf::CmdFeatureMenuBuilder& menuBuilder, RimScriptCollection* scriptCollection );
-    static void appendPlotTemplateItems( caf::CmdFeatureMenuBuilder& menuBuilder, RimPlotTemplateFolderItem* plotTemplateRoot );
 
     static int appendImportMenu( caf::CmdFeatureMenuBuilder& menuBuilder, bool addSeparatorBeforeMenu = false, bool addOsduMenuItem = false );
     static int appendCreateCompletions( caf::CmdFeatureMenuBuilder& menuBuilder, bool addSeparatorBeforeMenu = false );

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseCaseCollection.cpp
@@ -121,10 +121,13 @@ void RimEclipseCaseCollection::removeCaseFromAllGroups( RimEclipseCase* reservoi
 //--------------------------------------------------------------------------------------------------
 void RimEclipseCaseCollection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
 {
-    menuBuilder.subMenuStart( "Import" );
+    menuBuilder << "RicImportEclipseCaseFeature";
+    menuBuilder << "RicImportGridAndSummaryEnsembleFeature";
+    menuBuilder << "Separator";
+
+    menuBuilder.subMenuStart( "Other Grid Models", QIcon( ":/Case.svg" ) );
     menuBuilder << importMenuFeatureNames();
     menuBuilder.subMenuEnd();
-    menuBuilder << "RicEclipseCaseNewGroupFeature";
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -197,11 +200,13 @@ void RimEclipseCaseCollection::recomputeStatisticsForAllCaseGroups()
 //--------------------------------------------------------------------------------------------------
 QStringList RimEclipseCaseCollection::importMenuFeatureNames()
 {
-    return { "RicImportEclipseCaseFeature",
-             "RicImportEclipseCasesFeature",
+    return { "RicImportEclipseCasesFeature",
              "RicImportEclipseCaseTimeStepFilterFeature",
+             "Separator",
              "RicImportInputEclipseCaseFeature",
+             "RicImportRoffCaseFeature",
              "Separator",
              "RicCreateGridCaseGroupFromFilesFeature",
-             "RicCreateGridCaseEnsemblesFromFilesFeature" };
+             "RicCreateGridCaseEnsemblesFromFilesFeature",
+             "RicEclipseCaseNewGroupFeature" };
 }

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.cpp
@@ -2364,6 +2364,14 @@ RimDataFilterInViewCollection* RimEclipseView::dataFiltersInView() const
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+RimFilterInViewCollection* RimEclipseView::filterInViewCollection() const
+{
+    return m_filterInViewCollection();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 bool RimEclipseView::hasActivePropertyOrDataFilters() const
 {
     if ( eclipsePropertyFilterCollection()->hasActiveFilters() ) return true;

--- a/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
+++ b/ApplicationLibCode/ProjectDataModel/RimEclipseView.h
@@ -130,6 +130,7 @@ public:
     void                                      setOverridePropertyFilterCollection( RimEclipsePropertyFilterCollection* pfc );
 
     RimDataFilterInViewCollection* dataFiltersInView() const;
+    RimFilterInViewCollection*     filterInViewCollection() const;
 
     bool hasActivePropertyOrDataFilters() const;
     bool hasActiveDynamicPropertyOrDataFilters() const;

--- a/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimWellTargetMapping.cpp
@@ -41,6 +41,7 @@
 #include "RimEclipsePropertyFilterCollection.h"
 #include "RimEclipseResultDefinition.h"
 #include "RimEclipseView.h"
+#include "RimFilterInViewCollection.h"
 #include "RimRegularGridCase.h"
 #include "RimReservoirGridEnsemble.h"
 #include "RimTools.h"
@@ -386,6 +387,8 @@ void RimWellTargetMapping::generateCandidates( RimEclipseCase* eclipseCase, bool
 //--------------------------------------------------------------------------------------------------
 void RimWellTargetMapping::generateEnsembleStatistics()
 {
+    // See RicNewWellTargetMappingFeature::isCommandEnabled() for comment on future support for ensembles with varying geometry.
+
     auto ensemble = firstAncestorOrThisOfType<RimEclipseCaseEnsemble>();
     if ( !ensemble ) return;
 
@@ -649,13 +652,11 @@ void RimWellTargetMapping::onGenerateButtonClicked()
     }
     else if ( hasGridEnsembleParent )
     {
-        // For RimReservoirGridEnsemble, generate for first case
-        // Full ensemble statistics support can be added later
-        if ( auto eclipseCase = firstCase() )
-        {
-            bool setTimeStepInView = true;
-            generateCandidates( eclipseCase, setTimeStepInView );
-        }
+        // For RimReservoirGridEnsemble implement two variants, shared grid and individual grids. Individual grids variant will require more
+        // work, and is not currently prioritized, so for now just show a warning if user tries to generate candidates for a
+        // RimReservoirGridEnsemble
+        //
+        // See RicNewWellTargetMappingFeature::isCommandEnabled() for comment on future support for ensembles with varying geometry.
     }
     else if ( auto eclipseCase = firstCase() )
     {
@@ -671,6 +672,7 @@ void RimWellTargetMapping::onGenerateButtonClicked()
             {
                 eclipseView->eclipsePropertyFilterCollection()->addFilterLinkedToCellResult();
                 eclipseView->eclipsePropertyFilterCollection()->updateConnectedEditors();
+                eclipseView->filterInViewCollection()->updateConnectedEditors();
             }
 
             if ( RiaGuiApplication::isRunning() || RiuMainWindow::instance() )

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.cpp
@@ -53,6 +53,7 @@
 #include "RimSummaryPlot.h"
 #include "RimWellRftPlot.h"
 
+#include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmFieldReorderCapability.h"
 #include "cafProgressInfo.h"
 
@@ -405,6 +406,31 @@ void RimSummaryCaseMainCollection::loadAllSummaryCaseData()
             sumCase->summaryReader()->createAddressesIfRequired();
         }
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSummaryCaseMainCollection::appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const
+{
+    menuBuilder << "RicImportSummaryCaseFeature";
+    menuBuilder << "RicImportGridAndSummaryEnsembleFeature";
+    menuBuilder << "RicImportEnsembleFeature";
+
+    menuBuilder << "Separator";
+
+    menuBuilder.subMenuStart( "Other Imports" );
+    menuBuilder << "RicImportRevealSummaryCaseFeature";
+    menuBuilder << "RicImportStimPlanSummaryCaseFeature";
+    menuBuilder << "RicImportSummaryCasesFeature";
+    menuBuilder << "RicImportSummaryGroupFeature";
+    menuBuilder.subMenuEnd();
+
+    menuBuilder << "Separator";
+    menuBuilder << "RicNewDerivedEnsembleFeature";
+    menuBuilder << "RicNewDerivedSummaryFeature";
+    menuBuilder << "Separator";
+    menuBuilder << "RicShowSummaryCurveCalculatorFeature";
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Summary/RimSummaryCaseMainCollection.h
@@ -81,6 +81,8 @@ public:
     void updateEnsembleNames();
 
 private:
+    void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
+
     void initAfterRead() override;
 
     static void loadSummaryCaseData( const std::vector<RimSummaryCase*>& summaryCases, bool extractStateFromFirstCase );

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -499,10 +499,10 @@ void RiuMainWindow::createMenus()
     fileMenu->addSeparator();
 
     // Import menu actions
-    RiuMenuBarBuildTools::addImportMenuWithActions( this, fileMenu );
+    RiuMenuBarBuildTools::addImportMenuForMainWindow( this, fileMenu );
 
     // Export menu actions
-    QMenu* exportMenu = fileMenu->addMenu( "&Export" );
+    QMenu* exportMenu = fileMenu->addMenu( QIcon( ":/export.svg" ), "&Export" );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToFileFeature" ) );
     exportMenu->addAction( m_snapshotAllViewsToFile );
     exportMenu->addAction( cmdFeatureMgr->action( "RicAdvancedSnapshotExportFeature" ) );

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.cpp
@@ -109,32 +109,23 @@ QMenu* RiuMenuBarBuildTools::createDefaultHelpMenu( QMenuBar* menuBar )
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RiuMenuBarBuildTools::addImportMenuWithActions( QObject* parent, QMenu* menu )
+void RiuMenuBarBuildTools::addImportMenuForMainWindow( QObject* parent, QMenu* menu )
 {
     caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
 
     if ( !parent || !menu || !cmdFeatureMgr ) return;
 
-    QMenu* importMenu = menu->addMenu( "&Import" );
+    QMenu* importMenu = menu->addMenu( QIcon( ":/import.svg" ), "&Import" );
 
-    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Eclipse Cases" );
-    caf::CmdFeatureMenuBuilder::appendToMenu( importEclipseMenu, RimEclipseCaseCollection::importMenuFeatureNames() );
-
-    QMenu* importRoffMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Roff Grid Models" );
-    importRoffMenu->addAction( cmdFeatureMgr->action( "RicImportRoffCaseFeature" ) );
-
-    importMenu->addSeparator();
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportEclipseCaseFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportGridAndSummaryEnsembleFeature" ) );
 
     importMenu->addSeparator();
-    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/SummaryCase.svg" ), "Summary Cases" );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCasesFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryGroupFeature" ) );
-    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleFeature" ) );
+    QMenu* importEclipseMenu = importMenu->addMenu( QIcon( ":/Case48x48.png" ), "Other Grid Models" );
+    caf::CmdFeatureMenuBuilder::appendToMenu( importEclipseMenu, RimEclipseCaseCollection::importMenuFeatureNames() );
 
     importMenu->addSeparator();
-    QMenu* importGeoMechMenu = importMenu->addMenu( QIcon( ":/GeoMechCase24x24.png" ), "Geo Mechanical Cases" );
+    QMenu* importGeoMechMenu = importMenu->addMenu( QIcon( ":/GeoMechCase24x24.png" ), "Geo Mechanical Models" );
     importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseFeature" ) );
     importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportGeoMechCaseTimeStepFilterFeature" ) );
     importGeoMechMenu->addAction( cmdFeatureMgr->action( "RicImportElementPropertyFeature" ) );
@@ -148,12 +139,37 @@ void RiuMenuBarBuildTools::addImportMenuWithActions( QObject* parent, QMenu* men
     importWellMenu->addAction( cmdFeatureMgr->action( "RicImportWellMeasurementsFeature" ) );
 
     importMenu->addSeparator();
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedFmuDataFeature" ) );
-    importMenu->addAction( cmdFeatureMgr->action( "RicImportPressureDepthDataFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportFormationNamesFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportSurfacesFeature" ) );
     importMenu->addAction( cmdFeatureMgr->action( "RicImportSeismicFeature" ) );
+
+    RiuTools::enableAllActionsOnShow( parent, importMenu );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiuMenuBarBuildTools::addImportMenuForPlotWindow( QObject* parent, QMenu* menu )
+{
+    caf::CmdFeatureManager* cmdFeatureMgr = caf::CmdFeatureManager::instance();
+
+    if ( !parent || !menu || !cmdFeatureMgr ) return;
+
+    QMenu* importMenu = menu->addMenu( QIcon( ":/import.svg" ), "&Import" );
+
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportGridAndSummaryEnsembleFeature" ) );
+
+    importMenu->addSeparator();
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCaseFeature" ) );
+    QMenu* importSummaryMenu = importMenu->addMenu( QIcon( ":/SummaryCase.svg" ), "Summary Cases" );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryCasesFeature" ) );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportSummaryGroupFeature" ) );
+    importSummaryMenu->addAction( cmdFeatureMgr->action( "RicImportEnsembleFeature" ) );
+
+    importMenu->addSeparator();
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedDataFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportObservedFmuDataFeature" ) );
+    importMenu->addAction( cmdFeatureMgr->action( "RicImportPressureDepthDataFeature" ) );
 
     RiuTools::enableAllActionsOnShow( parent, importMenu );
 }

--- a/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.h
+++ b/ApplicationLibCode/UserInterface/RiuMenuBarBuildTools.h
@@ -33,7 +33,8 @@ QMenu* createDefaultEditMenu( QMenuBar* menuBar );
 QMenu* createDefaultViewMenu( QMenuBar* menuBar );
 QMenu* createDefaultHelpMenu( QMenuBar* menuBar );
 
-void addImportMenuWithActions( QObject* parent, QMenu* menu );
+void addImportMenuForMainWindow( QObject* parent, QMenu* menu );
+void addImportMenuForPlotWindow( QObject* parent, QMenu* menu );
 void addSaveProjectActions( QMenu* menu );
 void addCloseAndExitActions( QMenu* menu );
 

--- a/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuPlotMainWindow.cpp
@@ -340,10 +340,10 @@ void RiuPlotMainWindow::createMenus()
     fileMenu->addSeparator();
 
     // Import menu actions
-    RiuMenuBarBuildTools::addImportMenuWithActions( this, fileMenu );
+    RiuMenuBarBuildTools::addImportMenuForPlotWindow( this, fileMenu );
 
     // Export menu actions
-    QMenu* exportMenu = fileMenu->addMenu( "&Export" );
+    QMenu* exportMenu = fileMenu->addMenu( QIcon( ":/export.svg" ), "&Export" );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToFileFeature" ) );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotViewToPdfFeature" ) );
     exportMenu->addAction( cmdFeatureMgr->action( "RicSnapshotAllPlotsToFileFeature" ) );

--- a/docs/agents/build.md
+++ b/docs/agents/build.md
@@ -91,6 +91,9 @@ cmake --build --preset x64-relwithdebinfo --target ResInsight
 cmake --build --preset x64-relwithdebinfo --target extract-projectfile-versions
 ```
 
+**Important — use `cmake --build`, not `ninja` directly, when sharing `build/` with Visual Studio:**
+Visual Studio's "Open Folder" CMake integration uses its own bundled ninja (under `Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe`) and writes that path into `CMAKE_MAKE_PROGRAM`. If a CLI shell has a different `ninja.exe` first on `PATH`, invoking `ninja` directly produces a `.ninja_log` whose format the other ninja can't read (`ninja: warning: build log version is too old; starting over`), so both VS and the CLI repeatedly rebuild everything from scratch. `cmake --build build` dispatches to `CMAKE_MAKE_PROGRAM`, guaranteeing the same ninja binary as VS. If a build unexpectedly rebuilds far more than expected, verify with `where ninja` and `grep CMAKE_MAKE_PROGRAM build/CMakeCache.txt`.
+
 ## Build Presets
 
 Available CMake presets in `CMakePresets.json`:


### PR DESCRIPTION
## Summary
- Disable "Create Well Target Mapping" for grid ensembles in INDIVIDUAL_GRIDS mode; cross-referenced with RimWellTargetMapping::generateEnsembleStatistics so the future-support path is documented in both places.
- Refresh the filters-in-view facade on RimEclipseView after adding a property filter from the Well Target Mapping flow.
- Reorganize Eclipse case + summary imports: split addImportMenuWithActions into per-window variants, promote common entries to top-level, group the rest under submenus ("Other Grid Models", "Geo Mechanical Models"), and rename the Eclipse case import action to "Import Simulation Grid".
- Move the RimSummaryCaseMainCollection context-menu block out of RimContextCommandBuilder and into a proper appendMenuItems override.
- Add icons to "New Statistics Case", "New Grid Case Group", and the top-level "Import" / "Export" menus (new import.svg / export.svg using the project's standard mid-grey to remain readable on both light and dark backgrounds).
- Drop an unused appendPlotTemplateItems declaration from RimContextCommandBuilder.
- Agent docs: recommend `cmake --build build` over `ninja` directly when sharing the build/ directory with Visual Studio, to avoid full rebuilds caused by ninja-binary mismatch.