### PR TITLE
Fix crashes in command features

### DIFF
--- a/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
+++ b/ApplicationLibCode/Commands/CellFilterCommands/RicNewPolygonFilterFeature.cpp
@@ -104,8 +104,11 @@ void RicNewPolygonFilterFeature::onActionTriggered( bool isChecked )
         return;
     }
 
-    // If a case-level Data Filter Collection is selected, add polygon filters there.
-    auto* dataCollection = caf::SelectionManager::instance()->selectedItemOfType<RimDataFilterCollection>();
+    // If a case-level Data Filter Collection is the target, add polygon filters there. Resolve it the
+    // same way as every other cell filter feature, so that right clicking an Eclipse case creates the
+    // filter on the case rather than silently putting it in the active view's collection. The "Data
+    // Filters" node is hidden while empty, so the case node is what the user right clicks.
+    auto* dataCollection = RicCellFilterFeatureTools::selectedDataFilterCollection();
     if ( dataCollection )
     {
         if ( polygons.empty() ) polygons.push_back( nullptr );

--- a/ApplicationLibCode/Commands/CrossSectionCommands/RicAppendIntersectionFeature.cpp
+++ b/ApplicationLibCode/Commands/CrossSectionCommands/RicAppendIntersectionFeature.cpp
@@ -37,17 +37,32 @@ CAF_CMD_SOURCE_INIT( RicAppendIntersectionFeature, "RicAppendIntersectionFeature
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RicAppendIntersectionFeature::isCommandEnabled() const
+{
+    return selectedIntersectionCollection() != nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RicAppendIntersectionFeature::onActionTriggered( bool isChecked )
 {
-    const auto collection = caf::SelectionManager::instance()->objectsByType<caf::PdmObjectHandle>();
-    CVF_ASSERT( collection.size() == 1 );
-
-    RimIntersectionCollection* intersectionCollection = collection[0]->firstAncestorOrThisOfType<RimIntersectionCollection>();
-
-    CVF_ASSERT( intersectionCollection );
+    RimIntersectionCollection* intersectionCollection = selectedIntersectionCollection();
+    if ( !intersectionCollection ) return;
 
     RicAppendIntersectionFeatureCmd* cmd = new RicAppendIntersectionFeatureCmd( intersectionCollection );
     caf::CmdExecCommandManager::instance()->processExecuteCommand( cmd );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimIntersectionCollection* RicAppendIntersectionFeature::selectedIntersectionCollection()
+{
+    const auto collection = caf::SelectionManager::instance()->objectsByType<caf::PdmObjectHandle>();
+    if ( collection.size() != 1 ) return nullptr;
+
+    return collection[0]->firstAncestorOrThisOfType<RimIntersectionCollection>();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/CrossSectionCommands/RicAppendIntersectionFeature.h
+++ b/ApplicationLibCode/Commands/CrossSectionCommands/RicAppendIntersectionFeature.h
@@ -50,6 +50,10 @@ class RicAppendIntersectionFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
+    bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;
+
+private:
+    static RimIntersectionCollection* selectedIntersectionCollection();
 };

--- a/ApplicationLibCode/Commands/CrossSectionCommands/RicAppendSeparateIntersectionResultFeature.cpp
+++ b/ApplicationLibCode/Commands/CrossSectionCommands/RicAppendSeparateIntersectionResultFeature.cpp
@@ -35,18 +35,32 @@ CAF_CMD_SOURCE_INIT( RicAppendSeparateIntersectionResultFeature, "RicAppendSepar
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+bool RicAppendSeparateIntersectionResultFeature::isCommandEnabled() const
+{
+    return selectedIntersectionResultsDefinitionCollection() != nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RicAppendSeparateIntersectionResultFeature::onActionTriggered( bool isChecked )
 {
-    const auto collection = caf::SelectionManager::instance()->objectsByType<caf::PdmObjectHandle>();
-    CVF_ASSERT( collection.size() == 1 );
-
-    RimIntersectionResultsDefinitionCollection* intersectionResCollection =
-        collection[0]->firstAncestorOrThisOfType<RimIntersectionResultsDefinitionCollection>();
-
-    CVF_ASSERT( intersectionResCollection );
+    RimIntersectionResultsDefinitionCollection* intersectionResCollection = selectedIntersectionResultsDefinitionCollection();
+    if ( !intersectionResCollection ) return;
 
     RicAppendSeparateIntersectionResultFeatureCmd* cmd = new RicAppendSeparateIntersectionResultFeatureCmd( intersectionResCollection );
     caf::CmdExecCommandManager::instance()->processExecuteCommand( cmd );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RimIntersectionResultsDefinitionCollection* RicAppendSeparateIntersectionResultFeature::selectedIntersectionResultsDefinitionCollection()
+{
+    const auto collection = caf::SelectionManager::instance()->objectsByType<caf::PdmObjectHandle>();
+    if ( collection.size() != 1 ) return nullptr;
+
+    return collection[0]->firstAncestorOrThisOfType<RimIntersectionResultsDefinitionCollection>();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/CrossSectionCommands/RicAppendSeparateIntersectionResultFeature.h
+++ b/ApplicationLibCode/Commands/CrossSectionCommands/RicAppendSeparateIntersectionResultFeature.h
@@ -49,6 +49,10 @@ class RicAppendSeparateIntersectionResultFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 protected:
+    bool isCommandEnabled() const override;
     void onActionTriggered( bool isChecked ) override;
     void setupActionLook( QAction* actionToSetup ) override;
+
+private:
+    static RimIntersectionResultsDefinitionCollection* selectedIntersectionResultsDefinitionCollection();
 };

--- a/ApplicationLibCode/Commands/FractureCommands/RicConvertAllFractureTemplatesToFieldFeature.cpp
+++ b/ApplicationLibCode/Commands/FractureCommands/RicConvertAllFractureTemplatesToFieldFeature.cpp
@@ -50,6 +50,7 @@ CAF_CMD_SOURCE_INIT( RicConvertAllFractureTemplatesToFieldFeature, "RicConvertAl
 void RicConvertAllFractureTemplatesToFieldFeature::onActionTriggered( bool isChecked )
 {
     RimFractureTemplateCollection* fracTempColl = caf::firstAncestorOfTypeFromSelectedObject<RimFractureTemplateCollection>();
+    if ( !fracTempColl ) return;
 
     std::vector<RimEllipseFractureTemplate*> ellipseFracTemplates = fracTempColl->descendantsIncludingThisOfType<RimEllipseFractureTemplate>();
 

--- a/ApplicationLibCode/Commands/RicDeleteItemExec.cpp
+++ b/ApplicationLibCode/Commands/RicDeleteItemExec.cpp
@@ -62,12 +62,26 @@ void RicDeleteItemExec::redo()
             m_commandData.m_deletedObjectAsXml = xmlObj( obj )->writeObjectToXmlString();
         }
 
+        caf::PdmObjectHandle* parentObj = listField->ownerObject();
+
+        // Detach the object and refresh the editors before deleting it, so that nothing can reach it
+        // while its destructor runs.
+        //
+        // A destructor can re-enter the user interface. Deleting a 3D view removes its dock widget,
+        // the dock area then activates a sibling, and that selection change both repaints the project
+        // tree and rebuilds the property editor. The tree asks each of its nodes for a name, and the
+        // property editor walks project->allViews() to build the comparison view option list, which
+        // also asks every view for its name. The object being deleted has already lost its derived
+        // part by then, so producing its name calls a pure virtual function and aborts.
+        //
+        // erase() only detaches the object from the field, it does not delete it, so the object is
+        // still valid while the editors are refreshed. After the refresh no editor holds a node for
+        // it, and it is no longer reachable through the project.
+        listField->erase( m_commandData.m_indexToObject );
+        parentObj->uiCapability()->updateConnectedEditors();
+
         delete obj;
 
-        listField->erase( m_commandData.m_indexToObject );
-
-        caf::PdmObjectHandle* parentObj = listField->ownerObject();
-        parentObj->uiCapability()->updateConnectedEditors();
         parentObj->onChildDeleted( listField, referringObjects );
     }
 }

--- a/ApplicationLibCode/Commands/RicWellLogTools.cpp
+++ b/ApplicationLibCode/Commands/RicWellLogTools.cpp
@@ -204,7 +204,8 @@ ExtractionCurveType* RicWellLogTools::addExtractionCurve( RimWellLogTrack*      
 
     RiaDefines::DepthUnitType defaultDepthUnit = RiaDefines::DepthUnitType::UNIT_METER;
 
-    if ( auto eclipseCase = dynamic_cast<RimEclipseCase*>( caseToApply ) )
+    // A case can be part of the project without being opened, in which case it has no case data yet.
+    if ( auto eclipseCase = dynamic_cast<RimEclipseCase*>( caseToApply ); eclipseCase && eclipseCase->eclipseCaseData() )
     {
         defaultDepthUnit = RiaDefines::fromEclipseUnit( eclipseCase->eclipseCaseData()->unitsType() );
     }

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicClearSourceSteppingEnsembleCurveSetFeature.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicClearSourceSteppingEnsembleCurveSetFeature.cpp
@@ -42,7 +42,7 @@ bool RicClearSourceSteppingEnsembleCurveSetFeature::isCommandEnabled() const
     {
         auto c = objects[0];
 
-        auto summaryPlot = c->firstAncestorOrThisOfTypeAsserted<RimSummaryPlot>();
+        auto summaryPlot = c->firstAncestorOrThisOfType<RimSummaryPlot>();
         if ( summaryPlot )
         {
             if ( summaryPlot->ensembleCurveSetCollection()->curveSetForSourceStepping() ||

--- a/ApplicationLibCode/Commands/SummaryPlotCommands/RicClearSourceSteppingSummaryCurveFeature.cpp
+++ b/ApplicationLibCode/Commands/SummaryPlotCommands/RicClearSourceSteppingSummaryCurveFeature.cpp
@@ -42,7 +42,7 @@ bool RicClearSourceSteppingSummaryCurveFeature::isCommandEnabled() const
     {
         auto c = objects[0];
 
-        auto summaryPlot = c->firstAncestorOrThisOfTypeAsserted<RimSummaryPlot>();
+        auto summaryPlot = c->firstAncestorOrThisOfType<RimSummaryPlot>();
         if ( summaryPlot )
         {
             if ( summaryPlot->ensembleCurveSetCollection()->curveSetForSourceStepping() ||
@@ -66,7 +66,7 @@ void RicClearSourceSteppingSummaryCurveFeature::onActionTriggered( bool isChecke
     {
         auto c = summaryCurves[0];
 
-        auto summaryPlot = c->firstAncestorOrThisOfTypeAsserted<RimSummaryPlot>();
+        auto summaryPlot = c->firstAncestorOrThisOfType<RimSummaryPlot>();
         if ( summaryPlot )
         {
             RicClearSourceSteppingEnsembleCurveSetFeature::clearAllSourceSteppingInSummaryPlot( summaryPlot );

--- a/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/ContourMap/RimEclipseContourMapView.cpp
@@ -210,7 +210,7 @@ void RimEclipseContourMapView::onCreateDisplayModel()
         updateGeometry();
     }
 
-    if ( viewer()->mainCamera()->viewMatrix() == sm_defaultViewMatrix )
+    if ( viewer() && viewer()->mainCamera()->viewMatrix() == sm_defaultViewMatrix )
     {
         zoomAll();
     }
@@ -521,7 +521,7 @@ void RimEclipseContourMapView::fieldChangedByUi( const caf::PdmFieldHandle* chan
 
     if ( changedField == &m_showAxisLines )
     {
-        viewer()->showEdgeTickMarksXY( true, m_showAxisLines() );
+        if ( viewer() ) viewer()->showEdgeTickMarksXY( true, m_showAxisLines() );
         scheduleCreateDisplayModelAndRedraw();
     }
     else if ( changedField == backgroundColorField() )


### PR DESCRIPTION
Four crashes found by exercising the `Ric*Feature` command layer against a range of selections. Each one is small and independent of the others. Split out from the command feature test work so the fixes can be reviewed on their own.

## Clearing source stepping

`RicClearSourceSteppingSummaryCurveFeature` and `RicClearSourceSteppingEnsembleCurveSetFeature` resolved the summary plot with `firstAncestorOrThisOfTypeAsserted`, but picked the candidate object with `objectsByType<caf::PdmObject>`, which matches any object. Selecting a single object outside a summary plot therefore aborted while the enabled state was evaluated, for instance while building a context menu. The null check on the following line shows the non-asserting lookup was intended.

## Converting fracture templates

`RicConvertAllFractureTemplatesToFieldFeature` dereferenced the fracture template collection without checking it, and aborted when triggered outside a fracture template context. The corresponding Metric feature already has this guard.

## Deleting an item

Deleting a 3D view crashed with a pure virtual call. The object was destroyed while it was still attached to its parent field and still referenced by the open editors, and a destructor can re-enter the user interface: removing the view's dock widget makes the dock area activate a sibling, and the resulting selection change both repaints the project tree and rebuilds the property editor. The tree asks its nodes for a name, and the property editor walks `project->allViews()` to build the comparison view option list, which asks every view for its name. By then the object has lost its derived part, so producing the name calls the pure virtual `createAutoName()`.

The object is now erased from the field and the connected editors refreshed before it is deleted. `erase()` only detaches, so the object is still valid while the editors are refreshed, and afterwards it is reachable neither through the project nor from any editor.

Reproduced in the application with a project holding three GeoMech views and one Eclipse view, where deleting a GeoMech view aborted. Verified fixed with the same project.

## Guards and a wrong target collection

- `RicWellLogTools` read `eclipseCaseData()` without checking it. A case can be part of the project without being opened, and then has no case data.
- `RimEclipseContourMapView` dereferenced `viewer()` when creating the display model and when the axis line setting changed. Both run for a view without a viewer, and two other places in the same file already guard this way.
- `RicNewPolygonFilterFeature` resolved the case level data filter collection from the selection itself, so it only reacted to the collection node. Every other cell filter feature resolves it through `RicCellFilterFeatureTools::selectedDataFilterCollection`, which also accepts a selected Eclipse case. The Data Filters node is hidden while empty, so the case node is what is right clicked, and the polygon filter silently ended up in the active view's collection instead of on the case.
- `RicAppendIntersectionFeature` and `RicAppendSeparateIntersectionResultFeature` had no `isCommandEnabled` override, so they reported themselves enabled for any selection while `onActionTriggered` only handles a selection inside an intersection collection. The context menu offers these commands in the right context only, so this part is hardening rather than a user visible fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)