### PR TITLE
#14343 Add context menu for toggling selected cases in ensemble import dialog

### DIFF
--- a/.github/workflows/ResInsightWithCache.yml
+++ b/.github/workflows/ResInsightWithCache.yml
@@ -66,6 +66,8 @@ jobs:
       BUILD_TYPE: Release
       BUILDCACHE_DIR: ${{ github.workspace }}/buildcache_dir
       BUILDCACHE_ACCURACY: SLOPPY
+      # 500 MB, in bytes
+      BUILDCACHE_MAX_CACHE_SIZE: 524288000
       VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       # Supply-chain hardening: never install Python packages published within
       # the last week, to avoid pulling freshly published (potentially
@@ -120,12 +122,15 @@ jobs:
       - name: Print time stamp
         run: echo "timestamp ${{ steps.current-time.outputs.formattedTime }}"
 
-      - name: Cache Buildcache
+      - name: Restore Buildcache
         id: cache-buildcache
-        uses: actions/cache@v6
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.BUILDCACHE_DIR }}
           key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-${{ steps.current-time.outputs.formattedTime }}
+          # Fall back to the most recent cache for this configuration if no
+          # cache exists for the current date
+          restore-keys: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-
       - name: Create Folder for buildcache
         run: New-Item ${{ env.BUILDCACHE_DIR }} -ItemType "directory" -Force
         shell: pwsh
@@ -265,6 +270,16 @@ jobs:
 
       - name: Stats for buildcache
         run: buildcache -s
+
+      - name: Save Buildcache
+        # Save the cache with the current date, unless a cache for the current
+        # date was already restored (cache keys are immutable and cannot be
+        # overwritten)
+        if: steps.cache-buildcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ env.BUILDCACHE_DIR }}
+          key: ${{ matrix.config.os }}-${{ matrix.config.cc }}-${{ matrix.config.qt-version }}-cache-v03-${{ steps.current-time.outputs.formattedTime }}
 
       - name: Run Unit Tests
         if: matrix.config.execute-unit-tests

--- a/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp
+++ b/ApplicationLibCode/Application/Tools/Summary/RiaSummaryTools.cpp
@@ -252,6 +252,9 @@ std::pair<std::vector<time_t>, std::vector<double>>
                                                const std::vector<double>&                 values,
                                                RiaDefines::DateTimePeriod                 period )
 {
+    // The resampler requires a valid period and non-empty data, return input data unchanged
+    if ( period == RiaDefines::DateTimePeriod::NONE || timeSteps.empty() || values.empty() ) return { timeSteps, values };
+
     RiaTimeHistoryCurveResampler resampler;
     resampler.setCurveData( values, timeSteps );
 

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
@@ -33,9 +33,7 @@
 
 #include "cafAppEnum.h"
 
-#include <QApplication>
 #include <QCheckBox>
-#include <QClipboard>
 #include <QCollator>
 #include <QComboBox>
 #include <QDialogButtonBox>
@@ -849,11 +847,6 @@ void RicImportGridAndSummaryEnsembleDialog::slotFileListCustomMenuRequested( con
     QMenu    menu;
     QAction* action;
 
-    action = new QAction( QIcon( ":/Copy.svg" ), "&Copy", this );
-    connect( action, SIGNAL( triggered() ), SLOT( slotCopyFileItemText() ) );
-    menu.addAction( action );
-    menu.addSeparator();
-
     action = new QAction( "On", this );
     connect( action, SIGNAL( triggered() ), SLOT( slotTurnOnFileListItems() ) );
     menu.addAction( action );
@@ -868,22 +861,6 @@ void RicImportGridAndSummaryEnsembleDialog::slotFileListCustomMenuRequested( con
 
     QPoint globalPoint = m_fileTreeView->mapToGlobal( point );
     menu.exec( globalPoint );
-}
-
-//--------------------------------------------------------------------------------------------------
-///
-//--------------------------------------------------------------------------------------------------
-void RicImportGridAndSummaryEnsembleDialog::slotCopyFileItemText()
-{
-    auto index = m_fileTreeView->currentIndex();
-    if ( index.isValid() )
-    {
-        auto item = m_filePathModel.itemFromIndex( index );
-        if ( item )
-        {
-            QApplication::clipboard()->setText( item->text() );
-        }
-    }
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.cpp
@@ -33,7 +33,9 @@
 
 #include "cafAppEnum.h"
 
+#include <QApplication>
 #include <QCheckBox>
+#include <QClipboard>
 #include <QCollator>
 #include <QComboBox>
 #include <QDialogButtonBox>
@@ -44,6 +46,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QMenu>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QRegularExpression>
@@ -248,6 +251,10 @@ RicImportGridAndSummaryEnsembleDialog::RicImportGridAndSummaryEnsembleDialog( QW
     connect( m_createGridEnsembleCheckBox, &QCheckBox::toggled, this, updateOkFromCheckboxes );
     connect( m_createSummaryEnsembleCheckBox, &QCheckBox::toggled, this, updateOkFromCheckboxes );
     connect( m_treeFilterButton, SIGNAL( clicked() ), this, SLOT( slotFilterTreeViewClicked() ) );
+    connect( m_fileTreeView,
+             SIGNAL( customContextMenuRequested( const QPoint& ) ),
+             this,
+             SLOT( slotFileListCustomMenuRequested( const QPoint& ) ) );
     connect( m_treeFilterLineEdit, &QLineEdit::returnPressed, m_treeFilterButton, &QPushButton::click );
     connect( m_treeFilterLineEdit, &QLineEdit::textEdited, m_treeFilterButton, &QPushButton::click );
 
@@ -829,6 +836,111 @@ void RicImportGridAndSummaryEnsembleDialog::slotFilterTreeViewClicked()
                 {
                     matchedItem->setCheckState( Qt::Checked );
                 }
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotFileListCustomMenuRequested( const QPoint& point )
+{
+    QMenu    menu;
+    QAction* action;
+
+    action = new QAction( QIcon( ":/Copy.svg" ), "&Copy", this );
+    connect( action, SIGNAL( triggered() ), SLOT( slotCopyFileItemText() ) );
+    menu.addAction( action );
+    menu.addSeparator();
+
+    action = new QAction( "On", this );
+    connect( action, SIGNAL( triggered() ), SLOT( slotTurnOnFileListItems() ) );
+    menu.addAction( action );
+
+    action = new QAction( "Off", this );
+    connect( action, SIGNAL( triggered() ), SLOT( slotTurnOffFileListItems() ) );
+    menu.addAction( action );
+
+    action = new QAction( "Toggle", this );
+    connect( action, SIGNAL( triggered() ), SLOT( slotToggleFileListItems() ) );
+    menu.addAction( action );
+
+    QPoint globalPoint = m_fileTreeView->mapToGlobal( point );
+    menu.exec( globalPoint );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotCopyFileItemText()
+{
+    auto index = m_fileTreeView->currentIndex();
+    if ( index.isValid() )
+    {
+        auto item = m_filePathModel.itemFromIndex( index );
+        if ( item )
+        {
+            QApplication::clipboard()->setText( item->text() );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotTurnOnFileListItems()
+{
+    auto selectionModel = m_fileTreeView->selectionModel();
+    auto indices        = selectionModel->selectedIndexes();
+    for ( auto& index : indices )
+    {
+        if ( index.isValid() )
+        {
+            auto item = m_filePathModel.itemFromIndex( index );
+            if ( item && item->isCheckable() )
+            {
+                item->setCheckState( Qt::Checked );
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotTurnOffFileListItems()
+{
+    auto selectionModel = m_fileTreeView->selectionModel();
+    auto indices        = selectionModel->selectedIndexes();
+    for ( auto& index : indices )
+    {
+        if ( index.isValid() )
+        {
+            auto item = m_filePathModel.itemFromIndex( index );
+            if ( item && item->isCheckable() )
+            {
+                item->setCheckState( Qt::Unchecked );
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RicImportGridAndSummaryEnsembleDialog::slotToggleFileListItems()
+{
+    auto selectionModel = m_fileTreeView->selectionModel();
+    auto indices        = selectionModel->selectedIndexes();
+    for ( auto& index : indices )
+    {
+        if ( index.isValid() )
+        {
+            auto item = m_filePathModel.itemFromIndex( index );
+            if ( item && item->isCheckable() )
+            {
+                item->setCheckState( item->checkState() == Qt::Checked ? Qt::Unchecked : Qt::Checked );
             }
         }
     }

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.h
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.h
@@ -84,7 +84,6 @@ private slots:
     void slotSearchClicked();
     void slotFilterTreeViewClicked();
     void slotFileListCustomMenuRequested( const QPoint& point );
-    void slotCopyFileItemText();
     void slotTurnOnFileListItems();
     void slotTurnOffFileListItems();
     void slotToggleFileListItems();

--- a/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.h
+++ b/ApplicationLibCode/Commands/RicImportGridAndSummaryEnsembleDialog.h
@@ -83,6 +83,11 @@ private slots:
     void slotUseRealizationStarClicked();
     void slotSearchClicked();
     void slotFilterTreeViewClicked();
+    void slotFileListCustomMenuRequested( const QPoint& point );
+    void slotCopyFileItemText();
+    void slotTurnOnFileListItems();
+    void slotTurnOffFileListItems();
+    void slotToggleFileListItems();
     void slotOkClicked();
     void slotCancelClicked();
     void showEvent( QShowEvent* event ) override;

--- a/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Flow/RimWellAllocationPlot.cpp
@@ -439,8 +439,13 @@ void RimWellAllocationPlot::updateFromWell()
     QString wellStatusText = QString( "(%1)" ).arg( RimWellAllocationPlot::wellStatusTextForTimeStep( m_wellName, m_case, m_timeStep ) );
 
     QString flowTypeText = m_flowDiagSolution() ? "Well Allocation" : "Well Flow";
-    setDescription( flowTypeText + ": " + m_wellName + " " + wellStatusText + ", " + m_case->timeStepStrings()[m_timeStep] + " (" +
-                    m_case->caseUserDescription() + ")" );
+
+    // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
+    const QStringList timeStepNames = m_case->timeStepStrings();
+    QString           timeStepText;
+    if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) timeStepText = timeStepNames[m_timeStep];
+
+    setDescription( flowTypeText + ": " + m_wellName + " " + wellStatusText + ", " + timeStepText + " (" + m_case->caseUserDescription() + ")" );
 
     /// Pie chart
 

--- a/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
+++ b/ApplicationLibCode/ProjectDataModel/GridCrossPlots/RimGridCrossPlotDataSet.cpp
@@ -465,7 +465,11 @@ QString RimGridCrossPlotDataSet::timeStepString() const
             {
                 return "All Time Steps";
             }
-            return m_case->timeStepStrings()[m_timeStep];
+
+            // The stored time step can be out of range if the data set has been switched to a case with fewer time steps
+            const QStringList timeStepNames = m_case->timeStepStrings();
+            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
+            return "";
         }
     }
     return "";

--- a/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Histogram/RimGridStatisticsHistogramDataSource.cpp
@@ -253,7 +253,10 @@ std::string RimGridStatisticsHistogramDataSource::name() const
         if ( m_case() && m_property->hasDynamicResult() )
         {
             if ( m_timeStep == -1 ) return "All Time Steps";
-            return m_case->timeStepStrings()[m_timeStep];
+
+            // The stored time step can be out of range if the case has been replaced by a case with fewer time steps
+            const QStringList timeStepNames = m_case->timeStepStrings();
+            if ( m_timeStep() >= 0 && m_timeStep() < timeStepNames.size() ) return timeStepNames[m_timeStep];
         }
 
         return "";


### PR DESCRIPTION
Fixes OPM/ResInsight#14343

The file tree in the "Import Grid and Summary Ensemble" dialog set `Qt::CustomContextMenu` as context menu policy, but the `customContextMenuRequested` signal was never connected, so right-clicking selected realizations did nothing.

Add the same context menu as in `RicRecursiveFileSearchDialog` with On, Off, and Toggle actions operating on the selected items.