### PR TITLE
Add headless mode with software OpenGL rendering for 3D snapshots

### DIFF
--- a/ApplicationExeCode/CMakeLists.txt
+++ b/ApplicationExeCode/CMakeLists.txt
@@ -227,6 +227,14 @@ if(UNIX AND NOT APPLE)
   target_link_libraries(ResInsight PRIVATE xcb)
 endif()
 
+if(MSVC)
+  # Delay-load opengl32.dll so that the statically linked OpenGL calls can be
+  # redirected to the software rasterizer opengl32sw.dll in headless mode, see
+  # riaDelayLoadHook in RiaMainTools.cpp
+  target_link_libraries(ResInsight PRIVATE delayimp)
+  target_link_options(ResInsight PRIVATE /DELAYLOAD:opengl32.dll)
+endif()
+
 # ##############################################################################
 # Unity builds
 # ##############################################################################
@@ -407,6 +415,14 @@ if(RESINSIGHT_PRIVATE_INSTALL)
       DESTINATION ${RESINSIGHT_INSTALL_FOLDER}
       RUNTIME_DEPENDENCIES PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
       POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+    )
+
+    # The software OpenGL rasterizer is loaded dynamically (used by --headless),
+    # so it is not picked up by the RUNTIME_DEPENDENCIES scan above
+    install(
+      FILES $<TARGET_FILE_DIR:ResInsight>/opengl32sw.dll
+      DESTINATION ${RESINSIGHT_INSTALL_FOLDER}
+      OPTIONAL
     )
   endif()
 

--- a/ApplicationExeCode/RiaMain.cpp
+++ b/ApplicationExeCode/RiaMain.cpp
@@ -82,6 +82,7 @@ void riaFilteredMessageHandler( QtMsgType type, const QMessageLogContext& contex
 
 RiaApplication* createApplication( int& argc, char* argv[] )
 {
+    bool isHeadless = false;
     for ( int i = 1; i < argc; ++i )
     {
         if ( !qstrcmp( argv[i], "--console" ) || !qstrcmp( argv[i], "--unittest" ) )
@@ -92,7 +93,18 @@ RiaApplication* createApplication( int& argc, char* argv[] )
             return new RiaConsoleApplication( argc, argv );
 #endif
         }
+
+        if ( !qstrcmp( argv[i], "--headless" ) )
+        {
+            isHeadless = true;
+        }
     }
+
+    if ( isHeadless )
+    {
+        RiaMainTools::enableHeadlessRendering();
+    }
+
 #ifdef ENABLE_GRPC
     return new RiaGrpcGuiApplication( argc, argv );
 #else

--- a/ApplicationExeCode/RiaMainTools.cpp
+++ b/ApplicationExeCode/RiaMainTools.cpp
@@ -19,6 +19,7 @@
 #include "RiaMainTools.h"
 #include "RiaBaseDefs.h"
 #include "RiaFileLogger.h"
+#include "RiaGuiApplication.h"
 #include "RiaLogging.h"
 #include "RiaOpenTelemetryManager.h"
 #include "RiaRegressionTestRunner.h"
@@ -59,6 +60,43 @@
 #ifndef __APPLE__
 #include <ucontext.h>
 #endif
+#endif
+
+#ifdef WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <delayimp.h>
+#endif
+
+#ifdef WIN32
+//--------------------------------------------------------------------------------------------------
+/// In headless mode Qt creates its OpenGL context using the software rasterizer opengl32sw.dll
+/// (Qt::AA_UseSoftwareOpenGL), while the statically linked OpenGL calls in the visualization
+/// framework would go to the system opengl32.dll where no context is current, causing an endless
+/// loop in glGetError(). opengl32.dll is therefore delay-loaded (see CMakeLists.txt) and redirected
+/// here to the same software rasterizer.
+//--------------------------------------------------------------------------------------------------
+FARPROC WINAPI riaDelayLoadHook( unsigned dliNotify, PDelayLoadInfo pdli )
+{
+    if ( dliNotify == dliNotePreLoadLibrary && RiaGuiApplication::isHeadless() &&
+         _stricmp( pdli->szDll, "opengl32.dll" ) == 0 )
+    {
+        if ( HMODULE softwareOpenGl = LoadLibraryW( L"opengl32sw.dll" ) )
+        {
+            return reinterpret_cast<FARPROC>( softwareOpenGl );
+        }
+    }
+
+    return nullptr;
+}
+
+extern "C" const PfnDliHook __pfnDliNotifyHook2 = riaDelayLoadHook;
 #endif
 
 namespace internal
@@ -385,6 +423,24 @@ void deleteStaleSettingsLockFiles()
 
         qDebug() << logMessage;
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Configure software OpenGL rendering for headless mode, allowing 3D views to be rendered and
+/// grabbed without a GPU and without showing any windows. Must be called before the QApplication
+/// object is created.
+//--------------------------------------------------------------------------------------------------
+void enableHeadlessRendering()
+{
+    // Use software OpenGL rendering so 3D views can be rendered without a GPU. On Windows this
+    // makes Qt load opengl32sw.dll (Mesa llvmpipe). Must be set before the QApplication exists.
+    QApplication::setAttribute( Qt::AA_UseSoftwareOpenGL );
+#ifndef WIN32
+    // On Linux the attribute has no effect, force Mesa software rendering instead
+    qputenv( "LIBGL_ALWAYS_SOFTWARE", "1" );
+#endif
+
+    RiaGuiApplication::enableHeadlessMode();
 }
 
 } // namespace RiaMainTools

--- a/ApplicationExeCode/RiaMainTools.h
+++ b/ApplicationExeCode/RiaMainTools.h
@@ -22,4 +22,5 @@ namespace RiaMainTools
 void initializeSingletons();
 void releaseSingletonAndFactoryObjects();
 void deleteStaleSettingsLockFiles();
+void enableHeadlessRendering();
 }; // namespace RiaMainTools

--- a/ApplicationExeCode/resinsight
+++ b/ApplicationExeCode/resinsight
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Find the installation path. We assume that this script is placed in the installation directory.
-INSTALL_PATH=$(dirname "$_")
+INSTALL_PATH=$(dirname "$0")
 
 # Store the users working directory
 WORKING_DIR=`pwd`
@@ -9,7 +9,26 @@ WORKING_DIR=`pwd`
 # Change to application directory
 cd "$INSTALL_PATH"
 
+# When running headless on a system without a display server, Qt still needs an X server to create
+# OpenGL contexts. Wrap the application in xvfb-run (X virtual framebuffer) when no display is available.
+XVFB_RUN=""
+if [ -z "$DISPLAY" ]; then
+    for arg in "$@"; do
+        if [ "$arg" = "--headless" ]; then
+            if command -v xvfb-run >/dev/null 2>&1; then
+                XVFB_RUN="xvfb-run -a"
+            else
+                echo "resinsight: DISPLAY is not set and xvfb-run is not installed." >&2
+                echo "resinsight: install xvfb to run headless without a display server," >&2
+                echo "resinsight: e.g. 'apt-get install xvfb' or 'dnf install xorg-x11-server-Xvfb'." >&2
+                exit 1
+            fi
+            break
+        fi
+    done
+fi
+
 # Start the application making the default file open path become the users cwd
 
-CommandLine="./ResInsight --startdir $WORKING_DIR $@"
+CommandLine="$XVFB_RUN ./ResInsight --startdir $WORKING_DIR $@"
 exec $CommandLine

--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -154,12 +154,30 @@
 ///
 //==================================================================================================
 
+bool RiaGuiApplication::sm_headlessMode = false;
+
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
 bool RiaGuiApplication::isRunning()
 {
     return dynamic_cast<RiaGuiApplication*>( RiaApplication::instance() ) != nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiaGuiApplication::enableHeadlessMode()
+{
+    sm_headlessMode = true;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RiaGuiApplication::isHeadless()
+{
+    return sm_headlessMode;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -277,6 +295,9 @@ QString RiaGuiApplication::promptForProjectSaveAsFileName() const
 //--------------------------------------------------------------------------------------------------
 bool RiaGuiApplication::askUserToSaveModifiedProject()
 {
+    // A modal dialog would hang a headless batch run
+    if ( isHeadless() ) return true;
+
     if ( RiaPreferencesSystem::current()->showProjectChangedDialog() && caf::PdmUiModelChangeDetector::instance()->isModelChanged() )
     {
         QMessageBox msgBox( activeMainWindow() );
@@ -523,6 +544,9 @@ RiaDefines::RINavigationPolicy RiaGuiApplication::navigationPolicy() const
 void RiaGuiApplication::initialize()
 {
     RiaApplication::initialize();
+
+    // Progress dialogs would pop up windows and can block a headless batch run
+    if ( isHeadless() ) caf::ProgressInfoStatic::setEnabled( false );
 
     applyGuiPreferences( nullptr );
 
@@ -899,8 +923,11 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( cvf::Progr
             auto mainPlotWnd = mainPlotWindow();
             if ( mainPlotWnd )
             {
-                mainPlotWnd->show();
-                mainPlotWnd->raise();
+                if ( !isHeadless() )
+                {
+                    mainPlotWnd->show();
+                    mainPlotWnd->raise();
+                }
 
                 processEvents();
 
@@ -911,8 +938,11 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( cvf::Progr
         if ( snapshotViews )
         {
             auto mainWnd = RiuMainWindow::instance();
-            mainWnd->show();
-            mainWnd->raise();
+            if ( !isHeadless() )
+            {
+                mainWnd->show();
+                mainWnd->raise();
+            }
 
             processEvents();
 
@@ -1031,7 +1061,7 @@ RiuMainWindow* RiaGuiApplication::getOrCreateAndShowMainWindow()
     {
         createMainWindow();
     }
-    else
+    else if ( !isHeadless() )
     {
         m_mainWindow->show();
     }
@@ -1077,7 +1107,7 @@ void RiaGuiApplication::createMainWindow()
     m_mainWindow->setDefaultWindowSize();
     m_mainWindow->setDefaultToolbarVisibility();
     m_mainWindow->loadWinGeoAndDockToolBarLayout();
-    m_mainWindow->showWindow();
+    if ( !isHeadless() ) m_mainWindow->showWindow();
 
     // if there is an existing logger, reconnect to it
 
@@ -1129,18 +1159,21 @@ RiuPlotMainWindow* RiaGuiApplication::getOrCreateAndShowMainPlotWindow()
         }
     }
 
-    if ( m_mainPlotWindow->isMinimized() )
+    if ( !isHeadless() )
     {
-        m_mainPlotWindow->showNormal();
-        m_mainPlotWindow->update();
-    }
-    else
-    {
-        m_mainPlotWindow->show();
-    }
+        if ( m_mainPlotWindow->isMinimized() )
+        {
+            m_mainPlotWindow->showNormal();
+            m_mainPlotWindow->update();
+        }
+        else
+        {
+            m_mainPlotWindow->show();
+        }
 
-    m_mainPlotWindow->raise();
-    m_mainPlotWindow->activateWindow();
+        m_mainPlotWindow->raise();
+        m_mainPlotWindow->activateWindow();
+    }
 
     return m_mainPlotWindow.get();
 }
@@ -1269,6 +1302,13 @@ void RiaGuiApplication::clearAllSelections()
 //--------------------------------------------------------------------------------------------------
 void RiaGuiApplication::showFormattedTextInMessageBoxOrConsole( const QString& text )
 {
+    // A modal dialog would hang a headless batch run
+    if ( isHeadless() )
+    {
+        std::cout << text.toStdString();
+        return;
+    }
+
     // Create a message dialog with cut/paste friendly text
     QDialog dlg( widgetToUseAsParent() );
     dlg.setModal( true );
@@ -1374,9 +1414,9 @@ void RiaGuiApplication::onProjectOpened()
         if ( !m_mainPlotWindow )
         {
             createMainPlotWindow();
-            m_mainPlotWindow->show();
+            if ( !isHeadless() ) m_mainPlotWindow->show();
         }
-        else
+        else if ( !isHeadless() )
         {
             m_mainPlotWindow->show();
             m_mainPlotWindow->raise();
@@ -1408,7 +1448,7 @@ void RiaGuiApplication::onProjectOpened()
     // Make sure to process events before this function to avoid strange Qt crash
     RiuPlotMainWindowTools::refreshToolbars();
 
-    if ( m_project->showPlotWindow() && m_project->showPlotWindowOnTop() )
+    if ( m_project->showPlotWindow() && m_project->showPlotWindowOnTop() && !isHeadless() )
     {
         m_mainPlotWindow->raise();
         m_mainPlotWindow->activateWindow();

--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -575,6 +575,23 @@ void RiaGuiApplication::initialize()
         RiaLogging::appendLoggerInstance( std::move( logger ) );
     }
 
+    if ( isHeadless() )
+    {
+        // The message panels are never shown in headless mode, so also write to stdout to make batch runs diagnosable
+        auto stdLogger = std::make_unique<RiaStdOutLogger>();
+
+        if ( m_logLevelFromCommandLine.has_value() )
+        {
+            stdLogger->setLevel( m_logLevelFromCommandLine.value() );
+        }
+        else
+        {
+            stdLogger->setLevel( int( RiaLogging::logLevelBasedOnPreferences() ) );
+        }
+
+        RiaLogging::appendLoggerInstance( std::move( stdLogger ) );
+    }
+
     {
         auto logFolder  = QDir::homePath() + "/.resinsight/logs";
         auto fileLogger = std::make_unique<RiaFileLogger>( logFolder.toStdString() );
@@ -1305,7 +1322,13 @@ void RiaGuiApplication::showFormattedTextInMessageBoxOrConsole( const QString& t
     // A modal dialog would hang a headless batch run
     if ( isHeadless() )
     {
-        std::cout << text.toStdString();
+        const std::string stdText = text.toStdString();
+        std::cout << stdText;
+
+        // Make sure the text ends with a newline and reaches the console even if the application aborts later
+        if ( stdText.empty() || stdText.back() != '\n' ) std::cout << '\n';
+        std::cout.flush();
+
         return;
     }
 

--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -935,6 +935,8 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( cvf::Progr
             snapshotFolder = snapshotFolderFromCommandLine;
         }
 
+        QStringList snapshotErrors;
+
         if ( snapshotPlots )
         {
             auto mainPlotWnd = mainPlotWindow();
@@ -948,7 +950,9 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( cvf::Progr
 
                 processEvents();
 
-                RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( snapshotFolder, snapshotWidth, snapshotHeight );
+                auto result =
+                    RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( snapshotFolder, snapshotWidth, snapshotHeight );
+                if ( !result ) snapshotErrors.push_back( result.error() );
             }
         }
 
@@ -963,7 +967,8 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( cvf::Progr
 
             processEvents();
 
-            RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( snapshotFolder, snapshotWidth, snapshotHeight );
+            auto result = RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( snapshotFolder, snapshotWidth, snapshotHeight );
+            if ( !result ) snapshotErrors.push_back( result.error() );
         }
 
         auto mainPlotWnd = mainPlotWindow();
@@ -973,6 +978,14 @@ RiaApplication::ApplicationStatus RiaGuiApplication::handleArguments( cvf::Progr
         }
 
         if ( RiuMainWindow::instance() ) RiuMainWindow::instance()->loadWinGeoAndDockToolBarLayout();
+
+        if ( !snapshotErrors.empty() )
+        {
+            // Report a non-zero exit code, as a batch run with missing images is otherwise indistinguishable from success
+            RiaLogging::error( snapshotErrors.join( ". " ).toStdString() );
+
+            return ApplicationStatus::EXIT_WITH_ERROR;
+        }
 
         return ApplicationStatus::EXIT_COMPLETED;
     }
@@ -1858,7 +1871,8 @@ void RiaGuiApplication::runMultiCaseSnapshots( const QString&       templateProj
         bool loadOk = loadProject( templateProjectFileName, ProjectLoadAction::PLA_NONE, &modifier );
         if ( loadOk )
         {
-            RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( snapshotFolderName );
+            auto result = RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( snapshotFolderName );
+            if ( !result ) RiaLogging::error( result.error().toStdString() );
         }
     }
     m_mainWindow->dockManager()->restoreState( curState );

--- a/ApplicationLibCode/Application/RiaGuiApplication.h
+++ b/ApplicationLibCode/Application/RiaGuiApplication.h
@@ -82,6 +82,9 @@ public:
     static bool               isRunning();
     static RiaGuiApplication* instance();
 
+    static void enableHeadlessMode();
+    static bool isHeadless();
+
     RiaGuiApplication( int& argc, char** argv );
     ~RiaGuiApplication() override;
 
@@ -168,4 +171,6 @@ private:
     QPointer<RiuPlotMainWindow> m_mainPlotWindow;
 
     std::unique_ptr<RiuRecentFileActionProvider> m_recentFileActionProvider;
+
+    static bool sm_headlessMode;
 };

--- a/ApplicationLibCode/Application/Tools/RiaArgumentParser.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaArgumentParser.cpp
@@ -71,6 +71,11 @@ bool RiaArgumentParser::parseArguments( cvf::ProgramOptions* progOpt )
                              cvf::ProgramOptions::MULTI_VALUE );
     progOpt->registerOption( "size", "<width> <height>", "Set size of the main application window.", cvf::ProgramOptions::MULTI_VALUE );
     progOpt->registerOption( "console", "", "Launch as a console application without graphics" );
+    progOpt->registerOption( "headless",
+                             "",
+                             "Run without showing any windows, using software OpenGL rendering. "
+                             "Combine with --savesnapshots to export images on machines without a GPU. "
+                             "On Linux without a display server, run under xvfb-run." );
     progOpt->registerOption( "server", "[<portnumber>]", "Launch as a GRPC server. Default port is 50051", cvf::ProgramOptions::SINGLE_VALUE );
     progOpt->registerOption( "portnumberfile", "[<filename>]", "Write the port number to this file.", cvf::ProgramOptions::SINGLE_VALUE );
 

--- a/ApplicationLibCode/Application/Tools/RiaRegressionTestRunner.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaRegressionTestRunner.cpp
@@ -250,9 +250,10 @@ void RiaRegressionTestRunner::runRegressionTest()
                 if ( regressionTestConfig.exportSnapshots3dViews )
                 {
                     QSize defaultSize = RiaRegressionTestRunner::regressionDefaultImageSize();
-                    RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( fullPathGeneratedFolder,
-                                                                                       defaultSize.width(),
-                                                                                       defaultSize.height() );
+                    auto  result      = RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( fullPathGeneratedFolder,
+                                                                                                     defaultSize.width(),
+                                                                                                     defaultSize.height() );
+                    if ( !result ) RiaLogging::error( result.error().toStdString() );
 
                     QApplication::processEvents();
                 }
@@ -260,10 +261,11 @@ void RiaRegressionTestRunner::runRegressionTest()
                 if ( regressionTestConfig.exportSnapshotsPlots )
                 {
                     QSize defaultSize = RiaRegressionTestRunner::regressionDefaultImageSize();
-                    RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( fullPathGeneratedFolder,
-                                                                                       defaultSize.width(),
-                                                                                       defaultSize.height(),
-                                                                                       true /*activate widget*/ );
+                    auto  result      = RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( fullPathGeneratedFolder,
+                                                                                                     defaultSize.width(),
+                                                                                                     defaultSize.height(),
+                                                                                                     true /*activate widget*/ );
+                    if ( !result ) RiaLogging::error( result.error().toStdString() );
                 }
 
                 uint64_t usedMemoryBeforeClose = caf::MemoryInspector::getApplicationPhysicalMemoryUsageMiB();

--- a/ApplicationLibCode/CommandFileInterface/RicfExportSnapshots.cpp
+++ b/ApplicationLibCode/CommandFileInterface/RicfExportSnapshots.cpp
@@ -101,6 +101,8 @@ caf::PdmScriptResponse RicfExportSnapshots::execute()
     {
         absolutePathToSnapshotDir = RiaApplication::instance()->createAbsolutePathFromProjectRelativePath( "snapshots" );
     }
+    QStringList snapshotErrors;
+
     if ( m_type == RicfExportSnapshots::SnapshotsType::VIEWS || m_type == RicfExportSnapshots::SnapshotsType::ALL )
     {
         if ( RiaRegressionTestRunner::instance()->isRunningRegressionTests() )
@@ -110,12 +112,13 @@ caf::PdmScriptResponse RicfExportSnapshots::execute()
             height            = defaultSize.height();
         }
 
-        RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( absolutePathToSnapshotDir,
-                                                                           width,
-                                                                           height,
-                                                                           m_prefix,
-                                                                           m_caseId(),
-                                                                           m_viewId() );
+        auto result = RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( absolutePathToSnapshotDir,
+                                                                                         width,
+                                                                                         height,
+                                                                                         m_prefix,
+                                                                                         m_caseId(),
+                                                                                         m_viewId() );
+        if ( !result ) snapshotErrors.push_back( result.error() );
     }
     if ( m_type == RicfExportSnapshots::SnapshotsType::PLOTS || m_type == RicfExportSnapshots::SnapshotsType::ALL )
     {
@@ -133,13 +136,19 @@ caf::PdmScriptResponse RicfExportSnapshots::execute()
 
         QString fileSuffix = ".png";
         if ( m_plotOutputFormat == PlotOutputFormat::PDF ) fileSuffix = ".pdf";
-        RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( absolutePathToSnapshotDir,
-                                                                           width,
-                                                                           height,
-                                                                           activateWidget,
-                                                                           m_prefix,
-                                                                           m_viewId(),
-                                                                           fileSuffix );
+        auto result = RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( absolutePathToSnapshotDir,
+                                                                                         width,
+                                                                                         height,
+                                                                                         activateWidget,
+                                                                                         m_prefix,
+                                                                                         m_viewId(),
+                                                                                         fileSuffix );
+        if ( !result ) snapshotErrors.push_back( result.error() );
+    }
+
+    if ( !snapshotErrors.empty() )
+    {
+        return caf::PdmScriptResponse( caf::PdmScriptResponse::COMMAND_ERROR, snapshotErrors.join( ". " ) );
     }
 
     return caf::PdmScriptResponse();

--- a/ApplicationLibCode/Commands/ExportCommands/RicAdvancedSnapshotExportFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicAdvancedSnapshotExportFeature.cpp
@@ -257,7 +257,9 @@ void RicAdvancedSnapshotExportFeature::exportViewVariationsToFolder( RimGridView
             QString absoluteFileName = caf::Utils::constructFullFileName( folder, fileName, ".png" );
 
             QApplication::processEvents();
-            RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, rimView );
+
+            // Errors are logged by saveSnapshotAs
+            (void)RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, rimView );
         }
         else
         {
@@ -295,7 +297,9 @@ void RicAdvancedSnapshotExportFeature::exportViewVariationsToFolder( RimGridView
                 QString absoluteFileName = caf::Utils::constructFullFileName( folder, fileName, ".png" );
 
                 QApplication::processEvents();
-                RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, rimView );
+
+                // Errors are logged by saveSnapshotAs
+                (void)RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, rimView );
             }
 
             rimView->cellFilterCollection()->removeFilter( rangeFilter );

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllPlotsToFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllPlotsToFileFeature.cpp
@@ -28,11 +28,14 @@
 #include "RicSnapshotFilenameGenerator.h"
 #include "RicSnapshotViewToFileFeature.h"
 
+#include "RiuPlotMainWindow.h"
 #include "RiuPlotMainWindowTools.h"
+#include "RiuTools.h"
 
 #include "cafUtils.h"
 
 #include <QAction>
+#include <QApplication>
 #include <QClipboard>
 #include <QDebug>
 #include <QDir>
@@ -93,6 +96,20 @@ std::expected<void, QString> RicSnapshotAllPlotsToFileFeature::exportSnapshotOfP
     }
 
     const QString absSnapshotPath = snapshotPath.absolutePath();
+
+    // RiaGuiApplication::instance() asserts when running as a console application, where command files can also
+    // trigger this export
+    if ( RiaGuiApplication::isRunning() )
+    {
+        if ( RiuPlotMainWindow* plotWindow = RiaGuiApplication::instance()->mainPlotWindow(); plotWindow && !plotWindow->isVisible() )
+        {
+            // In headless mode the plot window has never been shown, so the dock widgets and plot widgets have never
+            // been laid out. Deliver the deferred resize events so all plot widgets get their proper sizes before
+            // rendering.
+            RiuTools::sendDeferredResizeEvents( plotWindow );
+            QApplication::processEvents();
+        }
+    }
 
     size_t attemptedSnapshotCount = 0;
     size_t failedSnapshotCount    = 0;

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllPlotsToFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllPlotsToFileFeature.cpp
@@ -57,7 +57,11 @@ void RicSnapshotAllPlotsToFileFeature::saveAllPlots()
     QString snapshotFolderName = app->createAbsolutePathFromProjectRelativePath( "snapshots" );
 
     // save using existing plot sizes
-    exportSnapshotOfPlotsIntoFolder( snapshotFolderName, -1, -1, true /* activateWidget */ );
+    if ( auto result = exportSnapshotOfPlotsIntoFolder( snapshotFolderName, -1, -1, true /* activateWidget */ ); !result )
+    {
+        RiaLogging::error( result.error().toStdString() );
+        return;
+    }
 
     QString text = QString( "Exported snapshots to folder : \n%1" ).arg( snapshotFolderName );
     RiaLogging::info( text.toStdString() );
@@ -66,26 +70,32 @@ void RicSnapshotAllPlotsToFileFeature::saveAllPlots()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( const QString& snapshotFolderName,
-                                                                        int            width,
-                                                                        int            height,
-                                                                        bool           activateWidget,
-                                                                        const QString& prefix,
-                                                                        int            viewId,
-                                                                        const QString& preferredFileSuffix /*=".png"*/ )
+std::expected<void, QString> RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( const QString& snapshotFolderName,
+                                                                                                int            width,
+                                                                                                int            height,
+                                                                                                bool           activateWidget,
+                                                                                                const QString& prefix,
+                                                                                                int            viewId,
+                                                                                                const QString& preferredFileSuffix /*=".png"*/ )
 {
     RiaApplication* app = RiaApplication::instance();
 
     RimProject* proj = app->project();
-    if ( !proj ) return;
+    if ( !proj ) return std::unexpected( QString( "No project available" ) );
 
     QDir snapshotPath( snapshotFolderName );
     if ( !snapshotPath.exists() )
     {
-        if ( !snapshotPath.mkpath( "." ) ) return;
+        if ( !snapshotPath.mkpath( "." ) )
+        {
+            return std::unexpected( QString( "Not able to create snapshot folder %1" ).arg( snapshotFolderName ) );
+        }
     }
 
     const QString absSnapshotPath = snapshotPath.absolutePath();
+
+    size_t attemptedSnapshotCount = 0;
+    size_t failedSnapshotCount    = 0;
 
     std::vector<RimViewWindow*> viewWindows = RimMainPlotCollection::current()->descendantsIncludingThisOfType<RimViewWindow>();
     for ( auto viewWindow : viewWindows )
@@ -108,9 +118,19 @@ void RicSnapshotAllPlotsToFileFeature::exportSnapshotOfPlotsIntoFolder( const QS
 
             QString absoluteFileName = caf::Utils::constructFullFileName( absSnapshotPath, fileName, preferredFileSuffix );
 
-            RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, viewWindow, width, height );
+            attemptedSnapshotCount++;
+
+            // The error is logged by saveSnapshotAs, only the number of failures is needed here
+            if ( !RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, viewWindow, width, height ) ) failedSnapshotCount++;
         }
     }
+
+    if ( failedSnapshotCount > 0 )
+    {
+        return std::unexpected( QString( "Failed to export %1 of %2 plot snapshots" ).arg( failedSnapshotCount ).arg( attemptedSnapshotCount ) );
+    }
+
+    return {};
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllPlotsToFileFeature.h
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllPlotsToFileFeature.h
@@ -20,6 +20,8 @@
 
 #include "cafCmdFeature.h"
 
+#include <expected>
+
 class RimViewWindow;
 
 //==================================================================================================
@@ -32,13 +34,14 @@ class RicSnapshotAllPlotsToFileFeature : public caf::CmdFeature
 public:
     static void saveAllPlots();
 
-    static void exportSnapshotOfPlotsIntoFolder( const QString& snapshotFolderName,
-                                                 int            width               = -1,
-                                                 int            height              = -1,
-                                                 bool           activateWidget      = false,
-                                                 const QString& prefix              = "",
-                                                 int            viewId              = -1,
-                                                 const QString& preferredFileSuffix = ".png" );
+    // Returns an error description if one or more plots could not be exported
+    static std::expected<void, QString> exportSnapshotOfPlotsIntoFolder( const QString& snapshotFolderName,
+                                                                         int            width               = -1,
+                                                                         int            height              = -1,
+                                                                         bool           activateWidget      = false,
+                                                                         const QString& prefix              = "",
+                                                                         int            viewId              = -1,
+                                                                         const QString& preferredFileSuffix = ".png" );
 
 protected:
     void onActionTriggered( bool isChecked ) override;

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.cpp
@@ -35,6 +35,7 @@
 #include "RicSnapshotViewToFileFeature.h"
 
 #include "Riu3DMainWindowTools.h"
+#include "RiuMainWindow.h"
 #include "RiuViewer.h"
 
 #include "RigFemResultPosEnum.h"
@@ -124,6 +125,16 @@ std::expected<void, QString> RicSnapshotAllViewsToFileFeature::exportSnapshotOfV
 
     const QString absSnapshotPath = snapshotPath.absolutePath();
     RiaLogging::info( std::format( "Exporting snapshot of all views to {}", snapshotFolderName ) );
+
+    if ( RiuMainWindow* mainWnd = RiuMainWindow::instance(); mainWnd && !mainWnd->isVisible() )
+    {
+        // When running headless with a hidden main window, Qt selects the global share context for the OpenGL context
+        // of the first rendered view widget. The dock widget activation in the loop below gives the main window a
+        // native window handle, making Qt select a new share context for the remaining view widgets, which asserts in
+        // cvfqt::OpenGLWidget::initializeGL() as the contexts do not share resources. Create the native window up
+        // front so the share context selection is identical for all view widgets.
+        mainWnd->createWinId();
+    }
 
     size_t failedSnapshotCount = 0;
 

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.cpp
@@ -65,7 +65,11 @@ void RicSnapshotAllViewsToFileFeature::saveAllViews()
     // Save images in snapshot catalog relative to project directory
     QString snapshotFolderName = app->createAbsolutePathFromProjectRelativePath( "snapshots" );
 
-    exportSnapshotOfViewsIntoFolder( snapshotFolderName );
+    if ( auto result = exportSnapshotOfViewsIntoFolder( snapshotFolderName ); !result )
+    {
+        RiaLogging::error( result.error().toStdString() );
+        return;
+    }
 
     QString text = QString( "Exported snapshots to folder : \n%1" ).arg( snapshotFolderName );
     RiaLogging::info( text.toStdString() );
@@ -75,20 +79,23 @@ void RicSnapshotAllViewsToFileFeature::saveAllViews()
 /// Export snapshots of a given view (or viewId == -1 for all views) for the given case (or caseId == -1 for all cases)
 /// <= 0 for width and height means to use the existing view size
 //--------------------------------------------------------------------------------------------------
-void RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( const QString& snapshotFolderName,
-                                                                        int            width,
-                                                                        int            height,
-                                                                        const QString& prefix,
-                                                                        int            caseId,
-                                                                        int            viewId )
+std::expected<void, QString> RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( const QString& snapshotFolderName,
+                                                                                                int            width,
+                                                                                                int            height,
+                                                                                                const QString& prefix,
+                                                                                                int            caseId,
+                                                                                                int            viewId )
 {
     RimProject* project = RimProject::current();
-    if ( project == nullptr ) return;
+    if ( project == nullptr ) return std::unexpected( QString( "No project available" ) );
 
     QDir snapshotPath( snapshotFolderName );
     if ( !snapshotPath.exists() )
     {
-        if ( !snapshotPath.mkpath( "." ) ) return;
+        if ( !snapshotPath.mkpath( "." ) )
+        {
+            return std::unexpected( QString( "Not able to create snapshot folder %1" ).arg( snapshotFolderName ) );
+        }
     }
 
     std::vector<Rim3dView*> viewsForSnapshot;
@@ -118,6 +125,8 @@ void RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( const QS
     const QString absSnapshotPath = snapshotPath.absolutePath();
     RiaLogging::info( std::format( "Exporting snapshot of all views to {}", snapshotFolderName ) );
 
+    size_t failedSnapshotCount = 0;
+
     for ( auto riv : viewsForSnapshot )
     {
         RiuViewer* viewer = riv->viewer();
@@ -142,13 +151,20 @@ void RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( const QS
 
         QString absoluteFileName = caf::Utils::constructFullFileName( absSnapshotPath, fileName, ".png" );
 
-        RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, riv, width, height );
+        // The error is logged by saveSnapshotAs, only the number of failures is needed here
+        if ( !RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, riv, width, height ) ) failedSnapshotCount++;
 
         if ( RimGridView* rigv = dynamic_cast<RimGridView*>( riv ) )
         {
-            QImage img       = rigv->overlayInfoConfig()->statisticsDialogScreenShotImage();
-            absoluteFileName = caf::Utils::constructFullFileName( absSnapshotPath, fileName + "_Statistics", ".png" );
-            RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, img );
+            QImage img = rigv->overlayInfoConfig()->statisticsDialogScreenShotImage();
+
+            // The statistics image is empty unless the statistics dialog has been shown, so a missing image here is
+            // expected and not treated as a failure
+            if ( !img.isNull() )
+            {
+                absoluteFileName = caf::Utils::constructFullFileName( absSnapshotPath, fileName + "_Statistics", ".png" );
+                (void)RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, img );
+            }
         }
     }
 
@@ -162,6 +178,14 @@ void RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( const QS
                                        glInfo.vendor().toStdString(),
                                        glInfo.renderer().toStdString() ) );
     }
+
+    if ( failedSnapshotCount > 0 )
+    {
+        return std::unexpected(
+            QString( "Failed to export %1 of %2 view snapshots" ).arg( failedSnapshotCount ).arg( viewsForSnapshot.size() ) );
+    }
+
+    return {};
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.cpp
@@ -40,6 +40,9 @@
 #include "RigFemResultPosEnum.h"
 
 #include "cafUtils.h"
+#include "cafViewer.h"
+
+#include "cvfOpenGLContextGroup.h"
 
 #include <QAction>
 #include <QClipboard>
@@ -147,6 +150,17 @@ void RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( const QS
             absoluteFileName = caf::Utils::constructFullFileName( absSnapshotPath, fileName + "_Statistics", ".png" );
             RicSnapshotViewToFileFeature::saveSnapshotAs( absoluteFileName, img );
         }
+    }
+
+    if ( !viewsForSnapshot.empty() )
+    {
+        // The OpenGL strings are populated when the first context is initialized, which for hidden viewers happens
+        // inside the first snapshot grab. Useful to verify that the expected renderer (e.g. software/llvmpipe) is used.
+        const cvf::OpenGLInfo glInfo = caf::Viewer::contextGroup()->info();
+        RiaLogging::info( std::format( "OpenGL used for snapshots: {} / {} / {}",
+                                       glInfo.version().toStdString(),
+                                       glInfo.vendor().toStdString(),
+                                       glInfo.renderer().toStdString() ) );
     }
 }
 

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.h
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotAllViewsToFileFeature.h
@@ -19,6 +19,8 @@
 
 #include "cafCmdFeature.h"
 
+#include <expected>
+
 //==================================================================================================
 ///
 //==================================================================================================
@@ -29,12 +31,13 @@ class RicSnapshotAllViewsToFileFeature : public caf::CmdFeature
 public:
     static void saveAllViews();
 
-    static void exportSnapshotOfViewsIntoFolder( const QString& snapshotFolderName,
-                                                 int            width  = -1,
-                                                 int            height = -1,
-                                                 const QString& prefix = "",
-                                                 int            caseId = -1,
-                                                 int            viewId = -1 );
+    // Returns an error description if one or more views could not be exported
+    static std::expected<void, QString> exportSnapshotOfViewsIntoFolder( const QString& snapshotFolderName,
+                                                                         int            width  = -1,
+                                                                         int            height = -1,
+                                                                         const QString& prefix = "",
+                                                                         int            caseId = -1,
+                                                                         int            viewId = -1 );
 
 protected:
     void onActionTriggered( bool isChecked ) override;

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotViewToFileFeature.cpp
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotViewToFileFeature.cpp
@@ -48,36 +48,50 @@ CAF_CMD_SOURCE_INIT( RicSnapshotViewToFileFeature, "RicSnapshotViewToFileFeature
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicSnapshotViewToFileFeature::saveSnapshotAs( const QString& fileName, RimViewWindow* viewWindow, int width, int height )
+std::expected<void, QString>
+    RicSnapshotViewToFileFeature::saveSnapshotAs( const QString& fileName, RimViewWindow* viewWindow, int width, int height )
 {
     auto* plotWindow = dynamic_cast<RimPlotWindow*>( viewWindow );
     if ( plotWindow && fileName.endsWith( ".pdf" ) )
     {
         savePlotPdfReportAs( fileName, plotWindow );
+        return {};
     }
     else if ( viewWindow )
     {
         QImage image = viewWindow->captureSnapshot( width, height );
-        saveSnapshotAs( fileName, image );
+        return saveSnapshotAs( fileName, image );
     }
+
+    return std::unexpected( QString( "No view window to create a snapshot from" ) );
 }
 
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
-void RicSnapshotViewToFileFeature::saveSnapshotAs( const QString& fileName, const QImage& image )
+std::expected<void, QString> RicSnapshotViewToFileFeature::saveSnapshotAs( const QString& fileName, const QImage& image )
 {
-    if ( !image.isNull() )
+    if ( image.isNull() )
     {
-        if ( image.save( fileName ) )
-        {
-            RiaLogging::info( std::format( "Exported snapshot image to {}", fileName ) );
-        }
-        else
-        {
-            RiaLogging::error( std::format( "Error when trying to export snapshot image to {}", fileName ) );
-        }
+        // No image is captured if the 3D view has no valid OpenGL context, typically seen when running headless on a
+        // platform without support for offscreen rendering
+        const QString errorText = QString( "No snapshot image was captured for %1" ).arg( fileName );
+        RiaLogging::error( errorText.toStdString() );
+
+        return std::unexpected( errorText );
     }
+
+    if ( !image.save( fileName ) )
+    {
+        const QString errorText = QString( "Error when trying to export snapshot image to %1" ).arg( fileName );
+        RiaLogging::error( errorText.toStdString() );
+
+        return std::unexpected( errorText );
+    }
+
+    RiaLogging::info( std::format( "Exported snapshot image to {}", fileName ) );
+
+    return {};
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -147,7 +161,8 @@ void RicSnapshotViewToFileFeature::saveViewWindowToFile( RimViewWindow* viewWind
         }
         else
         {
-            RicSnapshotViewToFileFeature::saveSnapshotAs( fileName, viewWindow->snapshotWindowContent() );
+            // Errors are logged by saveSnapshotAs
+            (void)RicSnapshotViewToFileFeature::saveSnapshotAs( fileName, viewWindow->snapshotWindowContent() );
         }
     }
 }
@@ -160,7 +175,8 @@ void RicSnapshotViewToFileFeature::saveImageToFile( const QImage& image, const Q
     QString fileName = generateSaveFileName( defaultFileBaseName, false );
     if ( !fileName.isEmpty() )
     {
-        RicSnapshotViewToFileFeature::saveSnapshotAs( fileName, image );
+        // Errors are logged by saveSnapshotAs
+        (void)RicSnapshotViewToFileFeature::saveSnapshotAs( fileName, image );
     }
 }
 

--- a/ApplicationLibCode/Commands/ExportCommands/RicSnapshotViewToFileFeature.h
+++ b/ApplicationLibCode/Commands/ExportCommands/RicSnapshotViewToFileFeature.h
@@ -20,6 +20,8 @@
 
 #include "cafCmdFeature.h"
 
+#include <expected>
+
 class RimPlotWindow;
 class RimViewWindow;
 class QImage;
@@ -32,9 +34,10 @@ class RicSnapshotViewToFileFeature : public caf::CmdFeature
     CAF_CMD_HEADER_INIT;
 
 public:
-    static void saveSnapshotAs( const QString& fileName, RimViewWindow* viewWindow, int width = -1, int height = -1 );
-    static void saveSnapshotAs( const QString& fileName, const QImage& image );
-    static void savePlotPdfReportAs( const QString& fileName, RimPlotWindow* plotWindow );
+    // Returns an error description if no snapshot image could be written to file
+    static std::expected<void, QString> saveSnapshotAs( const QString& fileName, RimViewWindow* viewWindow, int width = -1, int height = -1 );
+    static std::expected<void, QString> saveSnapshotAs( const QString& fileName, const QImage& image );
+    static void                         savePlotPdfReportAs( const QString& fileName, RimPlotWindow* plotWindow );
 
     static void saveViewWindowToFile( RimViewWindow* viewWindow, const QString& defaultFileBaseName = "image" );
     static void saveImageToFile( const QImage& image, const QString& defaultFileBaseName = "image" );

--- a/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Rim3dView.cpp
@@ -73,6 +73,8 @@
 #include "cvfTransform.h"
 #include "cvfViewport.h"
 
+#include <QResizeEvent>
+
 #include <climits>
 
 namespace caf
@@ -537,6 +539,15 @@ QImage Rim3dView::captureSnapshot( int width, int height )
             // adjust for possible display DPI scaling
             const auto ratio = m_viewer->displayScalingRatio();
             m_viewer->layoutWidget()->setFixedSize( (int)( 1.0 * width / ratio ), (int)( 1.0 * height / ratio ) );
+
+            if ( !m_viewer->layoutWidget()->isVisible() )
+            {
+                // Hidden widgets defer resize events (Qt::WA_PendingResizeEvent), so the layout never propagates the
+                // new size to the GL widget. Deliver the resize synchronously so grabFramebuffer() renders at the
+                // requested size when running headless.
+                QResizeEvent resizeEvent( m_viewer->layoutWidget()->size(), orgSize );
+                QCoreApplication::sendEvent( m_viewer->layoutWidget(), &resizeEvent );
+            }
 
             image = m_viewer->snapshotImage();
 

--- a/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimMultiPlot.cpp
@@ -29,11 +29,13 @@
 #include "RiuMultiPlotBook.h"
 #include "RiuPlotMainWindow.h"
 #include "RiuPlotMainWindowTools.h"
+#include "RiuTools.h"
 
 #include "cafPdmFieldReorderCapability.h"
 #include "cafPdmUiComboBoxEditor.h"
 #include "cafPdmUiToolButtonEditor.h"
 
+#include <QApplication>
 #include <QPaintDevice>
 #include <QRegularExpression>
 
@@ -650,7 +652,28 @@ QImage RimMultiPlot::captureSnapshot( int width, int height )
 
     QSize orgViewSize = m_viewer->size();
 
-    image = RimViewWindow::internalCaptureSnapshot( m_dockWidget, m_viewer->bookWidget(), width, height );
+    if ( !m_viewer->isVisible() && width > 0 && height > 0 )
+    {
+        // QWidget::render() used by internalCaptureSnapshot() creates and lays out the whole hidden top level window as
+        // part of the first render, which reverts the plot sizes established below. Use the resolution independent
+        // rendering also used for PDF export instead, based on the page sizes set up by the resize below.
+        m_viewer->setFixedSize( width, height );
+        RiuTools::sendDeferredResizeEvents( m_viewer );
+        QApplication::processEvents();
+        RiuTools::sendDeferredResizeEvents( m_viewer );
+
+        QPixmap pix( width, height );
+        pix.fill( Qt::white );
+        m_viewer->renderTo( &pix );
+        image = pix.toImage();
+
+        m_viewer->setMinimumSize( 0, 0 );
+        m_viewer->setMaximumSize( QWIDGETSIZE_MAX, QWIDGETSIZE_MAX );
+    }
+    else
+    {
+        image = RimViewWindow::internalCaptureSnapshot( m_dockWidget, m_viewer->bookWidget(), width, height );
+    }
 
     m_viewer->resize( orgViewSize );
     doUpdateLayout();

--- a/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimViewWindow.cpp
@@ -28,6 +28,7 @@
 #include "RimDockWindowController.h"
 
 #include "RiuDockWidgetTools.h"
+#include "RiuTools.h"
 
 #include "cafPdmUiTreeAttributes.h"
 
@@ -38,6 +39,7 @@
 #include <QImage>
 #include <QPainter>
 #include <QPixmap>
+#include <QResizeEvent>
 #include <QWidget>
 
 CAF_PDM_XML_ABSTRACT_SOURCE_INIT( RimViewWindow, "ViewWindow" ); // Do not use. Abstract class
@@ -254,15 +256,28 @@ QImage RimViewWindow::internalCaptureSnapshot( ads::CDockWidget* dockWidget, QWi
     if ( shouldResize )
     {
         widget->setFixedSize( width, height );
-
-        // setFixedSize() only posts a deferred resize. If the pending resize is delivered from inside QWidget::render() below, a child
-        // QScrollArea may move its viewport mid-render and crash in Qt's backing-store blit (QWidgetRepaintManager::bltRect).
-        QApplication::processEvents();
     }
     else
     {
         width  = widget->width();
         height = widget->height();
+    }
+
+    if ( !widget->isVisible() )
+    {
+        // Without this, the plot content is rendered at a stale size when running headless. Deliver the events both
+        // before and after processEvents(), as the scheduled plot updates performed by processEvents() may create new
+        // child widgets that have not received their initial resize event yet.
+        RiuTools::sendDeferredResizeEvents( widget );
+        QApplication::processEvents();
+        RiuTools::sendDeferredResizeEvents( widget );
+    }
+
+    if ( shouldResize )
+    {
+        // setFixedSize() only posts a deferred resize. If the pending resize is delivered from inside QWidget::render() below, a child
+        // QScrollArea may move its viewport mid-render and crash in Qt's backing-store blit (QWidgetRepaintManager::bltRect).
+        QApplication::processEvents();
     }
 
     QPixmap pix( width, height );

--- a/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMainWindow.cpp
@@ -1567,7 +1567,11 @@ void RiuMainWindow::slotSnapshotAllViewsToFile()
 
     // Save images in snapshot catalog relative to project directory
     QString absolutePathToSnapshotDir = app->createAbsolutePathFromProjectRelativePath( "snapshots" );
-    RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( absolutePathToSnapshotDir );
+
+    if ( auto result = RicSnapshotAllViewsToFileFeature::exportSnapshotOfViewsIntoFolder( absolutePathToSnapshotDir ); !result )
+    {
+        RiaLogging::error( result.error().toStdString() );
+    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp
+++ b/ApplicationLibCode/UserInterface/RiuMultiPlotPage.cpp
@@ -395,7 +395,9 @@ void RiuMultiPlotPage::renderTo( QPainter* painter, double scalingFactor )
 
     for ( auto subTitle : subTitlesForVisiblePlots() )
     {
-        if ( subTitle->isVisible() )
+        // Use isHidden() instead of isVisible(), as isVisible() is false for all widgets when rendering headless with
+        // hidden windows, while isHidden() only reflects the explicit visibility set for the label
+        if ( !subTitle->isHidden() )
         {
             QPoint renderOffset = m_plotWidgetFrame->mapToParent( subTitle->frameGeometry().topLeft() ) - marginOffset;
             subTitle->render( painter, renderOffset );

--- a/ApplicationLibCode/UserInterface/RiuTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuTools.cpp
@@ -20,8 +20,11 @@
 
 #include "cafPdmUiComboBoxEditor.h"
 
+#include <QCoreApplication>
 #include <QMenu>
 #include <QObject>
+#include <QResizeEvent>
+#include <QWidget>
 
 //--------------------------------------------------------------------------------------------------
 ///
@@ -61,5 +64,29 @@ void RiuTools::enableUpDownArrowsForComboBox( caf::PdmUiEditorAttribute* attribu
         attrib->nextIcon                   = QIcon( ":/ComboBoxDown.svg" );
         attrib->previousIcon               = QIcon( ":/ComboBoxUp.svg" );
         attrib->showPreviousAndNextButtons = true;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Widgets that have never been shown defer their resize events (Qt::WA_PendingResizeEvent), so their layouts have
+/// never been updated. QWidget::show() and QWidget::grab() deliver the deferred events, but QWidget::render() does
+/// not. When running headless with hidden windows, call this before rendering widgets to file to make sure widget
+/// layouts reflect the current widget sizes. Mirrors the static sendResizeEvents() in Qt's qwidget.cpp.
+//--------------------------------------------------------------------------------------------------
+void RiuTools::sendDeferredResizeEvents( QWidget* widget )
+{
+    if ( !widget ) return;
+
+    QResizeEvent resizeEvent( widget->size(), QSize() );
+    QCoreApplication::sendEvent( widget, &resizeEvent );
+    widget->setAttribute( Qt::WA_PendingResizeEvent, false );
+
+    for ( QObject* child : widget->children() )
+    {
+        auto childWidget = qobject_cast<QWidget*>( child );
+        if ( childWidget && !childWidget->isWindow() && childWidget->testAttribute( Qt::WA_PendingResizeEvent ) )
+        {
+            sendDeferredResizeEvents( childWidget );
+        }
     }
 }

--- a/ApplicationLibCode/UserInterface/RiuTools.h
+++ b/ApplicationLibCode/UserInterface/RiuTools.h
@@ -22,6 +22,7 @@
 
 class QMenu;
 class QObject;
+class QWidget;
 
 namespace caf
 {
@@ -33,4 +34,5 @@ namespace RiuTools
 Qt::WindowFlags defaultDialogFlags();
 void            enableAllActionsOnShow( QObject* object, QMenu* menu );
 void            enableUpDownArrowsForComboBox( caf::PdmUiEditorAttribute* attribute );
+void            sendDeferredResizeEvents( QWidget* widget );
 } // end namespace RiuTools

--- a/Fwk/AppFwk/cafViewer/cafViewer.cpp
+++ b/Fwk/AppFwk/cafViewer/cafViewer.cpp
@@ -1228,6 +1228,18 @@ bool caf::Viewer::isShadersSupported()
 //--------------------------------------------------------------------------------------------------
 QImage caf::Viewer::snapshotImage()
 {
+    if ( !isVisible() )
+    {
+        // A widget that has never been shown has not received any resize event, so the internal
+        // framebuffers used for rendering have not been sized (or created at all). The first grab
+        // initializes the OpenGL machinery, and the synthetic resize event delivered afterwards
+        // sizes the framebuffers through resizeGL() before the final grab below.
+        grabFramebuffer();
+
+        QResizeEvent resizeEvent( size(), size() );
+        QCoreApplication::sendEvent( this, &resizeEvent );
+    }
+
     auto image = grabFramebuffer();
 
     // Convert to RGB32 format to avoid visual artifacts related to alpha channel

--- a/Fwk/AppFwk/cafViewer/cafViewer.h
+++ b/Fwk/AppFwk/cafViewer/cafViewer.h
@@ -184,6 +184,9 @@ public:
     // display scaling ratio (should be 1 if DPI scaling is not enabled)
     double displayScalingRatio() const;
 
+    // System to make sure we share OpenGL resources
+    static cvf::OpenGLContextGroup* contextGroup();
+
 public slots:
     virtual void slotSetCurrentFrame( int frameIndex );
     virtual void slotEndAnimation();
@@ -253,8 +256,6 @@ private:
     void                        updateOverlayImagePresence();
 
     // System to make sure we share OpenGL resources
-    static cvf::OpenGLContextGroup* contextGroup();
-
     static cvf::ref<cvf::OpenGLContextGroup> sm_openGLContextGroup;
 
     caf::FrameAnimationControl* m_animationControl;

--- a/GrpcInterface/Python/rips/PythonExamples/export_and_plotting/headless_snapshot_export.py
+++ b/GrpcInterface/Python/rips/PythonExamples/export_and_plotting/headless_snapshot_export.py
@@ -1,0 +1,62 @@
+# Export snapshots of 3D views from a ResInsight instance launched in headless mode.
+#
+# Headless mode hides all windows and uses software OpenGL rendering, so no GPU is required.
+# On Linux a display server is still needed to create the OpenGL context. Launch the bundled
+# 'resinsight' script instead of the 'ResInsight' binary, as the script automatically wraps the
+# application in xvfb-run when no display is available (requires the xvfb package).
+
+import os
+import sys
+
+import rips
+
+# The executable path is used both by rips.Instance.launch() and to locate the bundled TestModels
+resinsight_exe_path = os.environ.get("RESINSIGHT_EXECUTABLE")
+if not resinsight_exe_path:
+    sys.exit(
+        "Set the environment variable RESINSIGHT_EXECUTABLE to the path of the "
+        "ResInsight executable (Linux: the bundled 'resinsight' launcher script)."
+    )
+
+# This requires the TestModels to be installed with ResInsight (RESINSIGHT_BUNDLE_TESTMODELS):
+resinsight_install_path = os.path.dirname(resinsight_exe_path)
+test_models_path = os.path.join(resinsight_install_path, "TestModels")
+path_name = os.path.join(
+    test_models_path, "TEST10K_FLT_LGR_NNC/TEST10K_FLT_LGR_NNC.EGRID"
+)
+if not os.path.isfile(path_name):
+    sys.exit(
+        "Could not find the test model "
+        + path_name
+        + ". This example requires the TestModels to be installed with ResInsight."
+    )
+
+# Launch ResInsight without showing any windows. Raises rips.RipsError on failure.
+resinsight = rips.Instance.launch(command_line_parameters=["--headless"])
+
+case = resinsight.project.load_case(path_name)
+
+# Create a view, as the case is loaded without any views
+view = case.create_view()
+view.apply_cell_result(
+    result_type=rips.PropertyType.DYNAMIC_NATIVE, result_variable="SOIL"
+)
+
+snapshot_folder = os.path.join(os.getcwd(), "snapshots")
+resinsight.set_export_folder(
+    export_type="SNAPSHOTS", path=snapshot_folder, create_folder=True
+)
+
+# Export a snapshot of all 3D views in the project
+resinsight.project.export_snapshots(snapshot_type="VIEWS", width=800, height=600)
+
+exported_files = (
+    sorted(os.listdir(snapshot_folder)) if os.path.isdir(snapshot_folder) else []
+)
+for file_name in exported_files:
+    print("Exported snapshot: " + os.path.join(snapshot_folder, file_name))
+
+resinsight.exit()
+
+if not exported_files:
+    sys.exit("No snapshots were exported to " + snapshot_folder)

--- a/docs/class-diagrams/ResInsightHeadlessSnapshots.txt
+++ b/docs/class-diagrams/ResInsightHeadlessSnapshots.txt
@@ -1,18 +1,33 @@
 
-Investigations on using ResInsight to render plots in a compleatly Headless state
+Headless snapshot export from ResInsight
 
-- Qt 5.8 or higher needed, it seems. Tested with Qt 5.14.1. Tested with Qt 5.6.1 on CentOS 6 and the plots was rendered without fonts.
-- Start ResInsight with the additional options -platform offscreen
-- The project can not contain visible 3D views. If it does, ResInsight will crash
-- Might add -stylesheet <path to stylesheet definition file> to explicitly control fonts
-  example contents of stylesheets file:
-  
-	* { font: bold italic large "Times New Roman" }
-	
-  The "*" might be substituted with specific classes or widgets.
-  It seems as the Qwt plot axis-titles are not affected by the stylesheet set above
-  
+ResInsight can run without showing any windows and export snapshots of both 3D views and plots
+using the --headless command line option. Software OpenGL rendering is used, so no GPU is required.
+
 - Example command line:
 
-  ./ResInsight --project FPPLot.rsp --savesnapshots all --snapshotsize 500 500 -stylesheet stylesheet.txt -platform offscreen
-  
+  ResInsight --headless --project MyProject.rsp --savesnapshots all --snapshotsize 1000 745 --snapshotfolder snapshots
+
+  The application exits after the snapshots have been written.
+
+- Windows: software OpenGL is provided by opengl32sw.dll (Mesa llvmpipe), which is deployed
+  alongside ResInsight.exe by windeployqt.
+
+- Linux: LIBGL_ALWAYS_SOFTWARE=1 is set automatically, using the system Mesa llvmpipe driver.
+  A display server is still required by Qt to create OpenGL contexts. On a machine without a
+  display server, run under xvfb:
+
+  xvfb-run -a ./ResInsight --headless --project MyProject.rsp --savesnapshots all
+
+- To verify that the software renderer was used, check the log for a line like:
+  "OpenGL used for snapshots: ... Mesa ... llvmpipe ..."
+
+- The older approach of using the Qt platform plugin option "-platform offscreen" (single dash)
+  still works for projects containing only plots, but fails to render 3D views, as the offscreen
+  plugin cannot create an OpenGL context. No image is written for those views, and the run exits
+  with a non-zero exit code. The reason is written to the log file in ~/.resinsight/logs, as the
+  logging to stdout is only enabled by --headless. Prefer --headless, which handles both plots and
+  3D views. When using -platform offscreen, fonts can be controlled with -stylesheet <path to
+  stylesheet definition file>, e.g.:
+
+	* { font: bold italic large "Times New Roman" }

--- a/docs/class-diagrams/ResInsightHeadlessSnapshots.txt
+++ b/docs/class-diagrams/ResInsightHeadlessSnapshots.txt
@@ -14,8 +14,13 @@ using the --headless command line option. Software OpenGL rendering is used, so 
   alongside ResInsight.exe by windeployqt.
 
 - Linux: LIBGL_ALWAYS_SOFTWARE=1 is set automatically, using the system Mesa llvmpipe driver.
-  A display server is still required by Qt to create OpenGL contexts. On a machine without a
-  display server, run under xvfb:
+  A display server is still required by Qt to create OpenGL contexts. The bundled launcher script
+  detects this: when DISPLAY is not set and --headless is given, it automatically wraps the
+  application in xvfb-run (requires the xvfb package):
+
+  ./resinsight --headless --project MyProject.rsp --savesnapshots all
+
+  When starting the ResInsight binary directly without a display server, run under xvfb manually:
 
   xvfb-run -a ./ResInsight --headless --project MyProject.rsp --savesnapshots all
 


### PR DESCRIPTION
Adds a headless mode so 3D view snapshots can be exported from a batch run without a display server, using a software OpenGL rasterizer.

## Changes

- **Headless mode with software OpenGL rendering** — new command line handling and rendering setup that lets `--savesnapshots` produce 3D view images without a GPU or display.
- **Setup moved to `RiaMainTools`** — the headless rendering configuration was lifted out of `RiaMain.cpp` so it lives with the rest of the application startup helpers.
- **Log to stdout in headless mode** — the message panels are never shown headless, so `RiaLogging` output had nowhere to go. A `RiaStdOutLogger` is now appended when running headless, following the pattern already used for regression tests.
- **Non-zero exit code on failed snapshot export** — a 3D view snapshot yields a null image when no valid OpenGL context is available. This was silently ignored, so a batch run could write no images and still exit 0, hiding failures from CI. The snapshot export functions now return `std::expected`, log why a snapshot could not be created, and `--savesnapshots` exits with an error code if any requested snapshot is missing. The statistics image is empty unless the statistics dialog has been shown, so it is only exported when present.

Closes #1015

## Notes

Verified on Linux (Ubuntu 24.04, Qt 6.11, Mesa 25.2.8 llvmpipe): snapshots render correctly under `xvfb-run`, the 3D view PNG is byte-identical to a non-headless run, failures now exit non-zero, and all 929 unit tests pass. Details in https://github.com/magnesj/ResInsight/issues/1015#issuecomment-5078800176

This is a re-open of #1017, which was merged but is no longer contained in `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

