### PR TITLE
#14149 Fix crash when loading a keyword from a truncated or corrupt file

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -86,7 +86,7 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Get Python executable path
         shell: bash

--- a/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
+++ b/ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp
@@ -1000,7 +1000,12 @@ bool RifReaderEclipseOutput::staticResult( const QString& result, RiaDefines::Po
         for ( i = 0; i < numOccurrences; i++ )
         {
             std::vector<double> partValues;
-            RifEclipseOutputFileTools::keywordData( m_ecl_init_file, result, i, &partValues );
+            if ( !RifEclipseOutputFileTools::keywordData( m_ecl_init_file, result, i, &partValues ) )
+            {
+                // Reading the keyword failed (e.g. a truncated or corrupt file). Signal failure to the
+                // caller instead of returning a partially populated result.
+                return false;
+            }
             fileValues.insert( fileValues.end(), partValues.begin(), partValues.end() );
         }
 

--- a/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp
+++ b/ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp
@@ -241,6 +241,12 @@ static void ecl_file_kw_load_kw( ecl_file_kw_type * file_kw , fortio_type * fort
   {
     fortio_fseek( fortio , file_kw->file_offset , SEEK_SET );
     file_kw->kw = ecl_kw_fread_alloc( fortio );
+    if (file_kw->kw == NULL)
+      /* Reading the keyword failed (e.g. a truncated or corrupt file, or a
+         stored file offset past the end of file). Leave file_kw->kw as NULL and
+         let the calling scope handle the missing keyword instead of
+         dereferencing a NULL pointer in ecl_file_kw_assert_kw(). */
+      return;
     ecl_file_kw_assert_kw( file_kw );
     inv_map_add_kw( inv_map , file_kw , file_kw->kw );
   }


### PR DESCRIPTION
## Summary

Fixes #14149 (`BugInRelease`). A linked-view cell-result update could crash with a SIGSEGV inside ERT while loading a static result from a damaged INIT file.

**Root cause:** `ecl_kw_fread_alloc` returns `NULL` when a keyword block cannot be read (truncated/corrupt file, or a stored file offset past EOF). `ecl_file_kw_load_kw` did not check for this and passed the `NULL` straight into `ecl_file_kw_assert_kw`, which dereferenced it in `ecl_kw_get_data_type` (`ecl_kw.cpp:1776`) → segfault caught by `manageSegFailureSA`.

## Changes

- **ERT layer** (`ThirdParty/Ert/lib/ecl/ecl_file_kw.cpp`): `ecl_file_kw_load_kw` now guards against the `NULL` keyword and returns early, leaving `file_kw->kw` as `NULL` for the caller to handle. The callers up the chain already tolerate a `NULL` keyword (`ecl_file_kw_get_kw` checks before bumping `ref_count`; `RifEclipseOutputFileTools::keywordData` guards with `if (kwData)`).
- **Client layer** (`ApplicationLibCode/FileInterface/RifReaderEclipseOutput.cpp`): `staticResult` now checks the `keywordData` return value and returns `false` on a failed load, so `findOrLoadKnownScalarResult` clears the result instead of building a silently truncated one.

## Note

This touches vendored third-party ERT code, so the ERT-layer fix is also a candidate for upstreaming to OPM/ert.
