### PR TITLE
AppFwk: make PdmUiTreeOrdering::add null-tolerant and clean up containsField

### DIFF
--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiTreeOrdering.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmUiCore/cafPdmUiTreeOrdering.cpp
@@ -51,7 +51,7 @@ namespace caf
 //--------------------------------------------------------------------------------------------------
 void PdmUiTreeOrdering::add( PdmFieldHandle* field, QString uiConfigName )
 {
-    CAF_ASSERT( field );
+    if ( !field ) return;
 
     if ( field->uiCapability()->isUiTreeHidden( uiConfigName ) )
     {
@@ -75,7 +75,7 @@ void PdmUiTreeOrdering::add( PdmFieldHandle* field, QString uiConfigName )
 //--------------------------------------------------------------------------------------------------
 PdmUiTreeOrdering* PdmUiTreeOrdering::add( PdmObjectHandle* object )
 {
-    CAF_ASSERT( object );
+    if ( !object ) return nullptr;
 
     auto node = new PdmUiTreeOrdering( this, object );
 
@@ -102,7 +102,7 @@ bool PdmUiTreeOrdering::containsField( const PdmFieldHandle* field )
     CAF_ASSERT( field );
     for ( int cIdx = 0; cIdx < this->childCount(); ++cIdx )
     {
-        PdmUiTreeOrdering* child = dynamic_cast<PdmUiTreeOrdering*>( this->child( cIdx ) ); // What ???
+        PdmUiTreeOrdering* child = this->child( cIdx );
 
         if ( child->m_field == field )
         {


### PR DESCRIPTION
Framework cleanup for `caf::PdmUiTreeOrdering::add`, split out from the #14112 contour map fix.

## Null-tolerant `add`
Both pointer overloads previously called `CAF_ASSERT(...)` on their argument. `CAF_ASSERT` is unconditional — it calls `std::abort()` in every build configuration, not just debug — so passing a null field/object hard-aborts the application. Because adding an optional child to a tree is inherently an "add it if it exists" operation, every call site had to pre-guard against null.

This makes both overloads a no-op on null instead:

- `add(PdmFieldHandle*)` returns early.
- `add(PdmObjectHandle*)` returns `nullptr`.

This removes a class of latent release-build aborts and the need for repetitive null checks scattered across `defineUiTreeOrdering` implementations.

## `containsField` cleanup
Removed a redundant `dynamic_cast<PdmUiTreeOrdering*>` (and its `// What ???` comment) — `child()` already returns `PdmUiTreeOrdering*`, matching how the sibling `containsObject` is written.

Verified by building `cafPdmUiCore` and dependents.