### PR TITLE
#14344 Update ensemble grid model views on polygon import

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -66,6 +66,8 @@ jobs:
       BUILD_TYPE: Release
       BUILDCACHE_DIR: ${{ github.workspace }}/buildcache_dir
       BUILDCACHE_ACCURACY: SLOPPY
+      # 500 MB, in bytes
+      BUILDCACHE_MAX_CACHE_SIZE: 524288000
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       # Supply-chain hardening: never install Python packages published within
       # the last week, to avoid pulling freshly published (potentially
@@ -120,12 +122,15 @@ jobs:
       - name: Print time stamp
         run: echo "timestamp ${{ steps.current-time.outputs.formattedTime }}"
 
-      - name: Cache Buildcache
+      - name: Restore Buildcache
         id: cache-buildcache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.BUILDCACHE_DIR }}
           key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-${{ steps.current-time.outputs.formattedTime }}
+          # Fall back to the most recent cache for this configuration if no
+          # cache exists for the current date
+          restore-keys: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-
       - name: Create Folder for buildcache
         run: New-Item ${{ env.BUILDCACHE_DIR }} -ItemType "directory" -Force
         shell: pwsh
@@ -265,6 +270,16 @@ jobs:
 
       - name: Stats for buildcache
         run: buildcache -s
+
+      - name: Save Buildcache
+        # Save the cache with the current date, unless a cache for the current
+        # date was already restored (cache keys are immutable and cannot be
+        # overwritten)
+        if: steps.cache-buildcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.BUILDCACHE_DIR }}
+          key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-${{ steps.current-time.outputs.formattedTime }}
 
       - name: Run Unit Tests
         if: matrix.config.execute-unit-tests

--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp
@@ -252,6 +252,9 @@ std::pair<std::vector<time_t>, std::vector<double>>
                                                const std::vector<double>&                 values,
                                                RiaDefines::DateTimePeriod                 period )
 {
+    // The resampler requires a valid period and non-empty data, return input data unchanged
+    if ( period == RiaDefines::DateTimePeriod::NONE || timeSteps.empty() || values.empty() ) return { timeSteps, values };
+
     RiaTimeHistoryCurveResampler resampler;
     resampler.setCurveData( values, timeSteps );
 

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -439,8 +439,13 @@ void RimWellAllocationPlot::updateFromWell()
     QString wellStatusText = QString( "(%1)" ).arg( RimWellAllocationPlot::wellStatusTextForTimeStep( m_wellName, m_case, m_timeStep ) );
 
     QString flowTypeText = m_flowDiagSolution() ? "Well Allocation" : "Well Flow";
-    setDescription( flowTypeText + ": " + m_wellName + " " + wellStatusText + ", " + m_case->timeStepStrings()[m_timeStep] + " (" +
-                    m_case->caseUserDescription() + ")" );
+
+    // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
+    const QStringList timeStepNames = m_case->timeStepStrings();
+    QString           timeStepText;
+    if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) timeStepText = timeStepNames[m_timeStep];
+
+    setDescription( flowTypeText + ": " + m_wellName + " " + wellStatusText + ", " + timeStepText + " (" + m_case->caseUserDescription() + ")" );
 
     /// Pie chart
 

--- a/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
@@ -465,7 +465,11 @@ QString RimGridCrossPlotDataSet::timeStepString() const
             {
                 return "All Time Steps";
             }
-            return m_case->timeStepStrings()[m_timeStep];
+
+            // The stored time step can be out of range if the data set has been switched to a case with fewer time steps
+            const QStringList timeStepNames = m_case->timeStepStrings();
+            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
+            return "";
         }
     }
     return "";

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
@@ -253,7 +253,10 @@ std::string RimGridStatisticsHistogramDataSource::name() const
         if ( m_case() && m_property->hasDynamicResult() )
         {
             if ( m_timeStep == -1 ) return "All Time Steps";
-            return m_case->timeStepStrings()[m_timeStep];
+
+            // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
+            const QStringList timeStepNames = m_case->timeStepStrings();
+            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
         }
 
         return "";

--- a/ApplicationLibCode/ProjectDataModel/RimProject.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimProject.cpp
@@ -892,6 +892,16 @@ std::vector<Rim3dView*> RimProject::allViews() const
                     views.push_back( view );
                 }
             }
+
+            for ( auto gridEnsemble : oilField->analysisModels()->reservoirGridEnsembles.childrenByType() )
+            {
+                if ( !gridEnsemble ) continue;
+
+                for ( auto view : gridEnsemble->allViews() )
+                {
+                    views.push_back( view );
+                }
+            }
         }
     }
 

--- a/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
+++ b/ApplicationLibCode/ProjectDataModel/RimReservoirGridEnsemble.cpp
@@ -503,20 +503,30 @@ std::vector<RimEclipseView*> RimReservoirGridEnsemble::allViews() const
 {
     std::vector<RimEclipseView*> views;
 
-    for ( auto view : m_viewCollection->views() )
-    {
-        views.push_back( view );
-    }
+    // Use childrenByType() and null checks here, as this function can be called while child objects
+    // are being deleted during project close. PdmPointer entries in the child array fields are
+    // nulled one by one as the objects are destroyed.
 
-    for ( auto statCase : m_statisticsCaseCollection->reservoirs() )
+    if ( m_viewCollection )
     {
-        for ( auto view : statCase->reservoirViews() )
+        for ( auto view : m_viewCollection->views() )
         {
             views.push_back( view );
         }
     }
 
-    for ( auto cmap : m_statisticsContourMaps )
+    if ( m_statisticsCaseCollection )
+    {
+        for ( auto statCase : m_statisticsCaseCollection->reservoirs.childrenByType() )
+        {
+            for ( auto view : statCase->reservoirViews() )
+            {
+                views.push_back( view );
+            }
+        }
+    }
+
+    for ( auto cmap : m_statisticsContourMaps.childrenByType() )
     {
         for ( auto view : cmap->views() )
         {


### PR DESCRIPTION
Fixes OPM/ResInsight#14344

## Changes

**RimProject::allViews()**: Include views from reservoir grid ensembles (ensemble view collection, statistics case views, and statistics contour map views). Previously these views were not part of the project view traversal, so importing a polygon (or surface) did not update the Project Tree items or schedule a redraw for ensemble grid model views until a manual 3D view update was triggered.

**RimReservoirGridEnsemble::allViews()**: Iterate child array fields with childrenByType() and add null guards. This function can now be called re-entrantly during project close (a dying view triggers a command enabled-state refresh via RiuMainWindow::onViewerRemoved), and direct range-for iteration over the child array fields yields entries that are nulled one by one during deleteChildren(), causing an access violation when dereferenced. This mirrors the existing null-safe pattern in RimEclipseCaseEnsemble::allViews().