### PR TITLE
#14182 Fix stack overflow when destroying deep AABB bounding box trees

### DIFF
--- a/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp
+++ b/Fwk/VizFwk/LibGeometry/cvfBoundingBoxTree.cpp
@@ -793,15 +793,29 @@ cvf::AABBTreeNodeLeaf* AABBTree::createOrAssignLeaf(size_t leafIndex, const std:
 void AABBTree::deleteInternalNodesBottomUp(AABBTreeNode* node)
 {
     // All leaf nodes (AABBTreeNodeLeaf) are allocated in m_leafPool and does not require a delete
-    if (node->type() == AB_LEAF) return;
+    if (!node || node->type() == AB_LEAF) return;
 
-    auto internalNode = dynamic_cast<AABBTreeNodeInternal*>(node);
-    CVF_ASSERT(internalNode);
+    // Use an explicit stack instead of recursion. The tree can become very unbalanced (height
+    // proportional to the leaf count rather than log2 of it), and recursing once per level would
+    // overflow the call stack when the tree is destroyed. Deleting an internal node does not touch
+    // its children, so the children pointers are read before the node is deleted and the order in
+    // which the internal nodes are deleted does not matter.
+    std::vector<AABBTreeNodeInternal*> pendingNodes;
+    pendingNodes.push_back(static_cast<AABBTreeNodeInternal*>(node));
 
-    AABBTree::deleteInternalNodesBottomUp(internalNode->left());
-    AABBTree::deleteInternalNodesBottomUp(internalNode->right());
+    while (!pendingNodes.empty())
+    {
+        AABBTreeNodeInternal* internalNode = pendingNodes.back();
+        pendingNodes.pop_back();
 
-    delete internalNode;
+        AABBTreeNode* left  = internalNode->left();
+        AABBTreeNode* right = internalNode->right();
+
+        if (left && left->type() == AB_INTERNAL) pendingNodes.push_back(static_cast<AABBTreeNodeInternal*>(left));
+        if (right && right->type() == AB_INTERNAL) pendingNodes.push_back(static_cast<AABBTreeNodeInternal*>(right));
+
+        delete internalNode;
+    }
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the stack overflow reported in OPM/ResInsight#14182.

## Problem

The crash is a stack overflow, triggered during project close:
`closeProject()` → `RigMainGrid::~RigMainGrid()` → `BoundingBoxTree` destruction → `AABBTree::deleteInternalNodesBottomUp`.

`deleteInternalNodesBottomUp` recursed once per tree level. The AABB tree is built with a geometric split and can become deep/unbalanced (height proportional to the leaf count rather than `log2(N)`), so the recursive teardown exhausted the call stack. Building does not hit this because the deep subtrees are split across OpenMP threads, whereas deletion runs the full tree height on a single thread.

## Fix

Replace the recursion in `deleteInternalNodesBottomUp` with an explicit stack. Deleting an internal node does not touch its children (children are freed explicitly, the destructor is trivial), so the child pointers are read before the node is deleted and the deletion order is irrelevant. Leaf nodes remain pooled in `m_leafPool` and are never deleted individually, exactly as before. A null guard was added.

## Test

Added `BoundingBoxTree.DeepTreeDestruction`, which builds a deep, degenerate tree from a large clustered input set and verifies it is built, queried and destroyed without crashing.

## Note

There is a vendored copy of this file under `ThirdParty/custom-opm-common/.../external/resinsight/LibGeometry/cvfBoundingBoxTree.cpp`. It is not the copy used by `RigMainGrid` and is synced from upstream opm-common, so it is left untouched here; the same fix should be applied upstream.