### PR TITLE
#14445 Initialize loggers before reading cloud config files

### DIFF
--- a/ApplicationLibCode/Application/RiaApplication.cpp
+++ b/ApplicationLibCode/Application/RiaApplication.cpp
@@ -1697,6 +1697,13 @@ void RiaApplication::initialize()
     m_preferences->initAfterReadRecursively();
     applyPreferences();
 
+    // Parse log level early so it's available when the loggers are created
+    parseLogLevelFromQtArguments();
+
+    // Create loggers before reading the cloud configuration, to make sure the messages from the config file search
+    // are reported
+    initializeLoggers();
+
     RiaConnectorTools::configureCloudServices();
 
     // Start with a project
@@ -1710,9 +1717,6 @@ void RiaApplication::initialize()
     RiaCafLoggingManager::initializeCafLogging();
 
     initializeDataLoadController();
-
-    // Parse log level early so it's available before logger is created in subclass initialize()
-    parseLogLevelFromQtArguments();
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/RiaApplication.h
+++ b/ApplicationLibCode/Application/RiaApplication.h
@@ -233,6 +233,10 @@ protected:
     static std::vector<caf::PdmDeprecation> defaultDeprecations();
 
 protected:
+    // Create the logger instances required to report messages during application startup. Called from initialize()
+    // before any startup configuration is read, to make sure messages from the startup sequence are logged.
+    virtual void initializeLoggers() {}
+
     void initializeDataLoadController();
     void parseLogLevelFromQtArguments();
 

--- a/ApplicationLibCode/Application/RiaConsoleApplication.cpp
+++ b/ApplicationLibCode/Application/RiaConsoleApplication.cpp
@@ -109,6 +109,14 @@ void RiaConsoleApplication::initialize()
 
     RiaApplication::initialize();
 
+    m_socketServer = new RiaSocketServer( this );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiaConsoleApplication::initializeLoggers()
+{
     auto logger = std::make_unique<RiaStdOutLogger>();
 
     // Use command line log level if provided, otherwise use preference-based level
@@ -122,8 +130,6 @@ void RiaConsoleApplication::initialize()
     }
 
     RiaLogging::appendLoggerInstance( std::move( logger ) );
-
-    m_socketServer = new RiaSocketServer( this );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/RiaConsoleApplication.h
+++ b/ApplicationLibCode/Application/RiaConsoleApplication.h
@@ -46,6 +46,7 @@ public:
 
 protected:
     // Protected implementation specific overrides
+    void initializeLoggers() override;
     void invokeProcessEvents( QEventLoop::ProcessEventsFlags flags = QEventLoop::AllEvents ) override;
     void onProjectOpeningError( const QString& errMsg ) override;
     void onProjectOpened() override;

--- a/ApplicationLibCode/Application/RiaGuiApplication.cpp
+++ b/ApplicationLibCode/Application/RiaGuiApplication.cpp
@@ -551,14 +551,21 @@ void RiaGuiApplication::initialize()
         RiaLogging::appendLoggerInstance( std::move( logger ) );
     }
 
-    {
-        auto logFolder  = QDir::homePath() + "/.resinsight/logs";
-        auto fileLogger = std::make_unique<RiaFileLogger>( logFolder.toStdString() );
-        fileLogger->setLevel( int( RiaLogging::logLevelBasedOnPreferences() ) );
-
-        RiaLogging::appendLoggerInstance( std::move( fileLogger ) );
-    }
     m_socketServer = new RiaSocketServer( this );
+}
+
+//--------------------------------------------------------------------------------------------------
+///
+//--------------------------------------------------------------------------------------------------
+void RiaGuiApplication::initializeLoggers()
+{
+    // The message panel logger requires the main windows, and is created in initialize(). The file logger has no
+    // such dependency, and is created here to capture messages from the early startup sequence.
+    auto logFolder  = QDir::homePath() + "/.resinsight/logs";
+    auto fileLogger = std::make_unique<RiaFileLogger>( logFolder.toStdString() );
+    fileLogger->setLevel( int( RiaLogging::logLevelBasedOnPreferences() ) );
+
+    RiaLogging::appendLoggerInstance( std::move( fileLogger ) );
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/ApplicationLibCode/Application/RiaGuiApplication.h
+++ b/ApplicationLibCode/Application/RiaGuiApplication.h
@@ -126,6 +126,8 @@ public:
     void              showFormattedTextInMessageBoxOrConsole( const QString& errMsg ) override;
 
 protected:
+    void initializeLoggers() override;
+
     bool notify( QObject* receiver, QEvent* event ) override;
 
     // use the checkWithUserBeforeClose function, to get all checks in one go

--- a/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmSettings.cpp
+++ b/Fwk/AppFwk/cafProjectDataModel/cafPdmXml/cafPdmSettings.cpp
@@ -131,6 +131,9 @@ void PdmSettings::writeFieldsToApplicationStore( const caf::PdmObjectHandle* obj
 
         if ( children.empty() )
         {
+            // Do not write value if field is not writable
+            if ( fieldHandle->xmlCapability() && !fieldHandle->xmlCapability()->isIOWritable() ) continue;
+
             if ( caf::PdmValueField* valueField = dynamic_cast<caf::PdmValueField*>( fieldHandle ) )
             {
                 settings.setValue( context + fieldHandle->keyword(), valueField->toQVariant() );


### PR DESCRIPTION
Fixes #1036. Investigation of #1034.

**Loggers before cloud config**

`RiaConnectorTools::configureCloudServices()` runs from `RiaApplication::initialize()`, before `RiaGuiApplication`/`RiaConsoleApplication` append their loggers, so every message from the cloud config file search was dropped. Adds a virtual `initializeLoggers()` called from `initialize()` before the cloud configuration is read, and moves the file logger and std out logger creation into the overrides. `parseLogLevelFromQtArguments()` moves up accordingly so the command line log level is known when the loggers are created. The message panel logger depends on the main windows and is still created in `RiaGuiApplication::initialize()`.

**Read-only fields no longer written to preferences**

`caf::PdmSettings::writeFieldsToApplicationStore` now skips fields where `isIOWritable()` is false, mirroring the `isIOReadable()` check already present in `readFieldsFromApplicationStore`. This stops the OSDU/SUMO/OpenTelemetry configuration, including the client id and the Azure connection string, from being written into the user preferences file. These fields have IO disabled and are never read back, so nothing that was previously used stops being persisted.

Verified with `ResInsight.exe --console --help`: the `Imported OSDU/SUMO/OpenTelemetry configuration from ...` messages now reach the logger, where they were previously lost.

Note that these messages are logged at debug level and nothing is logged when no config file is found, so a failing search is still silent at the default log level.