### PR TITLE
#14069 Indicate grid ensembles with individual grids via info tag and tooltip

### DIFF
--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
@@ -46,8 +46,10 @@
 #include "RimWellTargetMapping.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
+#include "cafIconProvider.h"
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmObjectScriptingCapability.h"
+#include "cafPdmUiTreeAttributes.h"
 #include "cafProgressInfo.h"
 
 #include "RigCaseCellResultsData.h"
@@ -680,6 +682,7 @@ void RimReservoirGridEnsemble::fieldChangedByUi( const caf::PdmFieldHandle* chan
 {
     if ( changedField == &m_autoDetectGridType || changedField == &m_gridMode )
     {
+        updateGridModeToolTip();
         updateStatisticsVisibility();
         updateConnectedEditors();
     }
@@ -864,8 +867,35 @@ void RimReservoirGridEnsemble::loadGridDataFromFiles()
         // loadGridsInIndividualMode();
     }
 
+    updateGridModeToolTip();
     updateStatisticsVisibility();
     updateConnectedEditors();
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::updateGridModeToolTip()
+{
+    const bool individualGrids = ( gridMode() == GridModeType::INDIVIDUAL_GRIDS );
+
+    uiCapability()->setUiToolTip( individualGrids ? QString( "This ensemble has grids with varying number of K layers." ) : QString() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimReservoirGridEnsemble::defineObjectEditorAttribute( QString uiConfigName, caf::PdmUiEditorAttribute* attribute )
+{
+    if ( auto* treeItemAttribute = dynamic_cast<caf::PdmUiTreeViewItemAttribute*>( attribute ) )
+    {
+        if ( gridMode() == GridModeType::INDIVIDUAL_GRIDS )
+        {
+            auto tag  = caf::PdmUiTreeViewItemAttribute::createTag();
+            tag->icon = caf::IconProvider( ":/info.png" );
+            treeItemAttribute->tags.push_back( std::move( tag ) );
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.h
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.h
@@ -122,6 +122,7 @@ public:
 protected:
     void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
     void defineUiOrdering( QString uiConfigName, caf::PdmUiOrdering& uiOrdering ) override;
+    void defineObjectEditorAttribute( QString uiConfigName, caf::PdmUiEditorAttribute* attribute ) override;
     void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
     void createDerivedObjects() override;
     void initAfterRead() override;
@@ -139,6 +140,7 @@ private:
     bool detectGridDimensionEquality();
     void loadGridsInSharedMode();
     void loadGridsInIndividualMode();
+    void updateGridModeToolTip();
 
 private:
     // File set reference


### PR DESCRIPTION
Visual indicator for grid ensembles where the grids have varying dimensions (gridMode() == INDIVIDUAL_GRIDS). Adds an info-icon tree-view tag (same caf::PdmUiTreeViewItemAttribute::Tag mechanism used by RimSummaryCase's ensemble-statistics info icon) plus a tooltip on the ensemble explaining the indicator. The tag and tooltip are refreshed from updateGridModeToolTip(), called after grid detection in loadGridDataFromFiles() and when m_autoDetectGridType / m_gridMode change in fieldChangedByUi.