### PR TITLE
#14411 Enforce name uniqueness for surfaces, polygons and folders

### DIFF
--- a/ApplicationLibCode/Application/RiaDefines.cpp
+++ b/ApplicationLibCode/Application/RiaDefines.cpp
@@ -179,6 +179,15 @@ void caf::AppEnum<RiaDefines::RowCount>::setUp()
     setDefault( RiaDefines::RowCount::ROWS_2 );
 }
 
+template <>
+void caf::AppEnum<RiaDefines::NameConflictPolicy>::setUp()
+{
+    addItem( RiaDefines::NameConflictPolicy::FAIL, "FAIL", "Fail" );
+    addItem( RiaDefines::NameConflictPolicy::AUTO_RENAME, "AUTO_RENAME", "Auto Rename" );
+    addItem( RiaDefines::NameConflictPolicy::OVERWRITE, "OVERWRITE", "Overwrite" );
+    setDefault( RiaDefines::NameConflictPolicy::FAIL );
+}
+
 } // namespace caf
 
 namespace
@@ -192,6 +201,7 @@ struct RegisterScriptEnumNames
     {
         caf::PdmScriptEnumNameRegistry::registerName<RiaDefines::ResultCatType>( "PropertyType" );
         caf::PdmScriptEnumNameRegistry::registerName<RiaDefines::PorosityModelType>( "PorosityModelType" );
+        caf::PdmScriptEnumNameRegistry::registerName<RiaDefines::NameConflictPolicy>( "NameConflictPolicy" );
     }
 };
 const RegisterScriptEnumNames s_registerScriptEnumNames;

--- a/ApplicationLibCode/Application/RiaDefines.h
+++ b/ApplicationLibCode/Application/RiaDefines.h
@@ -211,6 +211,15 @@ enum class WellProductionType : short
 
 bool isInjector( WellProductionType wellProductionType );
 
+// How to handle a new item colliding with the name of an existing item in the same folder.
+// Used by the Python/gRPC API, where no user is present to resolve the conflict interactively.
+enum class NameConflictPolicy
+{
+    FAIL, // Abort the operation and report an error
+    AUTO_RENAME, // Append a numeric suffix to make the name unique
+    OVERWRITE // Delete the existing item carrying the name
+};
+
 QString stringListSeparator();
 
 enum class ColumnCount

--- a/ApplicationLibCode/Application/Tools/CMakeLists_files.cmake
+++ b/ApplicationLibCode/Application/Tools/CMakeLists_files.cmake
@@ -36,6 +36,7 @@ set(SOURCE_GROUP_HEADER_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaWeightedMeanCalculator.inl
     ${CMAKE_CURRENT_LIST_DIR}/RiaWeightedGeometricMeanCalculator.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaWeightedHarmonicMeanCalculator.h
+    ${CMAKE_CURRENT_LIST_DIR}/RiaNameUniquenessTools.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaOptionItemFactory.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaGitDiff.h
     ${CMAKE_CURRENT_LIST_DIR}/RiaWslTools.h
@@ -94,6 +95,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiaTimeHistoryCurveResampler.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaWeightedGeometricMeanCalculator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaWeightedHarmonicMeanCalculator.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiaNameUniquenessTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaOptionItemFactory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaGitDiff.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaWslTools.cpp

--- a/ApplicationLibCode/Application/Tools/RiaNameUniquenessTools.cpp
+++ b/ApplicationLibCode/Application/Tools/RiaNameUniquenessTools.cpp
@@ -1,0 +1,244 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RiaNameUniquenessTools.h"
+
+#include "RimNamedObject.h"
+#include "RimSurface.h"
+
+#include "cafPdmChildArrayField.h"
+#include "cafPdmNestedCollectionBase.h"
+#include "cafPdmObjectHandle.h"
+#include "cafPdmUiObjectHandle.h"
+#include "cafPdmValueField.h"
+
+#include <QVariant>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RiaNameUniquenessTools::objectName( const caf::PdmObjectHandle* object )
+{
+    if ( !object ) return {};
+
+    auto* mutableObject = const_cast<caf::PdmObjectHandle*>( object );
+
+    if ( auto* surface = dynamic_cast<RimSurface*>( mutableObject ) ) return surface->userDescription();
+    if ( auto* namedObject = dynamic_cast<RimNamedObject*>( mutableObject ) ) return namedObject->name();
+    if ( auto* collection = dynamic_cast<caf::PdmNestedCollectionBase*>( mutableObject ) ) return collection->collectionName();
+
+    if ( auto* uiObjectHandle = caf::uiObj( object ) )
+    {
+        if ( auto* valueField = dynamic_cast<caf::PdmValueField*>( uiObjectHandle->userDescriptionField() ) )
+        {
+            return valueField->toQVariant().toString();
+        }
+    }
+
+    return {};
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiaNameUniquenessTools::setObjectName( caf::PdmObjectHandle* object, const QString& name )
+{
+    if ( !object ) return;
+
+    if ( auto* surface = dynamic_cast<RimSurface*>( object ) )
+    {
+        surface->setUserDescription( name );
+        return;
+    }
+
+    if ( auto* namedObject = dynamic_cast<RimNamedObject*>( object ) )
+    {
+        namedObject->setName( name );
+        return;
+    }
+
+    if ( auto* collection = dynamic_cast<caf::PdmNestedCollectionBase*>( object ) )
+    {
+        collection->setCollectionName( name );
+        return;
+    }
+
+    if ( auto* uiObjectHandle = caf::uiObj( object ) )
+    {
+        if ( auto* valueField = dynamic_cast<caf::PdmValueField*>( uiObjectHandle->userDescriptionField() ) )
+        {
+            valueField->setFromQVariant( name );
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::set<QString> RiaNameUniquenessTools::namesInCollection( const caf::PdmChildArrayFieldHandle* childArrayField,
+                                                             const caf::PdmObjectHandle*          objectToExclude )
+{
+    std::set<QString> names;
+    if ( !childArrayField ) return names;
+
+    auto* mutableField = const_cast<caf::PdmChildArrayFieldHandle*>( childArrayField );
+    for ( size_t i = 0; i < mutableField->size(); i++ )
+    {
+        auto* child = mutableField->at( i );
+        if ( !child || child == objectToExclude ) continue;
+
+        names.insert( objectName( child ) );
+    }
+
+    return names;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::set<QString> RiaNameUniquenessTools::siblingNames( const caf::PdmObjectHandle* object )
+{
+    if ( !object ) return {};
+
+    auto* childArrayField = dynamic_cast<caf::PdmChildArrayFieldHandle*>( object->parentField() );
+    if ( !childArrayField ) return {};
+
+    return namesInCollection( childArrayField, object );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RiaNameUniquenessTools::makeUnique( const QString& candidateName, const std::set<QString>& takenNames )
+{
+    // An empty name means the object has no name of its own, and derives its tree label from
+    // other properties (a grid case surface is labelled from its case and K index). Numbering
+    // those would only produce labels like "_1 - K:3".
+    if ( candidateName.isEmpty() ) return candidateName;
+
+    if ( !takenNames.contains( candidateName ) ) return candidateName;
+
+    int     counter = 1;
+    QString uniqueName;
+    do
+    {
+        uniqueName = QString( "%1_%2" ).arg( candidateName ).arg( counter++ );
+    } while ( takenNames.contains( uniqueName ) );
+
+    return uniqueName;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RiaNameUniquenessTools::isUniqueAmongSiblings( const caf::PdmObjectHandle* object, const QString& candidateName )
+{
+    if ( candidateName.isEmpty() ) return true;
+
+    return !siblingNames( object ).contains( candidateName );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RiaNameUniquenessTools::makeUniqueAmongSiblings( const caf::PdmObjectHandle* object, const QString& candidateName )
+{
+    return makeUnique( candidateName, siblingNames( object ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RiaNameUniquenessTools::ensureUniqueAmongSiblings( caf::PdmObjectHandle* object )
+{
+    const QString currentName = objectName( object );
+    const QString uniqueName  = makeUniqueAmongSiblings( object, currentName );
+
+    if ( uniqueName != currentName ) setObjectName( object, uniqueName );
+
+    return uniqueName;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+bool RiaNameUniquenessTools::isUniqueInCollection( const caf::PdmChildArrayFieldHandle* childArrayField, const QString& candidateName )
+{
+    if ( candidateName.isEmpty() ) return true;
+
+    return !namesInCollection( childArrayField ).contains( candidateName );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+QString RiaNameUniquenessTools::makeUniqueInCollection( const caf::PdmChildArrayFieldHandle* childArrayField, const QString& candidateName )
+{
+    return makeUnique( candidateName, namesInCollection( childArrayField ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+caf::PdmObjectHandle* RiaNameUniquenessTools::findInCollection( const caf::PdmChildArrayFieldHandle* childArrayField, const QString& name )
+{
+    if ( !childArrayField ) return nullptr;
+
+    auto* mutableField = const_cast<caf::PdmChildArrayFieldHandle*>( childArrayField );
+    for ( size_t i = 0; i < mutableField->size(); i++ )
+    {
+        auto* child = mutableField->at( i );
+        if ( child && objectName( child ) == name ) return child;
+    }
+
+    return nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+RiaNameUniquenessTools::ConflictResolution RiaNameUniquenessTools::applyConflictPolicy( const caf::PdmChildArrayFieldHandle* childArrayField,
+                                                                                        const QString&                 candidateName,
+                                                                                        RiaDefines::NameConflictPolicy policy )
+{
+    ConflictResolution resolution;
+    resolution.nameToUse = candidateName;
+
+    if ( candidateName.isEmpty() ) return resolution;
+
+    auto* existingObject = findInCollection( childArrayField, candidateName );
+    if ( !existingObject ) return resolution;
+
+    switch ( policy )
+    {
+        case RiaDefines::NameConflictPolicy::AUTO_RENAME:
+            resolution.nameToUse = makeUniqueInCollection( childArrayField, candidateName );
+            break;
+
+        case RiaDefines::NameConflictPolicy::OVERWRITE:
+            resolution.objectToReplace = existingObject;
+            break;
+
+        case RiaDefines::NameConflictPolicy::FAIL:
+        default:
+            resolution.errorMessage = QString( "An item named '%1' already exists in this folder" ).arg( candidateName );
+            break;
+    }
+
+    return resolution;
+}

--- a/ApplicationLibCode/Application/Tools/RiaNameUniquenessTools.h
+++ b/ApplicationLibCode/Application/Tools/RiaNameUniquenessTools.h
@@ -1,0 +1,96 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RiaDefines.h"
+
+#include <QString>
+
+#include <set>
+
+namespace caf
+{
+class PdmChildArrayFieldHandle;
+class PdmObjectHandle;
+} // namespace caf
+
+//==================================================================================================
+///
+/// Helpers used to keep names unique among siblings in the project tree.
+///
+/// Siblings are the objects held by the same caf::PdmChildArrayField. Items and folders live in
+/// two distinct child arrays (m_items and m_subCollections in caf::PdmNestedCollection), so a
+/// folder and an item may carry the same name under the same parent. Names in different folders
+/// never conflict.
+///
+/// All comparison is case sensitive.
+///
+//==================================================================================================
+namespace RiaNameUniquenessTools
+{
+// Name of an object as shown in the project tree. Knows about the name field of surfaces,
+// named objects and nested collections, and falls back to the user description field.
+QString objectName( const caf::PdmObjectHandle* object );
+void    setObjectName( caf::PdmObjectHandle* object, const QString& name );
+
+// Names of the objects in a child array field, optionally excluding one object.
+std::set<QString> namesInCollection( const caf::PdmChildArrayFieldHandle* childArrayField,
+                                     const caf::PdmObjectHandle*          objectToExclude = nullptr );
+
+// Names used by the other objects in the child array field holding this object.
+std::set<QString> siblingNames( const caf::PdmObjectHandle* object );
+
+// Appends _1, _2, ... to candidateName until the result is not present in takenNames.
+QString makeUnique( const QString& candidateName, const std::set<QString>& takenNames );
+
+bool    isUniqueAmongSiblings( const caf::PdmObjectHandle* object, const QString& candidateName );
+QString makeUniqueAmongSiblings( const caf::PdmObjectHandle* object, const QString& candidateName );
+
+// Renames the object if one of its siblings already carries the same name. The object must
+// already be inserted into its parent collection. Returns the name in effect after the call.
+QString ensureUniqueAmongSiblings( caf::PdmObjectHandle* object );
+
+// For objects not yet inserted into a parent collection.
+bool    isUniqueInCollection( const caf::PdmChildArrayFieldHandle* childArrayField, const QString& candidateName );
+QString makeUniqueInCollection( const caf::PdmChildArrayFieldHandle* childArrayField, const QString& candidateName );
+
+// The object in the child array field carrying this exact name, or nullptr.
+caf::PdmObjectHandle* findInCollection( const caf::PdmChildArrayFieldHandle* childArrayField, const QString& name );
+
+//==================================================================================================
+/// Outcome of applying a name conflict policy. Exactly one of the three states applies:
+///  - errorMessage set     : the policy is FAIL and the name is taken, abort the operation
+///  - objectToReplace set  : the policy is OVERWRITE, the caller must delete this object
+///  - neither set          : use nameToUse, which is unique
+//==================================================================================================
+struct ConflictResolution
+{
+    QString               nameToUse;
+    caf::PdmObjectHandle* objectToReplace = nullptr;
+    QString               errorMessage;
+};
+
+// Resolves a name conflict for a name about to be used in childArrayField. Deleting the object
+// to replace is left to the caller, as the removal must go through the owning collection to keep
+// views and referring objects in sync.
+ConflictResolution applyConflictPolicy( const caf::PdmChildArrayFieldHandle* childArrayField,
+                                        const QString&                       candidateName,
+                                        RiaDefines::NameConflictPolicy       policy );
+
+}; // namespace RiaNameUniquenessTools

--- a/ApplicationLibCode/Commands/RicNewNestedCollectionFeature.cpp
+++ b/ApplicationLibCode/Commands/RicNewNestedCollectionFeature.cpp
@@ -18,6 +18,8 @@
 
 #include "RicNewNestedCollectionFeature.h"
 
+#include "RiaNameUniquenessTools.h"
+
 #include "Riu3DMainWindowTools.h"
 
 #include "cafPdmNestedCollectionBase.h"
@@ -63,6 +65,8 @@ void RicNewNestedCollectionFeature::onActionTriggered( bool isChecked )
 
     caf::PdmObject* added = parent->addNewSubCollection();
     if ( !added ) return;
+
+    RiaNameUniquenessTools::ensureUniqueAmongSiblings( added );
 
     Riu3DMainWindowTools::selectAsCurrentItem( added );
 }

--- a/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp
+++ b/ApplicationLibCode/FileInterface/RifHdf5SummaryExporter.cpp
@@ -130,16 +130,33 @@ bool RifHdf5SummaryExporter::ensureHdf5FileIsCreated( const std::string& smspecF
             // performance penalty
             sourceSummaryData.loadData();
 
+            std::string exportErrorText;
+
 #pragma omp critical( critical_section_HDF5_export )
             {
                 // HDF5 file access is not thread-safe, always make sure we use the HDF5 library from a single thread
 
-                RifHdf5Exporter exporter( h5FileName );
+                // NB! An exception must never escape an OpenMP structured block, as this will terminate the application
+                try
+                {
+                    RifHdf5Exporter exporter( h5FileName );
 
-                writeGeneralSection( exporter, sourceSummaryData );
-                writeSummaryVectors( exporter, sourceSummaryData );
+                    writeGeneralSection( exporter, sourceSummaryData );
+                    writeSummaryVectors( exporter, sourceSummaryData );
 
-                hdfFilesCreatedCount++;
+                    hdfFilesCreatedCount++;
+                }
+                catch ( std::exception& e )
+                {
+                    exportErrorText = e.what();
+                }
+            }
+
+            if ( !exportErrorText.empty() )
+            {
+                RiaLogging::error( std::format( "HDF export to file {} failed : {}", smspecFileName, exportErrorText ) );
+
+                return false;
             }
         }
         catch ( std::exception& e )
@@ -158,8 +175,6 @@ bool RifHdf5SummaryExporter::ensureHdf5FileIsCreated( const std::string& smspecF
 //--------------------------------------------------------------------------------------------------
 bool RifHdf5SummaryExporter::writeGeneralSection( RifHdf5Exporter& exporter, Opm::EclIO::ESmry& sourceSummaryData )
 {
-    auto timesteps = sourceSummaryData.dates();
-
     auto group = exporter.createGroup( nullptr, "general" );
 
     {

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygon.cpp
@@ -29,6 +29,7 @@
 #include "RimPolygonTools.h"
 
 #include "RiuGuiTheme.h"
+#include "RiuNameConflictTools.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmFieldScriptingCapability.h"
@@ -222,6 +223,12 @@ void RimPolygon::fieldChangedByUi( const caf::PdmFieldHandle* changedField, cons
     if ( changedField == &m_pointsInDomainCoords || changedField == &m_pointsInDomainCoordsForUi )
     {
         coordinatesChanged.send();
+    }
+    else if ( changedField == nameField() )
+    {
+        // Keep the name unique among the polygons in the same folder
+        auto resolvedName = RiuNameConflictTools::resolveRenameConflict( this, newValue.toString() );
+        setName( resolvedName.value_or( oldValue.toString() ) );
     }
 
     objectChanged.send();

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonCollection.cpp
@@ -19,6 +19,7 @@
 #include "RimPolygonCollection.h"
 
 #include "RiaColorTables.h"
+#include "RiaNameUniquenessTools.h"
 
 #include "Rim3dView.h"
 #include "RimPolygon.h"
@@ -69,7 +70,7 @@ RimPolygonCollection* RimPolygonCollection::createTopmost()
 RimPolygon* RimPolygonCollection::createUserDefinedPolygon()
 {
     auto newPolygon = new RimPolygon();
-    newPolygon->setName( "Polygon " + QString::number( allPolygons().size() + 1 ) );
+    newPolygon->setName( "Polygon " + QString::number( items().size() + 1 ) );
 
     auto colorCandidates = RiaColorTables::summaryCurveDefaultPaletteColors();
     newPolygon->setColor( colorCandidates.cycledColor3f( allPolygons().size() ) );
@@ -94,6 +95,7 @@ RimPolygon* RimPolygonCollection::appendUserDefinedPolygon()
 void RimPolygonCollection::addUserDefinedPolygon( RimPolygon* polygon )
 {
     m_items.push_back( polygon );
+    ensureUniquePolygonName( polygon );
 
     connectPolygonSignals( polygon );
 
@@ -140,6 +142,7 @@ void RimPolygonCollection::addPolygonFile( RimPolygonFile* polygonFile )
     if ( !polygonFile ) return;
 
     addSubCollection( polygonFile );
+    RiaNameUniquenessTools::ensureUniqueAmongSiblings( polygonFile );
     connectPolygonFileSignals( polygonFile );
 
     updateViewTreeItems();

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonContainer.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonContainer.cpp
@@ -18,8 +18,12 @@
 
 #include "RimPolygonContainer.h"
 
+#include "RiaNameUniquenessTools.h"
+
 #include "RimPolygon.h"
 #include "RimPolygonCollection.h"
+
+#include "RiuNameConflictTools.h"
 
 CAF_PDM_XML_ABSTRACT_SOURCE_INIT( RimPolygonContainer, "RimPolygonContainer" ); // Abstract class
 
@@ -47,10 +51,35 @@ RimPolygonContainer* RimPolygonContainer::addNewSubCollection()
 //--------------------------------------------------------------------------------------------------
 ///
 //--------------------------------------------------------------------------------------------------
+void RimPolygonContainer::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
+{
+    if ( changedField == &m_collectionName )
+    {
+        // Keep the name unique among the folders in the same parent folder
+        auto resolvedName = RiuNameConflictTools::resolveRenameConflict( this, newValue.toString() );
+        m_collectionName  = resolvedName.value_or( oldValue.toString() );
+    }
+
+    caf::PdmNestedCollection<RimPolygonContainer, RimPolygon>::fieldChangedByUi( changedField, oldValue, newValue );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
 void RimPolygonContainer::loadData()
 {
     for ( auto* sub : subCollections() )
     {
         if ( sub ) sub->loadData();
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimPolygonContainer::ensureUniquePolygonName( RimPolygon* polygon )
+{
+    if ( !polygon ) return;
+
+    RiaNameUniquenessTools::ensureUniqueAmongSiblings( polygon );
 }

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonContainer.h
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonContainer.h
@@ -48,4 +48,11 @@ public:
     // Default behavior recurses into sub-collections. Leaf containers (e.g., file-backed)
     // override to load their own data; folder containers inherit the recursion.
     virtual void loadData();
+
+    // Renames the polygon if another polygon in this container already carries the same name.
+    void ensureUniquePolygonName( RimPolygon* polygon );
+
+protected:
+    // Enforces name uniqueness among sibling folders when the folder is renamed.
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
 };

--- a/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonFile.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Polygons/RimPolygonFile.cpp
@@ -98,6 +98,12 @@ void RimPolygonFile::loadData()
         m_items.deleteChildren();
 
         m_items.setValue( polygonsFromFile );
+
+        // A file may contain several polygons sharing the same id, and thus the same generated name
+        for ( auto* polygon : polygonsFromFile )
+        {
+            ensureUniquePolygonName( polygon );
+        }
     }
 
     if ( polygonsFromFile.empty() )
@@ -178,6 +184,8 @@ void RimPolygonFile::fieldChangedByUi( const caf::PdmFieldHandle* changedField, 
         m_items.deleteChildren();
         loadData();
     }
+
+    RimPolygonContainer::fieldChangedByUi( changedField, oldValue, newValue );
 
     objectChanged.send();
 }

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurface.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurface.cpp
@@ -25,6 +25,8 @@
 #include "RimRegularLegendConfig.h"
 #include "RimSurfaceCollection.h"
 
+#include "RiuNameConflictTools.h"
+
 #include "RigStatisticsMath.h"
 #include "Surface/RigSurface.h"
 
@@ -252,6 +254,10 @@ void RimSurface::fieldChangedByUi( const caf::PdmFieldHandle* changedField, cons
     }
     else if ( changedField == &m_userDescription )
     {
+        // Keep the name unique among the surfaces in the same folder
+        auto resolvedName = RiuNameConflictTools::resolveRenameConflict( this, newValue.toString() );
+        m_userDescription = resolvedName.value_or( oldValue.toString() );
+
         updateConnectedEditors();
     }
     else if ( changedField == &m_depthOffset )

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceCollection.cpp
@@ -20,6 +20,7 @@
 
 #include "RiaColorTables.h"
 #include "RiaLogging.h"
+#include "RiaNameUniquenessTools.h"
 
 #include "Rim2dIntersectionView.h"
 #include "Rim2dIntersectionViewCollection.h"
@@ -36,6 +37,8 @@
 #include "RimSurface.h"
 #include "RimSurfaceInView.h"
 #include "RimSurfaceResultDefinition.h"
+
+#include "RiuNameConflictTools.h"
 
 #include "cafCmdFeatureMenuBuilder.h"
 #include "cafPdmFieldReorderCapability.h"
@@ -92,6 +95,32 @@ RimSurfaceCollection* RimSurfaceCollection::createTopmost()
 void RimSurfaceCollection::addSurface( RimSurface* surface )
 {
     m_items.push_back( surface );
+    ensureUniqueSurfaceName( surface );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSurfaceCollection::ensureUniqueSurfaceName( RimSurface* surface )
+{
+    if ( !surface ) return;
+
+    RiaNameUniquenessTools::ensureUniqueAmongSiblings( surface );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RimSurfaceCollection::fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue )
+{
+    if ( changedField == &m_collectionName )
+    {
+        // Keep the name unique among the folders in the same parent folder
+        auto resolvedName = RiuNameConflictTools::resolveRenameConflict( this, newValue.toString() );
+        m_collectionName  = resolvedName.value_or( oldValue.toString() );
+    }
+
+    caf::PdmNestedCollection<RimSurfaceCollection, RimSurface>::fieldChangedByUi( changedField, oldValue, newValue );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -234,6 +263,7 @@ RimSurface* RimSurfaceCollection::copySurfaces( std::vector<RimSurface*> surface
     for ( RimSurface* surface : newsurfaces )
     {
         m_items.push_back( surface );
+        ensureUniqueSurfaceName( surface );
         retsurf = surface;
     }
 
@@ -259,6 +289,7 @@ RimSurface* RimSurfaceCollection::addGridCaseSurface( RimCase* sourceCase, int o
     }
 
     m_items.push_back( s );
+    ensureUniqueSurfaceName( s );
 
     updateConnectedEditors();
 
@@ -479,6 +510,12 @@ RimSurface* RimSurfaceCollection::addSurfacesAtIndex( int position, std::vector<
         {
             m_items.push_back( surf );
         }
+    }
+
+    // Surfaces moved in from another folder may collide with the names already present here
+    for ( auto surf : surfaces )
+    {
+        ensureUniqueSurfaceName( surf );
     }
 
     // make sure the views are in sync with the collection order

--- a/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceCollection.h
+++ b/ApplicationLibCode/ProjectDataModel/Surfaces/RimSurfaceCollection.h
@@ -64,8 +64,14 @@ public:
 
     std::vector<RimSurface*> surfaces() const;
 
+    // Renames the surface if another surface in this folder already carries the same name.
+    void ensureUniqueSurfaceName( RimSurface* surface );
+
 protected:
     void appendMenuItems( caf::CmdFeatureMenuBuilder& menuBuilder ) const override;
+
+    // Enforces name uniqueness among sibling folders when the folder is renamed.
+    void fieldChangedByUi( const caf::PdmFieldHandle* changedField, const QVariant& oldValue, const QVariant& newValue ) override;
 
 private:
     void orderChanged( const caf::SignalEmitter* emitter );

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcNestedCollectionBase.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcNestedCollectionBase.cpp
@@ -18,6 +18,9 @@
 
 #include "RimcNestedCollectionBase.h"
 
+#include "RiaNameUniquenessTools.h"
+
+#include "cafPdmChildArrayField.h"
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmNestedCollectionBase.h"
 
@@ -32,6 +35,13 @@ RimcNestedCollectionBase::RimcNestedCollectionBase( caf::PdmObjectHandle* self )
     CAF_PDM_InitObject( "Add Folder", "", "", "Add a new folder" );
 
     CAF_PDM_InitScriptableField( &m_folderName, "FolderName", QString( "Folder" ), "", "", "", "New folder name" );
+    CAF_PDM_InitScriptableField( &m_onNameConflict,
+                                 "OnNameConflict",
+                                 caf::AppEnum<RiaDefines::NameConflictPolicy>( RiaDefines::NameConflictPolicy::FAIL ),
+                                 "",
+                                 "",
+                                 "",
+                                 "How to handle a folder name already used in this folder" );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -45,6 +55,20 @@ std::expected<caf::PdmObjectHandle*, QString> RimcNestedCollectionBase::execute(
         return std::unexpected( "Cannot add subfolder" );
     }
 
+    auto* subCollections = coll->subCollectionsField();
+    auto  resolution     = RiaNameUniquenessTools::applyConflictPolicy( subCollections, m_folderName(), m_onNameConflict().value() );
+    if ( !resolution.errorMessage.isEmpty() ) return std::unexpected( resolution.errorMessage );
+
+    if ( resolution.objectToReplace && subCollections )
+    {
+        size_t index = subCollections->indexOf( resolution.objectToReplace );
+        if ( index < subCollections->size() )
+        {
+            subCollections->erase( index );
+            delete resolution.objectToReplace;
+        }
+    }
+
     caf::PdmObject* added = coll->addNewSubCollection();
     if ( !added )
     {
@@ -53,7 +77,7 @@ std::expected<caf::PdmObjectHandle*, QString> RimcNestedCollectionBase::execute(
 
     if ( auto* asNested = dynamic_cast<caf::PdmNestedCollectionBase*>( added ) )
     {
-        asNested->setCollectionName( m_folderName() );
+        asNested->setCollectionName( resolution.nameToUse );
     }
     coll->uiCapability()->updateConnectedEditors();
     return added;

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcNestedCollectionBase.h
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcNestedCollectionBase.h
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include "RiaDefines.h"
+
+#include "cafAppEnum.h"
 #include "cafPdmField.h"
 #include "cafPdmObjectHandle.h"
 #include "cafPdmObjectMethod.h"
@@ -42,5 +45,6 @@ public:
     QString                                       classKeywordReturnedType() const override;
 
 private:
-    caf::PdmField<QString> m_folderName;
+    caf::PdmField<QString>                                      m_folderName;
+    caf::PdmField<caf::AppEnum<RiaDefines::NameConflictPolicy>> m_onNameConflict;
 };

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcPolygonCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcPolygonCollection.cpp
@@ -18,6 +18,8 @@
 
 #include "RimcPolygonCollection.h"
 
+#include "RiaNameUniquenessTools.h"
+
 #include "Polygons/RimPolygon.h"
 #include "Polygons/RimPolygonCollection.h"
 
@@ -37,6 +39,13 @@ RimcPolygonCollection_createPolygon::RimcPolygonCollection_createPolygon( caf::P
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_name, "Name", "Name" );
     CAF_PDM_InitScriptableFieldNoDefault( &m_coordinates, "Coordinates", "Coordinates" );
+    CAF_PDM_InitScriptableField( &m_onNameConflict,
+                                 "OnNameConflict",
+                                 caf::AppEnum<RiaDefines::NameConflictPolicy>( RiaDefines::NameConflictPolicy::FAIL ),
+                                 "",
+                                 "",
+                                 "",
+                                 "How to handle a polygon name already used in this folder" );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -48,6 +57,20 @@ std::expected<caf::PdmObjectHandle*, QString> RimcPolygonCollection_createPolygo
 
     QString                 name   = m_name();
     std::vector<cvf::Vec3d> coords = m_coordinates();
+
+    if ( !name.isEmpty() )
+    {
+        auto resolution = RiaNameUniquenessTools::applyConflictPolicy( &polygonCollection->itemsField(), name, m_onNameConflict().value() );
+        if ( !resolution.errorMessage.isEmpty() ) return std::unexpected( resolution.errorMessage );
+
+        // The new polygon is added below, and that refreshes the views for both objects
+        if ( auto* existingPolygon = dynamic_cast<RimPolygon*>( resolution.objectToReplace ) )
+        {
+            polygonCollection->deleteItem( existingPolygon );
+        }
+
+        name = resolution.nameToUse;
+    }
 
     RimPolygon* polygon = new RimPolygon();
     if ( !name.isEmpty() )

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcSurfaceCollection.cpp
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcSurfaceCollection.cpp
@@ -19,6 +19,8 @@
 
 #include "SurfaceCommands/RicImportSurfacesFeature.h"
 
+#include "RiaNameUniquenessTools.h"
+
 #include "RimCase.h"
 #include "RimFileSurface.h"
 #include "RimGridCaseSurface.h"
@@ -29,6 +31,7 @@
 #include "cafPdmFieldScriptingCapability.h"
 #include "cafPdmObjectScriptingCapability.h"
 
+#include <QFileInfo>
 #include <QStringList>
 
 CAF_PDM_OBJECT_METHOD_SOURCE_INIT( RimSurfaceCollection, RimcSurfaceCollection_importSurface, "ImportSurface" );
@@ -45,6 +48,13 @@ RimcSurfaceCollection_importSurface::RimcSurfaceCollection_importSurface( caf::P
     CAF_PDM_InitObject( "Import Surface", "", "", "Import a new surface from file" );
 
     CAF_PDM_InitScriptableFieldNoDefault( &m_fileName, "FileName", "", "", "", "Filename to import surface from" );
+    CAF_PDM_InitScriptableField( &m_onNameConflict,
+                                 "OnNameConflict",
+                                 caf::AppEnum<RiaDefines::NameConflictPolicy>( RiaDefines::NameConflictPolicy::FAIL ),
+                                 "",
+                                 "",
+                                 "",
+                                 "How to handle a surface name already used in this folder" );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -53,13 +63,22 @@ RimcSurfaceCollection_importSurface::RimcSurfaceCollection_importSurface( caf::P
 std::expected<caf::PdmObjectHandle*, QString> RimcSurfaceCollection_importSurface::execute()
 {
     RimSurfaceCollection* coll = self<RimSurfaceCollection>();
-    if ( coll )
+    if ( !coll ) return nullptr;
+
+    // Imported surfaces are named after the file, see RimSurfaceCollection::importSurfacesFromFiles
+    const QString surfaceName = QFileInfo( m_fileName() ).fileName();
+
+    auto resolution = RiaNameUniquenessTools::applyConflictPolicy( &coll->itemsField(), surfaceName, m_onNameConflict().value() );
+    if ( !resolution.errorMessage.isEmpty() ) return std::unexpected( resolution.errorMessage );
+
+    if ( auto* existingSurface = dynamic_cast<RimSurface*>( resolution.objectToReplace ) )
     {
-        QStringList filelist;
-        filelist << m_fileName();
-        return coll->importSurfacesFromFiles( filelist );
+        coll->deleteItem( existingSurface );
     }
-    return nullptr;
+
+    QStringList filelist;
+    filelist << m_fileName();
+    return coll->importSurfacesFromFiles( filelist );
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -113,6 +132,13 @@ RimcSurfaceCollection_newRegularSurface::RimcSurfaceCollection_newRegularSurface
     CAF_PDM_InitObject( "New Regular Surface", "", "", "Create a new regular surface" );
 
     CAF_PDM_InitScriptableField( &m_name, "Name", QString( "" ), "Name" );
+    CAF_PDM_InitScriptableField( &m_onNameConflict,
+                                 "OnNameConflict",
+                                 caf::AppEnum<RiaDefines::NameConflictPolicy>( RiaDefines::NameConflictPolicy::FAIL ),
+                                 "",
+                                 "",
+                                 "",
+                                 "How to handle a surface name already used in this folder" );
 
     CAF_PDM_InitScriptableField( &m_originX, "OriginX", 0.0, "Origin X" );
     CAF_PDM_InitScriptableField( &m_originY, "OriginY", 0.0, "Origin Y" );
@@ -140,8 +166,16 @@ std::expected<caf::PdmObjectHandle*, QString> RimcSurfaceCollection_newRegularSu
     if ( m_incrementY() <= 0.0 ) return std::unexpected( "Invalid increment Y. Must be positive." );
     if ( m_rotation() < 0.0 || m_rotation() > 360.0 ) return std::unexpected( "Invalid rotation. Valid range: [0.0-360.0]" );
 
+    auto resolution = RiaNameUniquenessTools::applyConflictPolicy( &coll->itemsField(), m_name(), m_onNameConflict().value() );
+    if ( !resolution.errorMessage.isEmpty() ) return std::unexpected( resolution.errorMessage );
+
+    if ( auto* existingSurface = dynamic_cast<RimSurface*>( resolution.objectToReplace ) )
+    {
+        coll->deleteItem( existingSurface );
+    }
+
     RimRegularSurface* surface = new RimRegularSurface;
-    surface->setUserDescription( m_name() );
+    surface->setUserDescription( resolution.nameToUse );
 
     surface->setNx( m_nx() );
     surface->setNy( m_ny() );

--- a/ApplicationLibCode/ProjectDataModelCommands/RimcSurfaceCollection.h
+++ b/ApplicationLibCode/ProjectDataModelCommands/RimcSurfaceCollection.h
@@ -20,6 +20,9 @@
 
 #include "RimSurfaceCollection.h"
 
+#include "RiaDefines.h"
+
+#include "cafAppEnum.h"
 #include "cafPdmField.h"
 #include "cafPdmObjectHandle.h"
 #include "cafPdmObjectMethod.h"
@@ -47,7 +50,8 @@ public:
     QString                                       classKeywordReturnedType() const override;
 
 private:
-    caf::PdmField<QString> m_fileName;
+    caf::PdmField<QString>                                      m_fileName;
+    caf::PdmField<caf::AppEnum<RiaDefines::NameConflictPolicy>> m_onNameConflict;
 };
 
 //==================================================================================================
@@ -82,13 +86,14 @@ public:
     QString                                       classKeywordReturnedType() const override;
 
 private:
-    caf::PdmField<QString> m_name;
-    caf::PdmField<int>     m_nx;
-    caf::PdmField<int>     m_ny;
-    caf::PdmField<double>  m_originX;
-    caf::PdmField<double>  m_originY;
-    caf::PdmField<double>  m_depth;
-    caf::PdmField<double>  m_incrementX;
-    caf::PdmField<double>  m_incrementY;
-    caf::PdmField<double>  m_rotation;
+    caf::PdmField<QString>                                      m_name;
+    caf::PdmField<caf::AppEnum<RiaDefines::NameConflictPolicy>> m_onNameConflict;
+    caf::PdmField<int>                                          m_nx;
+    caf::PdmField<int>                                          m_ny;
+    caf::PdmField<double>                                       m_originX;
+    caf::PdmField<double>                                       m_originY;
+    caf::PdmField<double>                                       m_depth;
+    caf::PdmField<double>                                       m_incrementX;
+    caf::PdmField<double>                                       m_incrementY;
+    caf::PdmField<double>                                       m_rotation;
 };

--- a/ApplicationLibCode/UnitTests/CMakeLists.txt
+++ b/ApplicationLibCode/UnitTests/CMakeLists.txt
@@ -126,6 +126,7 @@ set(SOURCE_UNITTEST_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RigVfpTables-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiaResultName-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RigPolygonTools-Test.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiaNameUniquenessTools-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifVtkSurfaceImporter-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifVtkReader-Test.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RifVtkImportUtil-Test.cpp

--- a/ApplicationLibCode/UnitTests/HDF5FileWriter-Test.cpp
+++ b/ApplicationLibCode/UnitTests/HDF5FileWriter-Test.cpp
@@ -24,7 +24,50 @@
 #include "opm/io/eclipse/ESmry.hpp"
 #include <numeric>
 
+#include <QByteArray>
+#include <QFile>
+#include <QTemporaryDir>
+
 static const QString H5_TEST_DATA_DIRECTORY_2 = QString( "%1/h5-file/" ).arg( TEST_DATA_DIR );
+
+//--------------------------------------------------------------------------------------------------
+/// A summary file without a TIME vector must be reported as a failed export, not terminate the
+/// application. Opm::EclIO::ESmry::dates() throws when the TIME vector is missing.
+//--------------------------------------------------------------------------------------------------
+TEST( HDFTests, ExportSummaryFileWithoutTimeKeyword )
+{
+    const QString sourceFolder = QString( "%1/SummaryData/Reek/" ).arg( TEST_DATA_DIR );
+
+    QTemporaryDir tempDir;
+    ASSERT_TRUE( tempDir.isValid() );
+
+    ASSERT_TRUE( QFile::copy( sourceFolder + "3_R001_REEK-1.UNSMRY", tempDir.filePath( "3_R001_REEK-1.UNSMRY" ) ) );
+
+    // Copy the SMSPEC file and rename the TIME keyword, making ESmry load without a TIME vector
+    const QString smspecFileName = tempDir.filePath( "3_R001_REEK-1.SMSPEC" );
+    {
+        QFile sourceFile( sourceFolder + "3_R001_REEK-1.SMSPEC" );
+        ASSERT_TRUE( sourceFile.open( QIODevice::ReadOnly ) );
+
+        QByteArray content = sourceFile.readAll();
+
+        const QByteArray timeKeyword( "TIME    " );
+        ASSERT_EQ( 1, content.count( timeKeyword ) );
+        content.replace( timeKeyword, QByteArray( "TIMX    " ) );
+
+        QFile destinationFile( smspecFileName );
+        ASSERT_TRUE( destinationFile.open( QIODevice::WriteOnly ) );
+        ASSERT_EQ( content.size(), destinationFile.write( content ) );
+    }
+
+    const std::string h5FileName = tempDir.filePath( "3_R001_REEK-1.h5" ).toStdString();
+
+    size_t hdfFilesCreatedCount = 0;
+    EXPECT_TRUE( RifHdf5SummaryExporter::ensureHdf5FileIsCreated( smspecFileName.toStdString(), h5FileName, true, hdfFilesCreatedCount ) );
+
+    EXPECT_EQ( size_t( 1 ), hdfFilesCreatedCount );
+    EXPECT_TRUE( QFile::exists( QString::fromStdString( h5FileName ) ) );
+}
 
 //--------------------------------------------------------------------------------------------------
 ///

--- a/ApplicationLibCode/UnitTests/RiaNameUniquenessTools-Test.cpp
+++ b/ApplicationLibCode/UnitTests/RiaNameUniquenessTools-Test.cpp
@@ -1,0 +1,169 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "RiaNameUniquenessTools.h"
+
+#include "Polygons/RimPolygon.h"
+#include "Polygons/RimPolygonCollection.h"
+#include "RimRegularSurface.h"
+#include "RimSurfaceCollection.h"
+
+#include <memory>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaNameUniquenessTools, MakeUniqueAppendsNumericSuffix )
+{
+    EXPECT_EQ( QString( "Top" ), RiaNameUniquenessTools::makeUnique( "Top", {} ) );
+    EXPECT_EQ( QString( "Top_1" ), RiaNameUniquenessTools::makeUnique( "Top", { "Top" } ) );
+    EXPECT_EQ( QString( "Top_2" ), RiaNameUniquenessTools::makeUnique( "Top", { "Top", "Top_1" } ) );
+    EXPECT_EQ( QString( "Top_3" ), RiaNameUniquenessTools::makeUnique( "Top", { "Top", "Top_1", "Top_2" } ) );
+
+    // A gap in the numbering is filled
+    EXPECT_EQ( QString( "Top_1" ), RiaNameUniquenessTools::makeUnique( "Top", { "Top", "Top_2" } ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaNameUniquenessTools, MakeUniqueIsCaseSensitive )
+{
+    EXPECT_EQ( QString( "fault" ), RiaNameUniquenessTools::makeUnique( "fault", { "Fault" } ) );
+    EXPECT_EQ( QString( "Fault_1" ), RiaNameUniquenessTools::makeUnique( "Fault", { "Fault", "fault" } ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// An empty name means the object derives its tree label from other properties, and must not be
+/// numbered.
+//--------------------------------------------------------------------------------------------------
+TEST( RiaNameUniquenessTools, MakeUniqueLeavesEmptyNameUntouched )
+{
+    EXPECT_EQ( QString( "" ), RiaNameUniquenessTools::makeUnique( "", { "", "Top" } ) );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaNameUniquenessTools, SurfacesAreUniquePerFolder )
+{
+    auto rootCollection = std::make_unique<RimSurfaceCollection>();
+
+    auto* firstSurface = new RimRegularSurface();
+    firstSurface->setUserDescription( "Top" );
+    rootCollection->addSurface( firstSurface );
+
+    auto* secondSurface = new RimRegularSurface();
+    secondSurface->setUserDescription( "Top" );
+    rootCollection->addSurface( secondSurface );
+
+    EXPECT_EQ( QString( "Top" ), firstSurface->userDescription() );
+    EXPECT_EQ( QString( "Top_1" ), secondSurface->userDescription() );
+
+    // The same name is free again in another folder
+    auto* subFolder = new RimSurfaceCollection();
+    rootCollection->addSubCollection( subFolder );
+
+    auto* surfaceInSubFolder = new RimRegularSurface();
+    surfaceInSubFolder->setUserDescription( "Top" );
+    subFolder->addSurface( surfaceInSubFolder );
+
+    EXPECT_EQ( QString( "Top" ), surfaceInSubFolder->userDescription() );
+}
+
+//--------------------------------------------------------------------------------------------------
+/// Folders and items are two separate namespaces, a folder and a surface may share a name.
+//--------------------------------------------------------------------------------------------------
+TEST( RiaNameUniquenessTools, FoldersAndItemsAreSeparateNamespaces )
+{
+    auto rootCollection = std::make_unique<RimSurfaceCollection>();
+
+    auto* surface = new RimRegularSurface();
+    surface->setUserDescription( "Top" );
+    rootCollection->addSurface( surface );
+
+    auto* subFolder = new RimSurfaceCollection();
+    subFolder->setCollectionName( "Top" );
+    rootCollection->addSubCollection( subFolder );
+    RiaNameUniquenessTools::ensureUniqueAmongSiblings( subFolder );
+
+    EXPECT_EQ( QString( "Top" ), surface->userDescription() );
+    EXPECT_EQ( QString( "Top" ), subFolder->collectionName() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaNameUniquenessTools, PolygonsAreUniquePerFolder )
+{
+    auto rootCollection = std::make_unique<RimPolygonCollection>();
+
+    auto* firstPolygon = new RimPolygon();
+    firstPolygon->setName( "Fence" );
+    rootCollection->addUserDefinedPolygon( firstPolygon );
+
+    auto* secondPolygon = new RimPolygon();
+    secondPolygon->setName( "Fence" );
+    rootCollection->addUserDefinedPolygon( secondPolygon );
+
+    EXPECT_EQ( QString( "Fence" ), firstPolygon->name() );
+    EXPECT_EQ( QString( "Fence_1" ), secondPolygon->name() );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+TEST( RiaNameUniquenessTools, ConflictPolicyForScripting )
+{
+    auto rootCollection = std::make_unique<RimSurfaceCollection>();
+
+    auto* surface = new RimRegularSurface();
+    surface->setUserDescription( "Top" );
+    rootCollection->addSurface( surface );
+
+    {
+        auto resolution =
+            RiaNameUniquenessTools::applyConflictPolicy( &rootCollection->itemsField(), "Base", RiaDefines::NameConflictPolicy::FAIL );
+        EXPECT_TRUE( resolution.errorMessage.isEmpty() );
+        EXPECT_EQ( nullptr, resolution.objectToReplace );
+        EXPECT_EQ( QString( "Base" ), resolution.nameToUse );
+    }
+
+    {
+        auto resolution =
+            RiaNameUniquenessTools::applyConflictPolicy( &rootCollection->itemsField(), "Top", RiaDefines::NameConflictPolicy::FAIL );
+        EXPECT_FALSE( resolution.errorMessage.isEmpty() );
+    }
+
+    {
+        auto resolution =
+            RiaNameUniquenessTools::applyConflictPolicy( &rootCollection->itemsField(), "Top", RiaDefines::NameConflictPolicy::AUTO_RENAME );
+        EXPECT_TRUE( resolution.errorMessage.isEmpty() );
+        EXPECT_EQ( QString( "Top_1" ), resolution.nameToUse );
+    }
+
+    {
+        auto resolution =
+            RiaNameUniquenessTools::applyConflictPolicy( &rootCollection->itemsField(), "Top", RiaDefines::NameConflictPolicy::OVERWRITE );
+        EXPECT_TRUE( resolution.errorMessage.isEmpty() );
+        EXPECT_EQ( surface, resolution.objectToReplace );
+        EXPECT_EQ( QString( "Top" ), resolution.nameToUse );
+    }
+}

--- a/ApplicationLibCode/UserInterface/CMakeLists_files.cmake
+++ b/ApplicationLibCode/UserInterface/CMakeLists_files.cmake
@@ -15,6 +15,7 @@ set(SOURCE_GROUP_SOURCE_FILES
     ${CMAKE_CURRENT_LIST_DIR}/RiuPlotMainWindow.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuMainWindow.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuMainWindowBase.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/RiuNameConflictTools.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuProcessMonitor.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuProjectPropertyView.cpp
     ${CMAKE_CURRENT_LIST_DIR}/RiuPropertyViewTabWidget.cpp

--- a/ApplicationLibCode/UserInterface/RiuNameConflictTools.cpp
+++ b/ApplicationLibCode/UserInterface/RiuNameConflictTools.cpp
@@ -1,0 +1,57 @@
+/////////////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (C) 2026     Equinor ASA
+//
+//  ResInsight is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  ResInsight is distributed in the hope that it will be useful, but WITHOUT ANY
+//  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+//  FITNESS FOR A PARTICULAR PURPOSE.
+//
+//  See the GNU General Public License at <http://www.gnu.org/licenses/gpl.html>
+//  for more details.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+#include "RiuNameConflictTools.h"
+
+#include "RiaGuiApplication.h"
+#include "RiaNameUniquenessTools.h"
+#include "RiaRegressionTestRunner.h"
+
+#include <QMessageBox>
+#include <QPushButton>
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+std::optional<QString> RiuNameConflictTools::resolveRenameConflict( const caf::PdmObjectHandle* object, const QString& desiredName )
+{
+    if ( RiaNameUniquenessTools::isUniqueAmongSiblings( object, desiredName ) ) return desiredName;
+
+    const QString suggestedName = RiaNameUniquenessTools::makeUniqueAmongSiblings( object, desiredName );
+
+    if ( !RiaGuiApplication::isRunning() || RiaRegressionTestRunner::instance()->isRunningRegressionTests() )
+    {
+        return suggestedName;
+    }
+
+    QMessageBox msgBox;
+    msgBox.setWindowTitle( "Name Already In Use" );
+    msgBox.setIcon( QMessageBox::Icon::Warning );
+    msgBox.setText( QString( "\"%1\" already exists in this folder." ).arg( desiredName ) );
+    msgBox.setInformativeText( QString( "Use \"%1\" instead?" ).arg( suggestedName ) );
+
+    auto* useSuggestedButton = msgBox.addButton( QString( "Use \"%1\"" ).arg( suggestedName ), QMessageBox::AcceptRole );
+    msgBox.addButton( QMessageBox::Cancel );
+    msgBox.setDefaultButton( useSuggestedButton );
+
+    msgBox.exec();
+
+    if ( msgBox.clickedButton() == useSuggestedButton ) return suggestedName;
+
+    return {};
+}

--- a/ApplicationLibCode/UserInterface/RiuNameConflictTools.h
+++ b/ApplicationLibCode/UserInterface/RiuNameConflictTools.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2025- Equinor ASA
+//  Copyright (C) 2026     Equinor ASA
 //
 //  ResInsight is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -18,32 +18,27 @@
 
 #pragma once
 
-#include "RiaDefines.h"
-
-#include "cafAppEnum.h"
-#include "cafPdmField.h"
-#include "cafPdmObjectHandle.h"
-#include "cafPdmObjectMethod.h"
-
-#include "cvfVector3.h"
-
 #include <QString>
+
+#include <optional>
+
+namespace caf
+{
+class PdmObjectHandle;
+}
 
 //==================================================================================================
 ///
+/// Interactive resolution of name conflicts between siblings in the project tree.
+///
 //==================================================================================================
-class RimcPolygonCollection_createPolygon : public caf::PdmObjectCreationMethod
+namespace RiuNameConflictTools
 {
-    CAF_PDM_HEADER_INIT;
+// Returns the name to apply, or nothing if the user cancelled the rename.
+//
+// If desiredName is already unique among the siblings of the object, it is returned unchanged.
+// Otherwise the user is asked to accept an auto-generated unique name. When no GUI is available
+// (console mode, regression tests, scripting) the unique name is returned without prompting.
+std::optional<QString> resolveRenameConflict( const caf::PdmObjectHandle* object, const QString& desiredName );
 
-public:
-    RimcPolygonCollection_createPolygon( caf::PdmObjectHandle* self );
-
-    std::expected<caf::PdmObjectHandle*, QString> execute() override;
-    QString                                       classKeywordReturnedType() const override;
-
-private:
-    caf::PdmField<QString>                                      m_name;
-    caf::PdmField<std::vector<cvf::Vec3d>>                      m_coordinates;
-    caf::PdmField<caf::AppEnum<RiaDefines::NameConflictPolicy>> m_onNameConflict;
-};
+}; // namespace RiuNameConflictTools

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmNestedCollection.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmNestedCollection.h
@@ -72,9 +72,10 @@ public:
     std::vector<SelfT*> subCollections() const;
 
     // Subcollection CRUD
-    void       addSubCollection( SelfT* sub );
-    PdmObject* addNewSubCollection() override;
-    SelfT*     findSubCollectionByName( const QString& name ) const;
+    void                      addSubCollection( SelfT* sub );
+    PdmObject*                addNewSubCollection() override;
+    PdmChildArrayFieldHandle* subCollectionsField() override;
+    SelfT*                    findSubCollectionByName( const QString& name ) const;
 
     // Returns items held by this collection and recursively by all subcollections.
     // For items at this level only, use items().

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmNestedCollection.inl
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmNestedCollection.inl
@@ -201,6 +201,15 @@ PdmObject* PdmNestedCollection<SelfT, ItemT>::addNewSubCollection()
 ///
 //--------------------------------------------------------------------------------------------------
 template <typename SelfT, typename ItemT>
+PdmChildArrayFieldHandle* PdmNestedCollection<SelfT, ItemT>::subCollectionsField()
+{
+    return &m_subCollections;
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+template <typename SelfT, typename ItemT>
 SelfT* PdmNestedCollection<SelfT, ItemT>::findSubCollectionByName( const QString& name ) const
 {
     for ( auto coll : m_subCollections )

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmNestedCollectionBase.h
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmNestedCollectionBase.h
@@ -25,6 +25,7 @@
 
 namespace caf
 {
+class PdmChildArrayFieldHandle;
 
 //==================================================================================================
 ///
@@ -58,6 +59,11 @@ public:
     // Creates a subcollection, adds it to this collection, and returns it. Default returns
     // nullptr; concrete derivations (typically PdmNestedCollection<>) override.
     virtual PdmObject* addNewSubCollection() { return nullptr; }
+
+    // Type-erased access to the field holding the sub-collections, for generic code that must
+    // inspect the folders without knowing the concrete collection type. Default returns nullptr;
+    // PdmNestedCollection<> overrides.
+    virtual PdmChildArrayFieldHandle* subCollectionsField() { return nullptr; }
 
     // Marks this instance as the topmost folder: hides and disables IO on the collection name,
     // makes the object non-deletable.

--- a/GrpcInterface/Python/rips/tests/test_polygon.py
+++ b/GrpcInterface/Python/rips/tests/test_polygon.py
@@ -2,6 +2,8 @@ import sys
 import os
 import math
 
+import pytest
+
 sys.path.insert(1, os.path.join(sys.path[0], "../../"))
 import rips
 
@@ -65,3 +67,67 @@ def test_add_folders_and_polygons(rips_instance, initialize_test):
     assert [p.name for p in folder_a.polygons()] == ["A poly"]
     assert [p.name for p in folder_b.polygons()] == []
     assert [p.name for p in nested.polygons()] == ["nested poly"]
+
+
+def test_polygon_name_uniqueness(rips_instance, initialize_test):
+    rips_instance.project.open(
+        dataroot.PATH + "/TEST10K_FLT_LGR_NNC/10KWithWellLog.rsp"
+    )
+
+    root = rips_instance.project.descendants(rips.PolygonCollection)[0]
+
+    coordinates = [
+        [0.0, 0.0, -1000.0],
+        [100.0, 0.0, -1000.0],
+        [100.0, 100.0, -1000.0],
+        [0.0, 100.0, -1000.0],
+    ]
+
+    root.create_polygon(name="Fence", coordinates=coordinates)
+
+    # The default policy is to fail on a name already used in the same folder
+    with pytest.raises(rips.RipsError, match="already exists"):
+        root.create_polygon(name="Fence", coordinates=coordinates)
+
+    renamed = root.create_polygon(
+        name="Fence",
+        coordinates=coordinates,
+        on_name_conflict=rips.NameConflictPolicy.AUTO_RENAME,
+    )
+    assert renamed.name == "Fence_1"
+
+    # Names are case sensitive, so this is not a conflict
+    other_case = root.create_polygon(name="fence", coordinates=coordinates)
+    assert other_case.name == "fence"
+
+    overwritten = root.create_polygon(
+        name="Fence",
+        coordinates=coordinates,
+        on_name_conflict=rips.NameConflictPolicy.OVERWRITE,
+    )
+    assert overwritten.name == "Fence"
+    assert [p.name for p in root.polygons()].count("Fence") == 1
+
+    # A different folder is a separate namespace
+    folder = root.add_folder(folder_name="Folder A")
+    in_folder = folder.create_polygon(name="Fence", coordinates=coordinates)
+    assert in_folder.name == "Fence"
+
+
+def test_folder_name_uniqueness(rips_instance, initialize_test):
+    rips_instance.project.open(
+        dataroot.PATH + "/TEST10K_FLT_LGR_NNC/10KWithWellLog.rsp"
+    )
+
+    root = rips_instance.project.descendants(rips.PolygonCollection)[0]
+
+    root.add_folder(folder_name="Folder A")
+
+    with pytest.raises(rips.RipsError, match="already exists"):
+        root.add_folder(folder_name="Folder A")
+
+    renamed = root.add_folder(
+        folder_name="Folder A",
+        on_name_conflict=rips.NameConflictPolicy.AUTO_RENAME,
+    )
+    assert renamed.polygon_collection_name == "Folder A_1"

--- a/GrpcInterface/Python/rips/tests/test_surfaces.py
+++ b/GrpcInterface/Python/rips/tests/test_surfaces.py
@@ -156,3 +156,38 @@ def test_create_regular_surface_invalid_values(rips_instance, initialize_test):
 
     with pytest.raises(rips.RipsError, match="Invalid rotation."):
         surface_collection.new_regular_surface(rotation=-1.0)
+
+
+def test_surface_name_uniqueness(rips_instance, initialize_test):
+    case_path = dataroot.PATH + "/Case_with_10_timesteps/Real0/BRUGGE_0000.EGRID"
+    rips_instance.project.load_case(path=case_path)
+
+    surface_collection = rips_instance.project.descendants(rips.SurfaceCollection)[0]
+
+    surface_collection.new_regular_surface(name="Top")
+
+    # The default policy is to fail on a name already used in the same folder
+    with pytest.raises(rips.RipsError, match="already exists"):
+        surface_collection.new_regular_surface(name="Top")
+
+    renamed = surface_collection.new_regular_surface(
+        name="Top", on_name_conflict=rips.NameConflictPolicy.AUTO_RENAME
+    )
+    assert renamed.surface_user_description == "Top_1"
+
+    # Names are case sensitive, so this is not a conflict
+    other_case = surface_collection.new_regular_surface(name="top")
+    assert other_case.surface_user_description == "top"
+
+    overwritten = surface_collection.new_regular_surface(
+        name="Top", on_name_conflict=rips.NameConflictPolicy.OVERWRITE
+    )
+    assert overwritten.surface_user_description == "Top"
+
+    names = [s.surface_user_description for s in surface_collection.surfaces_field()]
+    assert names.count("Top") == 1
+
+    # A different folder is a separate namespace
+    folder = surface_collection.add_folder(folder_name="Folder A")
+    in_folder = folder.new_regular_surface(name="Top")
+    assert in_folder.surface_user_description == "Top"


### PR DESCRIPTION
Closes OPM/ResInsight#14411

Names must be unique among siblings sharing the same parent folder. Items in different folders may keep identical names, and comparison is case sensitive.

## Approach

Both trees now sit on `caf::PdmNestedCollection<SelfT, ItemT>`, which keeps items in `m_items` and folders in `m_subCollections`. `RiaNameUniquenessTools` builds on that: siblings are simply the other objects in the same `caf::PdmChildArrayField`, reached through `parentField()`. That makes one generic helper enough for surfaces, polygons and folders, and it gives two properties for free — folders and items are separate namespaces, and names in different folders never collide.

## Rename

Hooked in `fieldChangedByUi` on `RimSurface`, `RimPolygon`, `RimSurfaceCollection` and `RimPolygonContainer`, the last covering polygon folders and `RimPolygonFile`. Tree-view and property-editor renames both funnel through there, and it is the only place with the old value available for the cancel path.

On a collision `RiuNameConflictTools::resolveRenameConflict` offers the auto-generated name:

> "Top" already exists in this folder. Use "Top_1" instead? &nbsp;&nbsp; [ Use "Top_1" ] [ Cancel ]

Cancel restores the previous name. When no GUI is running, the unique name is applied without prompting, so console mode, regression tests and gRPC-driven field writes never block on a modal dialog.

## Auto-rename

Applied where no user is present to decide: manual creation, Add Folder, surface and polygon file import, polygons generated from one file, create-copy, duplicate, and drag and drop between folders. Drag and drop needed no change in `RiuDragDrop`, as it routes through `addSurfacesAtIndex`.

## Python API

`RiaDefines::NameConflictPolicy` with `FAIL` (default), `AUTO_RENAME` and `OVERWRITE`, exposed as `on_name_conflict` on `AddFolder`, `CreatePolygon`, `ImportSurface` and `NewRegularSurface`:

```python
root.create_polygon(name="Fence", coordinates=coords)                       # raises on collision
root.create_polygon(name="Fence", coordinates=coords,
                    on_name_conflict=rips.NameConflictPolicy.AUTO_RENAME)   # -> Fence_1
```

`NewSurface` is deliberately left out. Grid case surfaces derive their tree label from the case and K index and carry no name of their own, so a flag there would never fire.

## Notes

Objects with an empty name are exempt from numbering, for the same reason — otherwise six grid case surfaces would render as `_1 - K:3`.

Existing projects are not migrated. Project load deserializes straight into the child arrays, so duplicates already stored in a project file survive and are resolved as the user touches them. All in-project references to surfaces and polygons are `PdmPtrField`, so adding a migration pass later stays safe.

`caf::PdmNestedCollectionBase::subCollectionsField()` is added so the generic `AddFolder` can inspect sibling folders without knowing the concrete collection type.

## Verification

Full build clean. 960/960 C++ unit tests pass, including 7 new ones for the suffix rule, case sensitivity, per-folder scoping, separate namespaces and the conflict policy. 10/10 rips tests pass, including 3 new ones covering the Python flag across all three modes.
