### PR TITLE
Add headless mode with software OpenGL rendering for 3D snapshots

### DIFF
--- a/ApplicationExeCode/CMakeLists.txt
+++ b/ApplicationExeCode/CMakeLists.txt
@@ -229,7 +229,7 @@ endif()
 
 if(MSVC)
   # Delay-load opengl32.dll so that the statically linked OpenGL calls can be redirected to the
-  # software rasterizer opengl32sw.dll in headless mode, see riaDelayLoadHook in RiaMain.cpp
+  # software rasterizer opengl32sw.dll in headless mode, see riaDelayLoadHook in RiaMainTools.cpp
   target_link_libraries(ResInsight PRIVATE delayimp)
   target_link_options(ResInsight PRIVATE /DELAYLOAD:opengl32.dll)
 endif()

--- a/ApplicationExeCode/CMakeLists.txt
+++ b/ApplicationExeCode/CMakeLists.txt
@@ -227,6 +227,13 @@ if(UNIX AND NOT APPLE)
   target_link_libraries(ResInsight PRIVATE xcb)
 endif()
 
+if(MSVC)
+  # Delay-load opengl32.dll so that the statically linked OpenGL calls can be redirected to the
+  # software rasterizer opengl32sw.dll in headless mode, see riaDelayLoadHook in RiaMain.cpp
+  target_link_libraries(ResInsight PRIVATE delayimp)
+  target_link_options(ResInsight PRIVATE /DELAYLOAD:opengl32.dll)
+endif()
+
 # ##############################################################################
 # Unity builds
 # ##############################################################################
@@ -408,6 +415,11 @@ if(RESINSIGHT_PRIVATE_INSTALL)
       RUNTIME_DEPENDENCIES PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
       POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
     )
+
+    # The software OpenGL rasterizer is loaded dynamically (used by --headless), so it is not
+    # picked up by the RUNTIME_DEPENDENCIES scan above
+    install(FILES $<TARGET_FILE_DIR:ResInsight>/opengl32sw.dll
+            DESTINATION ${RESINSIGHT_INSTALL_FOLDER} OPTIONAL)
   endif()
 
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/ApplicationExeCode/RiaMain.cpp
+++ b/ApplicationExeCode/RiaMain.cpp
@@ -45,18 +45,6 @@
 #include <unistd.h>
 #endif
 
-#ifdef WIN32
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-
-#include <delayimp.h>
-#endif
-
 #include <signal.h>
 
 #include <exception>
@@ -92,31 +80,6 @@ void riaFilteredMessageHandler( QtMsgType type, const QMessageLogContext& contex
 }
 } // namespace
 
-#ifdef WIN32
-//--------------------------------------------------------------------------------------------------
-/// In headless mode Qt creates its OpenGL context using the software rasterizer opengl32sw.dll
-/// (Qt::AA_UseSoftwareOpenGL), while the statically linked OpenGL calls in the visualization
-/// framework would go to the system opengl32.dll where no context is current, causing an endless
-/// loop in glGetError(). opengl32.dll is therefore delay-loaded (see CMakeLists.txt) and redirected
-/// here to the same software rasterizer.
-//--------------------------------------------------------------------------------------------------
-FARPROC WINAPI riaDelayLoadHook( unsigned dliNotify, PDelayLoadInfo pdli )
-{
-    if ( dliNotify == dliNotePreLoadLibrary && RiaGuiApplication::isHeadless() &&
-         _stricmp( pdli->szDll, "opengl32.dll" ) == 0 )
-    {
-        if ( HMODULE softwareOpenGl = LoadLibraryW( L"opengl32sw.dll" ) )
-        {
-            return reinterpret_cast<FARPROC>( softwareOpenGl );
-        }
-    }
-
-    return nullptr;
-}
-
-extern "C" const PfnDliHook __pfnDliNotifyHook2 = riaDelayLoadHook;
-#endif
-
 RiaApplication* createApplication( int& argc, char* argv[] )
 {
     bool isHeadless = false;
@@ -139,14 +102,7 @@ RiaApplication* createApplication( int& argc, char* argv[] )
 
     if ( isHeadless )
     {
-        // Use software OpenGL rendering so 3D views can be rendered without a GPU. On Windows this
-        // makes Qt load opengl32sw.dll (Mesa llvmpipe). Must be set before the QApplication exists.
-        QApplication::setAttribute( Qt::AA_UseSoftwareOpenGL );
-#ifndef WIN32
-        // On Linux the attribute has no effect, force Mesa software rendering instead
-        qputenv( "LIBGL_ALWAYS_SOFTWARE", "1" );
-#endif
-        RiaGuiApplication::enableHeadlessMode();
+        RiaMainTools::enableHeadlessRendering();
     }
 
 #ifdef ENABLE_GRPC

--- a/ApplicationExeCode/RiaMain.cpp
+++ b/ApplicationExeCode/RiaMain.cpp
@@ -45,6 +45,18 @@
 #include <unistd.h>
 #endif
 
+#ifdef WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <delayimp.h>
+#endif
+
 #include <signal.h>
 
 #include <exception>
@@ -80,8 +92,34 @@ void riaFilteredMessageHandler( QtMsgType type, const QMessageLogContext& contex
 }
 } // namespace
 
+#ifdef WIN32
+//--------------------------------------------------------------------------------------------------
+/// In headless mode Qt creates its OpenGL context using the software rasterizer opengl32sw.dll
+/// (Qt::AA_UseSoftwareOpenGL), while the statically linked OpenGL calls in the visualization
+/// framework would go to the system opengl32.dll where no context is current, causing an endless
+/// loop in glGetError(). opengl32.dll is therefore delay-loaded (see CMakeLists.txt) and redirected
+/// here to the same software rasterizer.
+//--------------------------------------------------------------------------------------------------
+FARPROC WINAPI riaDelayLoadHook( unsigned dliNotify, PDelayLoadInfo pdli )
+{
+    if ( dliNotify == dliNotePreLoadLibrary && RiaGuiApplication::isHeadless() &&
+         _stricmp( pdli->szDll, "opengl32.dll" ) == 0 )
+    {
+        if ( HMODULE softwareOpenGl = LoadLibraryW( L"opengl32sw.dll" ) )
+        {
+            return reinterpret_cast<FARPROC>( softwareOpenGl );
+        }
+    }
+
+    return nullptr;
+}
+
+extern "C" const PfnDliHook __pfnDliNotifyHook2 = riaDelayLoadHook;
+#endif
+
 RiaApplication* createApplication( int& argc, char* argv[] )
 {
+    bool isHeadless = false;
     for ( int i = 1; i < argc; ++i )
     {
         if ( !qstrcmp( argv[i], "--console" ) || !qstrcmp( argv[i], "--unittest" ) )
@@ -92,7 +130,25 @@ RiaApplication* createApplication( int& argc, char* argv[] )
             return new RiaConsoleApplication( argc, argv );
 #endif
         }
+
+        if ( !qstrcmp( argv[i], "--headless" ) )
+        {
+            isHeadless = true;
+        }
     }
+
+    if ( isHeadless )
+    {
+        // Use software OpenGL rendering so 3D views can be rendered without a GPU. On Windows this
+        // makes Qt load opengl32sw.dll (Mesa llvmpipe). Must be set before the QApplication exists.
+        QApplication::setAttribute( Qt::AA_UseSoftwareOpenGL );
+#ifndef WIN32
+        // On Linux the attribute has no effect, force Mesa software rendering instead
+        qputenv( "LIBGL_ALWAYS_SOFTWARE", "1" );
+#endif
+        RiaGuiApplication::enableHeadlessMode();
+    }
+
 #ifdef ENABLE_GRPC
     return new RiaGrpcGuiApplication( argc, argv );
 #else

--- a/ApplicationExeCode/RiaMainTools.cpp
+++ b/ApplicationExeCode/RiaMainTools.cpp
@@ -19,6 +19,7 @@
 #include "RiaMainTools.h"
 #include "RiaBaseDefs.h"
 #include "RiaFileLogger.h"
+#include "RiaGuiApplication.h"
 #include "RiaLogging.h"
 #include "RiaOpenTelemetryManager.h"
 #include "RiaRegressionTestRunner.h"
@@ -59,6 +60,43 @@
 #ifndef __APPLE__
 #include <ucontext.h>
 #endif
+#endif
+
+#ifdef WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <delayimp.h>
+#endif
+
+#ifdef WIN32
+//--------------------------------------------------------------------------------------------------
+/// In headless mode Qt creates its OpenGL context using the software rasterizer opengl32sw.dll
+/// (Qt::AA_UseSoftwareOpenGL), while the statically linked OpenGL calls in the visualization
+/// framework would go to the system opengl32.dll where no context is current, causing an endless
+/// loop in glGetError(). opengl32.dll is therefore delay-loaded (see CMakeLists.txt) and redirected
+/// here to the same software rasterizer.
+//--------------------------------------------------------------------------------------------------
+FARPROC WINAPI riaDelayLoadHook( unsigned dliNotify, PDelayLoadInfo pdli )
+{
+    if ( dliNotify == dliNotePreLoadLibrary && RiaGuiApplication::isHeadless() &&
+         _stricmp( pdli->szDll, "opengl32.dll" ) == 0 )
+    {
+        if ( HMODULE softwareOpenGl = LoadLibraryW( L"opengl32sw.dll" ) )
+        {
+            return reinterpret_cast<FARPROC>( softwareOpenGl );
+        }
+    }
+
+    return nullptr;
+}
+
+extern "C" const PfnDliHook __pfnDliNotifyHook2 = riaDelayLoadHook;
 #endif
 
 namespace internal
@@ -385,6 +423,24 @@ void deleteStaleSettingsLockFiles()
 
         qDebug() << logMessage;
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Configure software OpenGL rendering for headless mode, allowing 3D views to be rendered and
+/// grabbed without a GPU and without showing any windows. Must be called before the QApplication
+/// object is created.
+//--------------------------------------------------------------------------------------------------
+void enableHeadlessRendering()
+{
+    // Use software OpenGL rendering so 3D views can be rendered without a GPU. On Windows this
+    // makes Qt load opengl32sw.dll (Mesa llvmpipe). Must be set before the QApplication exists.
+    QApplication::setAttribute( Qt::AA_UseSoftwareOpenGL );
+#ifndef WIN32
+    // On Linux the attribute has no effect, force Mesa software rendering instead
+    qputenv( "LIBGL_ALWAYS_SOFTWARE", "1" );
+#endif
+
+    RiaGuiApplication::enableHeadlessMode();
 }
 
 } // namespace RiaMainTools

--- a/ApplicationExeCode/RiaMainTools.h
+++ b/ApplicationExeCode/RiaMainTools.h
@@ -22,4 +22,5 @@ namespace RiaMainTools
 void initializeSingletons();
 void releaseSingletonAndFactoryObjects();
 void deleteStaleSettingsLockFiles();
+void enableHeadlessRendering();
 }; // namespace RiaMainTools

--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -154,12 +154,30 @@
 ///
 //==================================================================================================
 
+bool RiaGuiApplication::sm_headlessMode = false;
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 bool RiaGuiApplication::isRunning()
 {
     return dynamic_cast<RiaGuiApplication*>( RiaApplication::instance() ) != nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiaGuiApplication::enableHeadlessMode()
+{
+    sm_headlessMode = true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RiaGuiApplication::isHeadless()
+{
+    return sm_headlessMode;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -277,6 +295,9 @@ QString RiaGuiApplication::promptForProjectSaveAsFileName() const
 //--------------------------------------------------------------------------------------------------
 bool RiaGuiApplication::askUserToSaveModifiedProject()
 {
+    // A modal dialog would hang a headless batch run
+    if ( isHeadless() ) return true;
+
     if ( RiaPreferencesSystem::current()->showProjectChangedDialog() && caf::PdmUiModelChangeDetector::instance()->isModelChanged() )
     {
         QMessageBox msgBox( activeMainWindow() );
@@ -523,6 +544,9 @@ RiaDefines::RINavigationPolicy RiaGuiApplication::navigationPolicy() const
 void RiaGuiApplication::initialize()
 {
     RiaApplication::initialize();
+
+    // Progress dialogs would pop up windows and can block a headless batch run
+    if ( isHeadless() ) caf::ProgressInfoStatic::setEnabled( false );
 
     applyGuiPreferences( nullptr );
 
@@ -899,8 +923,11 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( cvf::Progr
             auto mainPlotWnd = mainPlotWindow();
             if ( mainPlotWnd )
             {
-                mainPlotWnd->show();
-                mainPlotWnd->raise();
+                if ( !isHeadless() )
+                {
+                    mainPlotWnd->show();
+                    mainPlotWnd->raise();
+                }
 
                 processEvents();
 
@@ -911,8 +938,11 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( cvf::Progr
         if ( snapshotViews )
         {
             auto mainWnd = RiuMainWindow::instance();
-            mainWnd->show();
-            mainWnd->raise();
+            if ( !isHeadless() )
+            {
+                mainWnd->show();
+                mainWnd->raise();
+            }
 
             processEvents();
 
@@ -1031,7 +1061,7 @@ RiuMainWindow* RiaGuiApplication::getOrCreateAndShowMainWindow()
     {
         createMainWindow();
     }
-    else
+    else if ( !isHeadless() )
     {
         m_mainWindow->show();
     }
@@ -1077,7 +1107,7 @@ void RiaGuiApplication::createMainWindow()
     m_mainWindow->setDefaultWindowSize();
     m_mainWindow->setDefaultToolbarVisibility();
     m_mainWindow->loadWinGeoAndDockToolBarLayout();
-    m_mainWindow->showWindow();
+    if ( !isHeadless() ) m_mainWindow->showWindow();
 
     // if there is an existing logger, reconnect to it
 
@@ -1129,18 +1159,21 @@ RiuPlotMainWindow* RiaGuiApplication::getOrCreateAndShowMainPlotWindow()
         }
     }
 
-    if ( m_mainPlotWindow->isMinimized() )
+    if ( !isHeadless() )
     {
-        m_mainPlotWindow->showNormal();
-        m_mainPlotWindow->update();
-    }
-    else
-    {
-        m_mainPlotWindow->show();
-    }
+        if ( m_mainPlotWindow->isMinimized() )
+        {
+            m_mainPlotWindow->showNormal();
+            m_mainPlotWindow->update();
+        }
+        else
+        {
+            m_mainPlotWindow->show();
+        }
 
-    m_mainPlotWindow->raise();
-    m_mainPlotWindow->activateWindow();
+        m_mainPlotWindow->raise();
+        m_mainPlotWindow->activateWindow();
+    }
 
     return m_mainPlotWindow.get();
 }
@@ -1269,6 +1302,13 @@ void RiaGuiApplication::clearAllSelections()
 //--------------------------------------------------------------------------------------------------
 void RiaGuiApplication::showFormattedTextInMessageBoxOrConsole( const QString& text )
 {
+    // A modal dialog would hang a headless batch run
+    if ( isHeadless() )
+    {
+        std::cout << text.toStdString();
+        return;
+    }
+
     // Create a message dialog with cut/paste friendly text
     QDialog dlg( widgetToUseAsParent() );
     dlg.setModal( true );
@@ -1374,9 +1414,9 @@ void RiaGuiApplication::onProjectOpened()
         if ( !m_mainPlotWindow )
         {
             createMainPlotWindow();
-            m_mainPlotWindow->show();
+            if ( !isHeadless() ) m_mainPlotWindow->show();
         }
-        else
+        else if ( !isHeadless() )
         {
             m_mainPlotWindow->show();
             m_mainPlotWindow->raise();
@@ -1408,7 +1448,7 @@ void RiaGuiApplication::onProjectOpened()
     // Make sure to process events before this function to avoid strange Qt crash
     RiuPlotMainWindowTools::refreshToolbars();
 
-    if ( m_project->showPlotWindow() && m_project->showPlotWindowOnTop() )
+    if ( m_project->showPlotWindow() && m_project->showPlotWindowOnTop() && !isHeadless() )
     {
         m_mainPlotWindow->raise();
         m_mainPlotWindow->activateWindow();

--- a/ApplicationLibCode/Application/RiaGuiApplication.h
+++ b/ApplicationLibCode/Application/RiaGuiApplication.h
@@ -82,6 +82,9 @@ public:
     static bool               isRunning();
     static RiaGuiApplication* instance();
 
+    static void enableHeadlessMode();
+    static bool isHeadless();
+
     RiaGuiApplication( int& argc, char** argv );
     ~RiaGuiApplication() override;
 
@@ -168,4 +171,6 @@ private:
     QPointer<RiuPlotMainWindow> m_mainPlotWindow;
 
     std::unique_ptr<RiuRecentFileActionProvider> m_recentFileActionProvider;
+
+    static bool sm_headlessMode;
 };

--- a/ApplicationLibCode/Application/Tools/RiaArgumentParser.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaArgumentParser.cpp
@@ -71,6 +71,11 @@ bool RiaArgumentParser::parseArguments( cvf::ProgramOptions* progOpt )
                              cvf::ProgramOptions::MULTI_VALUE );
     progOpt->registerOption( "size", "<width> <height>", "Set size of the main application window.", cvf::ProgramOptions::MULTI_VALUE );
     progOpt->registerOption( "console", "", "Launch as a console application without graphics" );
+    progOpt->registerOption( "headless",
+                             "",
+                             "Run without showing any windows, using software OpenGL rendering. "
+                             "Combine with --savesnapshots to export images on machines without a GPU. "
+                             "On Linux without a display server, run under xvfb-run." );
     progOpt->registerOption( "server", "[<portnumber>]", "Launch as a GRPC server. Default port is 50051", cvf::ProgramOptions::SINGLE_VALUE );
     progOpt->registerOption( "portnumberfile", "[<filename>]", "Write the port number to this file.", cvf::ProgramOptions::SINGLE_VALUE );
 

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.cpp
@@ -40,6 +40,9 @@
 #include "RigFemResultPosEnum.h"
 
 #include "cafUtils.h"
+#include "cafViewer.h"
+
+#include "cvfOpenGLContextGroup.h"
 
 #include <QAction>
 #include <QClipboard>
@@ -147,6 +150,17 @@ void RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( const QS
             absoluteFileName = caf::Utils::constructFullFileName( absSnapshotPath, fileName + "_Statistics", ".png" );
             RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, img );
         }
+    }
+
+    if ( !viewsForSnapshot.empty() )
+    {
+        // The OpenGL strings are populated when the first context is initialized, which for hidden viewers happens
+        // inside the first snapshot grab. Useful to verify that the expected renderer (e.g. software/llvmpipe) is used.
+        const cvf::OpenGLInfo glInfo = caf::Viewer::contextGroup()->info();
+        RiaLogging::info( std::format( "OpenGL used for snapshots: {} / {} / {}",
+                                       glInfo.version().toStdString(),
+                                       glInfo.vendor().toStdString(),
+                                       glInfo.renderer().toStdString() ) );
     }
 }
 

--- a/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
@@ -73,6 +73,8 @@
 #include "cvfTransform.h"
 #include "cvfViewport.h"
 
+#include <QResizeEvent>
+
 #include <climits>
 
 namespace caf
@@ -537,6 +539,15 @@ QImage Rim3dView::captureSnapshot( int width, int height )
             // adjust for possible display DPI scaling
             const auto ratio = m_viewer->displayScalingRatio();
             m_viewer->layoutWidget()->setFixedSize( (int)( 1.0 * width / ratio ), (int)( 1.0 * height / ratio ) );
+
+            if ( !m_viewer->layoutWidget()->isVisible() )
+            {
+                // Hidden widgets defer resize events (Qt::WA_PendingResizeEvent), so the layout never propagates the
+                // new size to the GL widget. Deliver the resize synchronously so grabFramebuffer() renders at the
+                // requested size when running headless.
+                QResizeEvent resizeEvent( m_viewer->layoutWidget()->size(), orgSize );
+                QCoreApplication::sendEvent( m_viewer->layoutWidget(), &resizeEvent );
+            }
 
             image = m_viewer->snapshotImage();
 

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -1228,6 +1228,18 @@ bool caf::Viewer::isShadersSupported()
 //--------------------------------------------------------------------------------------------------
 QImage caf::Viewer::snapshotImage()
 {
+    if ( !isVisible() )
+    {
+        // A widget that has never been shown has not received any resize event, so the internal
+        // framebuffers used for rendering have not been sized (or created at all). The first grab
+        // initializes the OpenGL machinery, and the synthetic resize event delivered afterwards
+        // sizes the framebuffers through resizeGL() before the final grab below.
+        grabFramebuffer();
+
+        QResizeEvent resizeEvent( size(), size() );
+        QCoreApplication::sendEvent( this, &resizeEvent );
+    }
+
     auto image = grabFramebuffer();
 
     // Convert to RGB32 format to avoid visual artifacts related to alpha channel

--- a/Fwk/AppFwk/cafViewer/cafViewer.h
+++ b/Fwk/AppFwk/cafViewer/cafViewer.h
@@ -184,6 +184,9 @@ public:
     // display scaling ratio (should be 1 if DPI scaling is not enabled)
     double displayScalingRatio() const;
 
+    // System to make sure we share OpenGL resources
+    static cvf::OpenGLContextGroup* contextGroup();
+
 public slots:
     virtual void slotSetCurrentFrame( int frameIndex );
     virtual void slotEndAnimation();
@@ -253,8 +256,6 @@ private:
     void                        updateOverlayImagePresence();
 
     // System to make sure we share OpenGL resources
-    static cvf::OpenGLContextGroup* contextGroup();
-
     static cvf::ref<cvf::OpenGLContextGroup> sm_openGLContextGroup;
 
     caf::FrameAnimationControl* m_animationControl;

--- a/docs/class-diagrams/ResInsightHeadlessSnapshots.txt
+++ b/docs/class-diagrams/ResInsightHeadlessSnapshots.txt
@@ -1,18 +1,30 @@
 
-Investigations on using ResInsight to render plots in a compleatly Headless state
+Headless snapshot export from ResInsight
 
-- Qt 5.8 or higher needed, it seems. Tested with Qt 5.14.1. Tested with Qt 5.6.1 on CentOS 6 and the plots was rendered without fonts.
-- Start ResInsight with the additional options -platform offscreen
-- The project can not contain visible 3D views. If it does, ResInsight will crash
-- Might add -stylesheet <path to stylesheet definition file> to explicitly control fonts
-  example contents of stylesheets file:
-  
-	* { font: bold italic large "Times New Roman" }
-	
-  The "*" might be substituted with specific classes or widgets.
-  It seems as the Qwt plot axis-titles are not affected by the stylesheet set above
-  
+ResInsight can run without showing any windows and export snapshots of both 3D views and plots
+using the --headless command line option. Software OpenGL rendering is used, so no GPU is required.
+
 - Example command line:
 
-  ./ResInsight --project FPPLot.rsp --savesnapshots all --snapshotsize 500 500 -stylesheet stylesheet.txt -platform offscreen
-  
+  ResInsight --headless --project MyProject.rsp --savesnapshots all --snapshotsize 1000 745 --snapshotfolder snapshots
+
+  The application exits after the snapshots have been written.
+
+- Windows: software OpenGL is provided by opengl32sw.dll (Mesa llvmpipe), which is deployed
+  alongside ResInsight.exe by windeployqt.
+
+- Linux: LIBGL_ALWAYS_SOFTWARE=1 is set automatically, using the system Mesa llvmpipe driver.
+  A display server is still required by Qt to create OpenGL contexts. On a machine without a
+  display server, run under xvfb:
+
+  xvfb-run -a ./ResInsight --headless --project MyProject.rsp --savesnapshots all
+
+- To verify that the software renderer was used, check the log for a line like:
+  "OpenGL used for snapshots: ... Mesa ... llvmpipe ..."
+
+- The older approach of using the Qt platform plugin option "-platform offscreen" (single dash)
+  still works for projects containing only plots, but crashes if the project contains visible
+  3D views. Prefer --headless, which handles both. When using -platform offscreen, fonts can be
+  controlled with -stylesheet <path to stylesheet definition file>, e.g.:
+
+	* { font: bold italic large "Times New Roman" }


### PR DESCRIPTION
Adds a `--headless` command line option that runs ResInsight without showing any windows, renders 3D views with software OpenGL (no GPU required), and writes snapshots to file:

```
ResInsight --headless --project MyProject.rsp --savesnapshots all --snapshotsize 1000 745 --snapshotfolder out
```

The application exits after the snapshots are written. Verified on Windows with both Eclipse and GeoMech views: output is pixel-identical to GUI exports apart from text antialiasing, and the log confirms the software renderer (`OpenGL used for snapshots: ... Mesa ... llvmpipe`).

## Changes

- **`--headless` option**: detected in `createApplication()` before the QApplication exists; `RiaMainTools::enableHeadlessRendering()` sets `Qt::AA_UseSoftwareOpenGL` (Windows → `opengl32sw.dll`) and `LIBGL_ALWAYS_SOFTWARE=1` (Linux → Mesa llvmpipe).
- **Delay-load redirect (Windows)**: VizFwk calls `glGetError`/`glGetString` through a static link to system `opengl32.dll`, while `AA_UseSoftwareOpenGL` puts Qt's context in `opengl32sw.dll` — cvf then sees no current context and `cvf_check_ogl`'s `glGetError()` loop spins forever. `opengl32.dll` is now delay-loaded and a `__pfnDliNotifyHook2` hook resolves it to `opengl32sw.dll` in headless mode only; normal runs are unaffected.
- **Hidden-widget snapshot fixes**: Qt never delivers resize events to never-shown widgets, so `caf::Viewer`'s offscreen scene FBO stayed at 1×1 and produced black images. `caf::Viewer::snapshotImage()` now initializes GL with a first `grabFramebuffer()`, sends a synchronous resize event, then grabs the final image; `Rim3dView::captureSnapshot()` delivers the layout resize synchronously so the hidden GL widget gets the requested size.
- **Headless guards in `RiaGuiApplication`**: windows are created but never shown/raised; progress dialogs are disabled; `--help`/error text goes to the console; the save-modified-project dialog is skipped.
- **Diagnostics**: after view export, the OpenGL version/vendor/renderer is logged to verify which GL implementation was used.
- **Deployment**: `opengl32sw.dll` is installed explicitly (`RUNTIME_DEPENDENCIES` cannot see dynamically loaded DLLs). Docs in `docs/class-diagrams/ResInsightHeadlessSnapshots.txt` updated; on Linux without a display server, run under `xvfb-run -a`.

Linux verification is still pending.

Fixes #1015
